### PR TITLE
fix: form data undefined values

### DIFF
--- a/packages/feeds-client/src/common/ApiClient.ts
+++ b/packages/feeds-client/src/common/ApiClient.ts
@@ -77,7 +77,7 @@ export class ApiClient {
       Object.keys(body).forEach((key) => {
         const value = body[key];
         if (value != null) {
-          encodedBody.append(key, body[key]);
+          encodedBody.append(key, value);
         }
       });
     }


### PR DESCRIPTION
`FormData` serializes falsy values as strings (so `'undefined'` instead of `undefined`). This then causes issues for some specific fields server-side, in this particular instance it broke `upload_sizes` from the image upload endpoint. 

Regardless, this should guard us against it.