### PR TITLE
Add global file endpoint url support

### DIFF
--- a/packages/feeds-client/index.ts
+++ b/packages/feeds-client/index.ts
@@ -10,3 +10,4 @@ export * from './src/common/ActivitySearchSource';
 export * from './src/common/UserSearchSource';
 export * from './src/common/FeedSearchSource';
 export * from './src/common/Poll';
+export * from './src/utils';

--- a/packages/feeds-client/src/Feed.ts
+++ b/packages/feeds-client/src/Feed.ts
@@ -26,7 +26,7 @@ import {
   addReactionToActivities,
   removeReactionFromActivities,
 } from './state-updates/activity-reaction-utils';
-import { StreamResponse } from './gen-imports';
+import { FeedsApi, StreamResponse } from './gen-imports';
 import { capitalize } from './common/utils';
 import type {
   ActivityIdOrCommentId,
@@ -417,7 +417,8 @@ export class Feed extends FeedApi {
     id: string,
     data?: FeedResponse,
   ) {
-    super(client, groupId, id);
+    // Need this ugly cast because fileUpload endpoints :(
+    super(client as unknown as FeedsApi, groupId, id);
     this.state = new StateStore<FeedState>({
       fid: `${groupId}:${id}`,
       group_id: groupId,

--- a/packages/feeds-client/src/FeedsClient.ts
+++ b/packages/feeds-client/src/FeedsClient.ts
@@ -2,6 +2,8 @@ import { FeedsApi } from './gen/feeds/FeedsApi';
 import {
   ActivityResponse,
   FeedResponse,
+  FileUploadRequest,
+  ImageUploadRequest,
   OwnUser,
   PollResponse,
   PollVotesResponse,
@@ -220,6 +222,26 @@ export class FeedsClient extends FeedsApi {
       set: {
         is_closed: true,
       },
+    });
+  };
+
+  // @ts-expect-error API spec says file should be a string
+  uploadFile = (request: Omit<FileUploadRequest, 'file'> & { file: File }) => {
+    return super.uploadFile({
+      // @ts-expect-error API spec says file should be a string
+      file: request.file,
+    });
+  };
+
+  // @ts-expect-error API spec says file should be a string
+  uploadImage = (
+    request: Omit<ImageUploadRequest, 'file'> & { file: File },
+  ) => {
+    return super.uploadImage({
+      // @ts-expect-error API spec says file should be a string
+      file: request.file,
+      // @ts-expect-error form data will only work if this is a string
+      upload_sizes: JSON.stringify(request.upload_sizes),
     });
   };
 

--- a/packages/feeds-client/src/utils.ts
+++ b/packages/feeds-client/src/utils.ts
@@ -1,0 +1,4 @@
+export const isImageFile = (file: File) => {
+  // photoshop files begin with 'image/'
+  return file.type.startsWith('image/') && !file.type.endsWith('.photoshop');
+};

--- a/sample-apps/react-sample-app/app/components/Activity.tsx
+++ b/sample-apps/react-sample-app/app/components/Activity.tsx
@@ -82,12 +82,11 @@ export const Activity = ({
             </Link>
             <div className="text-sm text-gray-700 flex items-center gap-1">
               <div>{activity.created_at.toLocaleString()}</div>
-              {/* {activity.custom?.edited_at && (
+              {activity.edited_at && (
                 <div>
-                  - edited at{' '}
-                  {new Date(activity.custom.edited_at).toLocaleString()}
+                  - edited at {new Date(activity.edited_at).toLocaleString()}
                 </div>
-              )} */}
+              )}
             </div>
           </div>
           {(canEdit || canDelete) && (
@@ -152,6 +151,21 @@ export const Activity = ({
             onChange={(text) => setEditedActivityText(text)}
           />
         )}
+        {activity.attachments?.map((attachment, index) => (
+          <div key={`activity-attachment-${activity.id}-${index}`}>
+            {attachment.type === 'image' && (
+              <img className="max-h-48" src={attachment.image_url} alt="" />
+            )}
+            {attachment.type === 'file' && (
+              <div className="flex items-center gap-1">
+                <span className="material-symbols-outlined">attach_file</span>
+                <a href={attachment.asset_url} target="_blank">
+                  File attachment
+                </a>
+              </div>
+            )}
+          </div>
+        ))}
         {activity.poll ? <Poll activity={activity} /> : null}
         <div className="flex justify-between">
           <div className="flex items-center gap-3">

--- a/sample-apps/react-sample-app/app/components/NewActivity.tsx
+++ b/sample-apps/react-sample-app/app/components/NewActivity.tsx
@@ -1,29 +1,62 @@
-import { Feed, FeedState } from '@stream-io/feeds-client';
+import { Feed, FeedState, isImageFile } from '@stream-io/feeds-client';
 import { useErrorContext } from '../error-context';
-import { useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { ActivityComposer } from './ActivityComposer';
 import { LoadingIndicator } from './LoadingIndicator';
 import { useStateStore } from '../hooks/useStateStore';
+import { useUserContext } from '../user-context';
 
 const selector = ({ own_capabilities = [] }: FeedState) => ({
   canPost: own_capabilities.includes('add-activity'),
 });
 
 export const NewActivity = ({ feed }: { feed: Feed }) => {
+  const { client } = useUserContext();
   const { logErrorAndDisplayNotification } = useErrorContext();
   const [isSending, setIsSending] = useState<boolean>(false);
   const [activityText, setActivityText] = useState('');
+  const [files, setFiles] = useState<FileList | null>(null);
 
   const { canPost } = useStateStore(feed.state, selector);
 
-  const sendActivity = async () => {
+  const sendActivity = async (event: FormEvent) => {
+    const currentTarget = event.currentTarget as HTMLFormElement;
+    event.preventDefault();
     setIsSending(true);
     try {
+      const requests = [];
+      for (let file of [...(files ?? [])]) {
+        if (isImageFile(file)) {
+          requests.push(
+            client?.uploadImage({
+              file,
+            }),
+          );
+        } else {
+          requests.push(
+            client?.uploadFile({
+              file,
+            }),
+          );
+        }
+      }
+      const fileResponses = await Promise.all(requests);
+
       await feed.addActivity({
         type: 'post',
         text: activityText,
+        attachments: fileResponses.map((response, index) => {
+          const isImage = isImageFile(files![index]);
+          return {
+            type: isImage ? 'image' : 'file',
+            [isImage ? 'image_url' : 'asset_url']: response?.file,
+            custom: {},
+          };
+        }),
       });
+      setFiles(null);
       setActivityText('');
+      currentTarget.reset();
     } catch (error) {
       if (error instanceof Error) {
         logErrorAndDisplayNotification(error, error.message);
@@ -38,16 +71,28 @@ export const NewActivity = ({ feed }: { feed: Feed }) => {
   }
 
   return (
-    <div className="w-full flex flex-col items-start gap-1">
+    <form
+      className="w-full flex flex-col items-start gap-1"
+      onSubmit={sendActivity}
+    >
       <ActivityComposer text={activityText} onChange={setActivityText} />
+      <input
+        type="file"
+        name="file"
+        multiple
+        onChange={(e) => {
+          if (e.target.files) {
+            setFiles(e.target.files);
+          }
+        }}
+      />
       <button
         type="submit"
         className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none"
-        onClick={() => sendActivity()}
         disabled={isSending || activityText === ''}
       >
         {isSending ? <LoadingIndicator /> : 'Post'}
       </button>
-    </div>
+    </form>
   );
 };


### PR DESCRIPTION
Adds endpoints to upload file and image.

I had a local issue, where links for files returned 405 for me, more details here: https://getstream.slack.com/archives/C06RK9WCR09/p1751557516943529 - you might run into it, or not

UI: very simple, you can attach one ore more files to an activity, but can't edit them.