### PR TITLE
feat: search implementation and bindings

### DIFF
--- a/packages/feeds-client/@react-bindings/contexts/StreamSearchContext.tsx
+++ b/packages/feeds-client/@react-bindings/contexts/StreamSearchContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import type { SearchController } from '../../src/common/SearchController';
+
+export const StreamSearchContext = createContext<SearchController | undefined>(undefined);
+
+/**
+ * The props for the StreamSearchProvider component.
+ */
+export type StreamSearchContextProps = {
+  searchController: SearchController;
+};
+
+/**
+ * Hook to access the nearest SearchController instance.
+ */
+export const useSearchContext = () => {
+  return useContext(StreamSearchContext);
+};

--- a/packages/feeds-client/@react-bindings/contexts/StreamSearchResultsContext.tsx
+++ b/packages/feeds-client/@react-bindings/contexts/StreamSearchResultsContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import type { SearchSource } from '../../src/common/BaseSearchSource';
+
+export const StreamSearchResultsContext = createContext<SearchSource | undefined>(undefined);
+
+/**
+ * The props for the StreamSearchResultsProvider component.
+ */
+export type StreamSearchResultsContextProps = {
+  source: SearchSource;
+};
+
+/**
+ * Hook to access the nearest SearchSource instance.
+ */
+export const useSearchResultsContext = () => {
+  return useContext(StreamSearchResultsContext);
+};

--- a/packages/feeds-client/@react-bindings/hooks/search-state-hooks/index.ts
+++ b/packages/feeds-client/@react-bindings/hooks/search-state-hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useSearchResult';
+export * from './useSearchQuery';

--- a/packages/feeds-client/@react-bindings/hooks/search-state-hooks/index.ts
+++ b/packages/feeds-client/@react-bindings/hooks/search-state-hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useSearchResult';
 export * from './useSearchQuery';
+export * from './useSearchSources';

--- a/packages/feeds-client/@react-bindings/hooks/search-state-hooks/index.ts
+++ b/packages/feeds-client/@react-bindings/hooks/search-state-hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useSearchResult';

--- a/packages/feeds-client/@react-bindings/hooks/search-state-hooks/useSearchQuery.ts
+++ b/packages/feeds-client/@react-bindings/hooks/search-state-hooks/useSearchQuery.ts
@@ -1,0 +1,17 @@
+import {
+  SearchController,
+  SearchControllerState,
+} from '../../../src/common/SearchController';
+import { useSearchContext } from '../../contexts/StreamSearchContext';
+import { useStateStore } from '../useStateStore';
+
+export const useSearchQuery = (controllerFromProps?: SearchController) => {
+  const controllerFromState = useSearchContext();
+  const controller = controllerFromProps ?? controllerFromState;
+
+  return useStateStore(controller?.state, selector);
+};
+
+const selector = ({ searchQuery }: SearchControllerState) => ({
+  searchQuery,
+});

--- a/packages/feeds-client/@react-bindings/hooks/search-state-hooks/useSearchResult.ts
+++ b/packages/feeds-client/@react-bindings/hooks/search-state-hooks/useSearchResult.ts
@@ -15,9 +15,7 @@ export const useSearchResult = (sourceFromProps?: SearchSource) => {
     useStateStore(source?.state, selector) ?? {};
 
   const loadMore = useStableCallback(async () => {
-    if (!isLoading && hasNext) {
-      source?.search(source?.searchQuery);
-    }
+    source?.search();
   });
 
   return useMemo(

--- a/packages/feeds-client/@react-bindings/hooks/search-state-hooks/useSearchResult.ts
+++ b/packages/feeds-client/@react-bindings/hooks/search-state-hooks/useSearchResult.ts
@@ -1,0 +1,34 @@
+import type {
+  SearchSource,
+  SearchSourceState,
+} from '../../../src/common/BaseSearchSource';
+import { useSearchResultsContext } from '../../contexts/StreamSearchResultsContext';
+import { useStateStore } from '../useStateStore';
+import { useStableCallback } from '../internal';
+import { useMemo } from 'react';
+
+export const useSearchResult = (sourceFromProps?: SearchSource) => {
+  const sourceFromContext = useSearchResultsContext();
+  const source = sourceFromProps ?? sourceFromContext;
+
+  const { items, error, isLoading, hasNext } =
+    useStateStore(source?.state, selector) ?? {};
+
+  const loadMore = useStableCallback(async () => {
+    if (!isLoading && hasNext) {
+      source?.search(source?.searchQuery);
+    }
+  });
+
+  return useMemo(
+    () => ({ items, error, isLoading, hasNext, loadMore }),
+    [error, hasNext, isLoading, items, loadMore],
+  );
+};
+
+const selector = (nextState: SearchSourceState) => ({
+  items: nextState.items,
+  isLoading: nextState.isLoading,
+  hasNext: nextState.hasNext,
+  error: nextState.lastQueryError,
+});

--- a/packages/feeds-client/@react-bindings/hooks/search-state-hooks/useSearchResult.ts
+++ b/packages/feeds-client/@react-bindings/hooks/search-state-hooks/useSearchResult.ts
@@ -26,9 +26,14 @@ export const useSearchResult = (sourceFromProps?: SearchSource) => {
   );
 };
 
-const selector = (nextState: SearchSourceState) => ({
-  items: nextState.items,
-  isLoading: nextState.isLoading,
-  hasNext: nextState.hasNext,
-  error: nextState.lastQueryError,
+const selector = ({
+  items,
+  isLoading,
+  hasNext,
+  lastQueryError,
+}: SearchSourceState) => ({
+  items,
+  isLoading,
+  hasNext,
+  error: lastQueryError,
 });

--- a/packages/feeds-client/@react-bindings/hooks/search-state-hooks/useSearchSources.ts
+++ b/packages/feeds-client/@react-bindings/hooks/search-state-hooks/useSearchSources.ts
@@ -5,13 +5,13 @@ import type {
 import { useSearchContext } from '../../contexts/StreamSearchContext';
 import { useStateStore } from '../useStateStore';
 
-export const useSearchQuery = (controllerFromProps?: SearchController) => {
+export const useSearchSources = (controllerFromProps?: SearchController) => {
   const controllerFromState = useSearchContext();
   const controller = controllerFromProps ?? controllerFromState;
 
   return useStateStore(controller?.state, selector);
 };
 
-const selector = ({ searchQuery }: SearchControllerState) => ({
-  searchQuery,
+const selector = ({ sources }: SearchControllerState) => ({
+  sources,
 });

--- a/packages/feeds-client/@react-bindings/index.ts
+++ b/packages/feeds-client/@react-bindings/index.ts
@@ -5,6 +5,7 @@ export * from './hooks/useCreateFeedsClient';
 
 export * from './hooks/client-state-hooks';
 export * from './hooks/feed-state-hooks';
+export * from './hooks/search-state-hooks';
 export * from './hooks/util';
 
 // Contexts

--- a/packages/feeds-client/@react-bindings/index.ts
+++ b/packages/feeds-client/@react-bindings/index.ts
@@ -11,8 +11,12 @@ export * from './hooks/util';
 
 export * from './contexts/StreamFeedsContext';
 export * from './contexts/StreamFeedContext';
+export * from './contexts/StreamSearchContext';
+export * from './contexts/StreamSearchResultsContext';
 
 // Wrappers
 
 export * from './wrappers/StreamFeeds';
 export * from './wrappers/StreamFeed';
+export * from './wrappers/StreamSearch';
+export * from './wrappers/StreamSearchResults';

--- a/packages/feeds-client/@react-bindings/wrappers/StreamSearch.tsx
+++ b/packages/feeds-client/@react-bindings/wrappers/StreamSearch.tsx
@@ -1,0 +1,23 @@
+import { PropsWithChildren } from 'react';
+import { StreamSearchContext } from '../contexts/StreamSearchContext';
+import type { SearchController } from '../../src/common/SearchController';
+
+/**
+ * The props for the StreamSearch component. It accepts a `SearchController` instance.
+ */
+export type StreamSearchProps = {
+  searchController: SearchController | undefined;
+};
+
+export const StreamSearch = ({
+  searchController,
+  children,
+}: PropsWithChildren<StreamSearchProps>) => {
+  return (
+    <StreamSearchContext.Provider value={searchController}>
+      {children}
+    </StreamSearchContext.Provider>
+  );
+};
+
+StreamSearch.displayName = 'StreamSearch';

--- a/packages/feeds-client/@react-bindings/wrappers/StreamSearchResults.tsx
+++ b/packages/feeds-client/@react-bindings/wrappers/StreamSearchResults.tsx
@@ -1,0 +1,23 @@
+import { PropsWithChildren } from 'react';
+import { StreamSearchResultsContext } from '../contexts/StreamSearchResultsContext';
+import type { SearchSource } from '../../src/common/BaseSearchSource';
+
+/**
+ * The props for the StreamSearchResults component. It accepts a `SearchSource` instance.
+ */
+export type StreamSearchResultsProps = {
+  source: SearchSource;
+};
+
+export const StreamSearchResults = ({
+  source,
+  children,
+}: PropsWithChildren<StreamSearchResultsProps>) => {
+  return (
+    <StreamSearchResultsContext.Provider value={source}>
+      {children}
+    </StreamSearchResultsContext.Provider>
+  );
+};
+
+StreamSearchResults.displayName = 'StreamSearchResults';

--- a/packages/feeds-client/src/common/ActivitySearchSource.ts
+++ b/packages/feeds-client/src/common/ActivitySearchSource.ts
@@ -7,9 +7,11 @@ import { ActivityResponse } from '../gen/models';
 export class ActivitySearchSource extends BaseSearchSource<ActivityResponse> {
   readonly type = 'activity' as const;
   private readonly client: FeedsClient;
+  private lastSearchQuery: string;
   constructor(client: FeedsClient, options?: SearchSourceOptions) {
     super(options);
     this.client = client;
+    this.lastSearchQuery = this.searchQuery;
   }
 
   protected async query(searchQuery: string) {
@@ -30,6 +32,8 @@ export class ActivitySearchSource extends BaseSearchSource<ActivityResponse> {
   }
 
   protected filterQueryResults(items: ActivityResponse[]) {
-    return items;
+    const searchQueryChanged = this.lastSearchQuery !== this.searchQuery;
+    this.lastSearchQuery = this.searchQuery;
+    return searchQueryChanged ? items : [...(this.items ?? []), ...items];
   }
 }

--- a/packages/feeds-client/src/common/ActivitySearchSource.ts
+++ b/packages/feeds-client/src/common/ActivitySearchSource.ts
@@ -7,11 +7,10 @@ import { ActivityResponse } from '../gen/models';
 export class ActivitySearchSource extends BaseSearchSource<ActivityResponse> {
   readonly type = 'activity' as const;
   private readonly client: FeedsClient;
-  private lastSearchQuery: string;
+
   constructor(client: FeedsClient, options?: SearchSourceOptions) {
     super(options);
     this.client = client;
-    this.lastSearchQuery = this.searchQuery;
   }
 
   protected async query(searchQuery: string) {
@@ -32,8 +31,6 @@ export class ActivitySearchSource extends BaseSearchSource<ActivityResponse> {
   }
 
   protected filterQueryResults(items: ActivityResponse[]) {
-    const searchQueryChanged = this.lastSearchQuery !== this.searchQuery;
-    this.lastSearchQuery = this.searchQuery;
-    return searchQueryChanged ? items : [...(this.items ?? []), ...items];
+    return items;
   }
 }

--- a/packages/feeds-client/src/common/ActivitySearchSource.ts
+++ b/packages/feeds-client/src/common/ActivitySearchSource.ts
@@ -7,20 +7,14 @@ import { ActivityResponse } from '../gen/models';
 export class ActivitySearchSource extends BaseSearchSource<ActivityResponse> {
   readonly type = 'activity' as const;
   private readonly client: FeedsClient;
-  // messageSearchChannelFilters: ChannelFilters | undefined;
-  // messageSearchFilters: MessageFilters | undefined;
-  // messageSearchSort: SearchMessageSort | undefined;
-  // channelQueryFilters: ChannelFilters | undefined;
-  // channelQuerySort: ChannelSort | undefined;
-  // channelQueryOptions: Omit<ChannelOptions, 'limit' | 'offset'> | undefined;
-
   constructor(client: FeedsClient, options?: SearchSourceOptions) {
     super(options);
     this.client = client;
   }
 
   protected async query(searchQuery: string) {
-    const { connected_user: connectedUser } = this.client.state.getLatestValue();
+    const { connected_user: connectedUser } =
+      this.client.state.getLatestValue();
     if (!connectedUser) return { items: [] };
 
     const { activities: items, next } = await this.client.queryActivities({
@@ -37,10 +31,3 @@ export class ActivitySearchSource extends BaseSearchSource<ActivityResponse> {
     return items;
   }
 }
-
-
-  // filter: {
-  //   'feed.name': { $autocomplete: searchQuery }
-  //   'feed.description': { $autocomplete: searchQuery }
-  //   'created_by.name': { $autocomplete: searchQuery }
-  // },

--- a/packages/feeds-client/src/common/ActivitySearchSource.ts
+++ b/packages/feeds-client/src/common/ActivitySearchSource.ts
@@ -19,7 +19,9 @@ export class ActivitySearchSource extends BaseSearchSource<ActivityResponse> {
 
     const { activities: items, next } = await this.client.queryActivities({
       sort: [{ direction: -1, field: 'created_at' }],
-      filter: { text: { $autocomplete: searchQuery } },
+      ...(searchQuery.length
+        ? { filter: { text: { $autocomplete: searchQuery } } }
+        : {}),
       limit: 10,
       next: this.next ?? undefined,
     });

--- a/packages/feeds-client/src/common/ActivitySearchSource.ts
+++ b/packages/feeds-client/src/common/ActivitySearchSource.ts
@@ -19,7 +19,7 @@ export class ActivitySearchSource extends BaseSearchSource<ActivityResponse> {
 
     const { activities: items, next } = await this.client.queryActivities({
       sort: [{ direction: -1, field: 'created_at' }],
-      ...(searchQuery.length
+      ...(!this.allowEmptySearchString || searchQuery.length > 0
         ? { filter: { text: { $autocomplete: searchQuery } } }
         : {}),
       limit: 10,

--- a/packages/feeds-client/src/common/BaseSearchSource.ts
+++ b/packages/feeds-client/src/common/BaseSearchSource.ts
@@ -166,6 +166,9 @@ export abstract class BaseSearchSource<T> implements SearchSource<T> {
   ): SearchSourceState<T> {
     return {
       ...this.initialState,
+      items: this.items,
+      hasNext: this.hasNext,
+      next: this.next,
       isActive: this.isActive,
       isLoading: true,
       searchQuery: newSearchString,

--- a/packages/feeds-client/src/common/BaseSearchSource.ts
+++ b/packages/feeds-client/src/common/BaseSearchSource.ts
@@ -195,7 +195,6 @@ export abstract class BaseSearchSource<T> implements SearchSource<T> {
     const hasNewSearchQuery = this.lastSearchQuery !== newSearchString;
     const searchString = newSearchString ?? this.searchQuery;
 
-    console.log('HASNEW: ', hasNewSearchQuery)
     if (hasNewSearchQuery) {
       this.state.next(this.getStateBeforeFirstQuery(newSearchString ?? ''));
     } else {
@@ -207,7 +206,6 @@ export abstract class BaseSearchSource<T> implements SearchSource<T> {
       const results = await this.query(searchString);
       if (!results) return;
       const { items, next } = results;
-      console.log('TESTING: ', next, this.next);
 
       if (typeof next === 'string' || next === null) {
         stateUpdate.next = next;

--- a/packages/feeds-client/src/common/BaseSearchSource.ts
+++ b/packages/feeds-client/src/common/BaseSearchSource.ts
@@ -69,7 +69,6 @@ export abstract class BaseSearchSource<T> implements SearchSource<T> {
   state: StateStore<SearchSourceState<T>>;
   protected pageSize: number;
   protected allowEmptySearchString: boolean;
-  protected lastSearchQuery: string | undefined;
   abstract readonly type: SearchSourceType;
   protected searchDebounced!: DebouncedExecQueryFunction;
 
@@ -81,7 +80,6 @@ export abstract class BaseSearchSource<T> implements SearchSource<T> {
     this.pageSize = pageSize;
     this.allowEmptySearchString = allowEmptySearchString;
     this.state = new StateStore<SearchSourceState<T>>(this.initialState);
-    this.lastSearchQuery = this.searchQuery;
     this.setDebounceOptions({ debounceMs });
   }
 
@@ -192,7 +190,7 @@ export abstract class BaseSearchSource<T> implements SearchSource<T> {
 
   async executeQuery(newSearchString?: string) {
     if (!this.canExecuteQuery(newSearchString)) return;
-    const hasNewSearchQuery = this.lastSearchQuery !== newSearchString;
+    const hasNewSearchQuery = typeof newSearchString !== 'undefined';
     const searchString = newSearchString ?? this.searchQuery;
 
     if (hasNewSearchQuery) {
@@ -215,7 +213,6 @@ export abstract class BaseSearchSource<T> implements SearchSource<T> {
         stateUpdate.hasNext = items.length === this.pageSize;
       }
 
-      this.lastSearchQuery = newSearchString;
       stateUpdate.items = await this.filterQueryResults(items);
     } catch (e) {
       stateUpdate.lastQueryError = e as Error;

--- a/packages/feeds-client/src/common/BaseSearchSource.ts
+++ b/packages/feeds-client/src/common/BaseSearchSource.ts
@@ -1,7 +1,7 @@
 import { StateStore } from './StateStore';
 import { debounce, type DebouncedFunc } from './utils';
 
-export type SearchSourceType = 'activity' | 'users' | 'feeds' | (string & {});
+export type SearchSourceType = 'activity' | 'user' | 'feed' | (string & {});
 
 export type QueryReturnValue<T> = { items: T[]; next?: string | null };
 

--- a/packages/feeds-client/src/common/BaseSearchSource.ts
+++ b/packages/feeds-client/src/common/BaseSearchSource.ts
@@ -1,12 +1,10 @@
 import { StateStore } from './StateStore';
 import { debounce, type DebouncedFunc } from './utils';
 
-export type SearchSourceType =
-  | 'channels'
-  | 'users'
-  | 'messages'
-  | (string & {});
+export type SearchSourceType = 'activities' | 'users' | 'feeds' | (string & {});
+
 export type QueryReturnValue<T> = { items: T[]; next?: string | null };
+
 export type DebounceOptions = {
   debounceMs: number;
 };
@@ -14,7 +12,6 @@ type DebouncedExecQueryFunction = DebouncedFunc<
   (searchString?: string) => Promise<void>
 >;
 
- 
 export interface SearchSource<T = any> {
   activate(): void;
 
@@ -46,7 +43,6 @@ export interface SearchSource<T = any> {
   readonly type: SearchSourceType;
 }
 
- 
 export type SearchSourceState<T = any> = {
   hasNext: boolean;
   isActive: boolean;

--- a/packages/feeds-client/src/common/FeedSearchSource.ts
+++ b/packages/feeds-client/src/common/FeedSearchSource.ts
@@ -27,7 +27,7 @@ export class FeedSearchSource extends BaseSearchSource<Feed> {
     const { feeds: items, next } = await this.client.queryFeeds({
       filter: {
         ...(this.feedGroupId ? { group_id: this.feedGroupId } : {}),
-        ...(searchQuery.length > 0
+        ...(!this.allowEmptySearchString || searchQuery.length > 0
           ? {
               $or: [
                 { name: { $autocomplete: searchQuery } },

--- a/packages/feeds-client/src/common/FeedSearchSource.ts
+++ b/packages/feeds-client/src/common/FeedSearchSource.ts
@@ -37,6 +37,7 @@ export class FeedSearchSource extends BaseSearchSource<Feed> {
             }
           : {}),
       },
+      next: this.next ?? undefined,
     });
 
     return { items, next };

--- a/packages/feeds-client/src/common/FeedSearchSource.ts
+++ b/packages/feeds-client/src/common/FeedSearchSource.ts
@@ -7,12 +7,6 @@ import { Feed } from '../Feed';
 export class FeedSearchSource extends BaseSearchSource<Feed> {
   readonly type = 'feed' as const;
   private readonly client: FeedsClient;
-  // messageSearchChannelFilters: ChannelFilters | undefined;
-  // messageSearchFilters: MessageFilters | undefined;
-  // messageSearchSort: SearchMessageSort | undefined;
-  // channelQueryFilters: ChannelFilters | undefined;
-  // channelQuerySort: ChannelSort | undefined;
-  // channelQueryOptions: Omit<ChannelOptions, 'limit' | 'offset'> | undefined;
 
   constructor(client: FeedsClient, options?: SearchSourceOptions) {
     super(options);
@@ -22,57 +16,6 @@ export class FeedSearchSource extends BaseSearchSource<Feed> {
   protected async query(searchQuery: string) {
     const { connected_user: connectedUser } = this.client.state.getLatestValue();
     if (!connectedUser) return { items: [] };
-
-    // const channelFilters: ChannelFilters = {
-    //   members: { $in: [this.client.userID] },
-    //   ...this.messageSearchChannelFilters,
-    // } as ChannelFilters;
-
-    // const messageFilters: MessageFilters = {
-    //   text: searchQuery,
-    //   type: 'regular', // FIXME: type: 'reply' resp. do not filter by type and allow to jump to a message in a thread - missing support
-    //   ...this.messageSearchFilters,
-    // } as MessageFilters;
-
-    // const sort: SearchMessageSort = {
-    //   created_at: -1,
-    //   ...this.messageSearchSort,
-    // };
-
-    // const options = {
-    //   limit: this.pageSize,
-    //   next: this.next,
-    //   sort,
-    // } as SearchOptions;
-
-    // const { next, results } = await this.client.search(
-    //   channelFilters,
-    //   messageFilters,
-    //   options,
-    // );
-    // const items = results.map(({ message }) => message);
-
-    // const cids = Array.from(
-    //   items.reduce((acc, message) => {
-    //     if (message.cid && !this.client.activeChannels[message.cid])
-    //       acc.add(message.cid);
-    //     return acc;
-    //   }, new Set<string>()), // keep the cids unique
-    // );
-    // const allChannelsLoadedLocally = cids.length === 0;
-    // if (!allChannelsLoadedLocally) {
-    //   await this.client.queryChannels(
-    //     {
-    //       cid: { $in: cids },
-    //       ...this.channelQueryFilters,
-    //     } as ChannelFilters,
-    //     {
-    //       last_message_at: -1,
-    //       ...this.channelQuerySort,
-    //     },
-    //     this.channelQueryOptions,
-    //   );
-    // }
 
     const { feeds: items, next } = await this.client.queryFeeds({
       filter: {

--- a/packages/feeds-client/src/common/SearchController.ts
+++ b/packages/feeds-client/src/common/SearchController.ts
@@ -23,6 +23,8 @@ export class SearchController {
   /**
    * Not intended for direct use by integrators, might be removed without notice resulting in
    * broken integrations.
+   *
+   * @internal
    */
   _internalState: StateStore<InternalSearchControllerState>;
   state: StateStore<SearchControllerState>;

--- a/packages/feeds-client/src/common/UserSearchSource.ts
+++ b/packages/feeds-client/src/common/UserSearchSource.ts
@@ -7,12 +7,6 @@ import { UserResponse } from '../gen/models';
 export class UserSearchSource extends BaseSearchSource<UserResponse> {
   readonly type = 'user' as const;
   private readonly client: FeedsClient;
-  // messageSearchChannelFilters: ChannelFilters | undefined;
-  // messageSearchFilters: MessageFilters | undefined;
-  // messageSearchSort: SearchMessageSort | undefined;
-  // channelQueryFilters: ChannelFilters | undefined;
-  // channelQuerySort: ChannelSort | undefined;
-  // channelQueryOptions: Omit<ChannelOptions, 'limit' | 'offset'> | undefined;
 
   constructor(client: FeedsClient, options?: SearchSourceOptions) {
     super(options);
@@ -20,59 +14,9 @@ export class UserSearchSource extends BaseSearchSource<UserResponse> {
   }
 
   protected async query(searchQuery: string) {
-    const { connected_user: connectedUser } = this.client.state.getLatestValue();
+    const { connected_user: connectedUser } =
+      this.client.state.getLatestValue();
     if (!connectedUser) return { items: [] };
-
-    // const channelFilters: ChannelFilters = {
-    //   members: { $in: [this.client.userID] },
-    //   ...this.messageSearchChannelFilters,
-    // } as ChannelFilters;
-
-    // const messageFilters: MessageFilters = {
-    //   text: searchQuery,
-    //   type: 'regular', // FIXME: type: 'reply' resp. do not filter by type and allow to jump to a message in a thread - missing support
-    //   ...this.messageSearchFilters,
-    // } as MessageFilters;
-
-    // const sort: SearchMessageSort = {
-    //   created_at: -1,
-    //   ...this.messageSearchSort,
-    // };
-
-    // const options = {
-    //   limit: this.pageSize,
-    //   next: this.next,
-    //   sort,
-    // } as SearchOptions;
-
-    // const { next, results } = await this.client.search(
-    //   channelFilters,
-    //   messageFilters,
-    //   options,
-    // );
-    // const items = results.map(({ message }) => message);
-
-    // const cids = Array.from(
-    //   items.reduce((acc, message) => {
-    //     if (message.cid && !this.client.activeChannels[message.cid])
-    //       acc.add(message.cid);
-    //     return acc;
-    //   }, new Set<string>()), // keep the cids unique
-    // );
-    // const allChannelsLoadedLocally = cids.length === 0;
-    // if (!allChannelsLoadedLocally) {
-    //   await this.client.queryChannels(
-    //     {
-    //       cid: { $in: cids },
-    //       ...this.channelQueryFilters,
-    //     } as ChannelFilters,
-    //     {
-    //       last_message_at: -1,
-    //       ...this.channelQuerySort,
-    //     },
-    //     this.channelQueryOptions,
-    //   );
-    // }
 
     const { users: items } = await this.client.queryUsers({
       payload: {

--- a/packages/feeds-client/src/common/UserSearchSource.ts
+++ b/packages/feeds-client/src/common/UserSearchSource.ts
@@ -21,9 +21,13 @@ export class UserSearchSource extends BaseSearchSource<UserResponse> {
     const { users: items } = await this.client.queryUsers({
       payload: {
         filter_conditions: {
-          name: {
-            $autocomplete: searchQuery,
-          },
+          ...(!this.allowEmptySearchString || searchQuery.length > 0
+            ? {
+                name: {
+                  $autocomplete: searchQuery,
+                },
+              }
+            : {}),
         },
       },
     });

--- a/packages/react-native-sdk/src/index.ts
+++ b/packages/react-native-sdk/src/index.ts
@@ -1,6 +1,8 @@
+// default exports
 export * from '@stream-io/feeds-client';
 export * from '@stream-io/feeds-client/react-bindings';
 
+// overrides
 import { StreamFeeds as SDKStreamFeeds } from './wrappers/StreamFeeds';
 
 export const StreamFeeds = SDKStreamFeeds;

--- a/sample-apps/react-native/ExpoTikTokApp/app/(tabs)/explore.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/app/(tabs)/explore.tsx
@@ -2,13 +2,15 @@ import { StyleSheet } from 'react-native';
 
 import { View } from '@/components/Themed';
 import { ConnectionLostHeader } from '@/components/ConnectionLostHeader';
-import { FeedList } from '@/components/FeedList';
+// import { FeedSourceResultList } from '@/components/Search/FeedSourceResultList';
+import { Search } from '@/components/Search';
 
 const ExploreScreen = () => {
   return (
-    <View style={styles.container}>
+    <View>
       <ConnectionLostHeader />
-      <FeedList types={['user']} />
+      {/* <FeedSourceResultList types={['user']} /> */}
+      <Search />
     </View>
   );
 }

--- a/sample-apps/react-native/ExpoTikTokApp/app/(tabs)/explore.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/app/(tabs)/explore.tsx
@@ -2,14 +2,12 @@ import { StyleSheet } from 'react-native';
 
 import { View } from '@/components/Themed';
 import { ConnectionLostHeader } from '@/components/ConnectionLostHeader';
-// import { FeedSourceResultList } from '@/components/Search/FeedSourceResultList';
 import { Search } from '@/components/Search';
 
 const ExploreScreen = () => {
   return (
-    <View>
+    <View style={styles.container}>
       <ConnectionLostHeader />
-      {/* <FeedSourceResultList types={['user']} /> */}
       <Search />
     </View>
   );
@@ -19,9 +17,7 @@ export default ExploreScreen;
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+    height: '100%',
   },
   title: {
     fontSize: 20,

--- a/sample-apps/react-native/ExpoTikTokApp/app/(tabs)/index.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/app/(tabs)/index.tsx
@@ -27,7 +27,5 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
-    paddingHorizontal: 16,
-    paddingTop: 60,
   },
 });

--- a/sample-apps/react-native/ExpoTikTokApp/app/activity-pager-screen.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/app/activity-pager-screen.tsx
@@ -1,19 +1,18 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import {
   StreamFeed,
-  useFeedsClient,
 } from '@stream-io/feeds-react-native-sdk';
 import { useLocalSearchParams } from 'expo-router';
 import { ActivityPager } from '@/components/ActivityPager/Pager';
+import { useCreateAndQueryFeed } from '@/hooks/useCreateAndQueryFeed';
 
 const ActivityPagerScreen = () => {
-  const client = useFeedsClient();
-  const { groupId, id } = useLocalSearchParams();
+  const { groupId: groupIdParam, id: idParam } = useLocalSearchParams();
 
-  const feed = useMemo(
-    () => client?.feed(groupId as string, id as string),
-    [groupId, id, client],
-  );
+  const groupId = groupIdParam as string;
+  const id = idParam as string;
+
+  const feed = useCreateAndQueryFeed({ groupId, userId: id });
 
   if (!feed) {
     return null;

--- a/sample-apps/react-native/ExpoTikTokApp/components/Activity.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Activity.tsx
@@ -28,16 +28,30 @@ export const Activity = ({
     return image ? { uri: image } : postPlaceholder;
   }, [image]);
 
+  const mainActivityFid = activity.feeds[0];
+
+  const routingParams = useMemo(() => {
+    if (feed) {
+      return {
+        initialIndex: index,
+        groupId: feed.group,
+        id: feed.id,
+      };
+    }
+    const [groupId, id] = mainActivityFid.split(':');
+    return {
+      activityId: activity.id,
+      groupId,
+      id,
+    };
+  }, [feed, index, mainActivityFid, activity.id]);
+
   return (
     <TouchableOpacity
       onPress={() =>
         router.push({
           pathname: '/activity-pager-screen',
-          params: {
-            initialIndex: index,
-            groupId: feed?.group,
-            id: feed?.id,
-          },
+          params: routingParams,
         })
       }
       style={styles.card}
@@ -48,9 +62,11 @@ export const Activity = ({
           style={styles.image}
           resizeMode="cover"
         />
-        <View style={styles.heartIcon}>
-          <Reaction type="like" entity={activity} />
-        </View>
+        {feed ? (
+          <View style={styles.heartIcon}>
+            <Reaction type="like" entity={activity} />
+          </View>
+        ) : null}
       </View>
       <Text style={styles.title} numberOfLines={2}>
         {activity.text}

--- a/sample-apps/react-native/ExpoTikTokApp/components/ActivityPager/Pager.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/ActivityPager/Pager.tsx
@@ -12,6 +12,7 @@ import { FlashList } from '@shopify/flash-list';
 import type { ActivityResponse } from '@stream-io/feeds-react-native-sdk';
 import { ActivityPagerContextProvider } from '@/contexts/ActivityPagerContext';
 import { PagerItem } from '@/components/ActivityPager/PagerItem';
+import { useInitialIndex } from '@/components/ActivityPager/hooks/useInitialIndex';
 
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 
@@ -29,7 +30,7 @@ const renderItem = ({ item }: { item: ActivityResponse }) => {
 const keyExtractor = (item: ActivityResponse) => item.id;
 
 export const ActivityPager = () => {
-  const { initialIndex } = useLocalSearchParams();
+  const initialIndex = useInitialIndex();
   const { activities, loadNextPage } = useFeedActivities() ?? {};
   const [activeId, setActiveId] = useState<string | undefined>(
     activities?.[Number(initialIndex)]?.id,
@@ -62,7 +63,7 @@ export const ActivityPager = () => {
     }
   }, [activities]);
 
-  return (
+  return initialIndex != null ? (
     <ActivityPagerContextProvider activeId={activeId}>
       <FlashList
         ref={flatListRef}
@@ -80,5 +81,5 @@ export const ActivityPager = () => {
         {...pagerProps}
       />
     </ActivityPagerContextProvider>
-  );
+  ) : null;
 };

--- a/sample-apps/react-native/ExpoTikTokApp/components/ActivityPager/hooks/useInitialIndex.ts
+++ b/sample-apps/react-native/ExpoTikTokApp/components/ActivityPager/hooks/useInitialIndex.ts
@@ -1,0 +1,28 @@
+import { useLocalSearchParams } from 'expo-router';
+import {
+  useFeedActivities
+} from '@stream-io/feeds-react-native-sdk';
+import { useRef } from 'react';
+
+export const useInitialIndex = () => {
+  const { initialIndex, activityId: activityIdParam } = useLocalSearchParams();
+  const { activities } = useFeedActivities() ?? {};
+
+  const activityId = activityIdParam as string;
+
+  const resolvedInitialIndexRef = useRef<number | undefined>(undefined);
+
+  if (resolvedInitialIndexRef.current === undefined && activities) {
+    if (initialIndex != null) {
+      resolvedInitialIndexRef.current = Number(initialIndex);
+    } else if (activities && activities.length > 0) {
+      const fallbackIndex = activities.findIndex((activity) => {
+        return activity.id === activityId;
+      });
+
+      resolvedInitialIndexRef.current = fallbackIndex !== -1 ? fallbackIndex : 0;
+    }
+  }
+
+  return resolvedInitialIndexRef.current;
+}

--- a/sample-apps/react-native/ExpoTikTokApp/components/ActivitySectionList.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/ActivitySectionList.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import {
+  ActivityResponse,
+  useFeedActivities,
+} from '@stream-io/feeds-react-native-sdk';
+import { ActivityIndicator, FlatList, StyleSheet } from 'react-native';
+import { Activity } from '@/components/Activity';
+import { useCallback } from 'react';
+import { LoadingIndicator, ErrorIndicator } from '@/components/Indicators';
+import { useStableCallback } from '@/hooks/useStableCallback';
+import { View } from '@/components/Themed';
+
+const renderItem = ({
+  item,
+  index,
+}: {
+  item: ActivityResponse;
+  index: number;
+}) => <Activity activity={item} index={index} />;
+
+const keyExtractor = (item: ActivityResponse) => item.id;
+
+export const ActivitySectionList = ({
+  activities,
+  is_loading: isLoading,
+  loadNextPage: loadNextPageProp,
+  error,
+  has_next_page: hasNextPage,
+}: ReturnType<typeof useFeedActivities> & { error?: Error }) => {
+  const hasActivities = activities?.length && activities.length > 0;
+
+  const loadNextPage = useStableCallback(() => {
+    if (!isLoading && hasNextPage) {
+      void loadNextPageProp();
+    }
+  });
+
+  const ListFooterComponent = useCallback(
+    () => (isLoading && hasActivities ? <ActivityIndicator /> : null),
+    [isLoading, hasActivities],
+  );
+
+  if (error) {
+    return <ErrorIndicator context="activities" />;
+  }
+
+  if (isLoading && (!activities || activities?.length === 0)) {
+    return <LoadingIndicator />;
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        // @ts-expect-error Using FlatList internal
+        strictMode={true}
+        data={activities}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        numColumns={2}
+        onEndReachedThreshold={0.2}
+        onEndReached={loadNextPage}
+        columnWrapperStyle={styles.columnWrapper}
+        contentContainerStyle={styles.listContent}
+        ListFooterComponent={ListFooterComponent}
+        showsVerticalScrollIndicator={false}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    paddingHorizontal: 16,
+    paddingTop: 60,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  greeting: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  headerIcons: {
+    flexDirection: 'row',
+    gap: 16,
+  },
+  tabs: {
+    flexDirection: 'row',
+    marginBottom: 16,
+    gap: 16,
+  },
+  listContent: {
+    paddingBottom: 16,
+  },
+  badgeContainer: {
+    position: 'absolute',
+    bottom: 8,
+    left: 8,
+    backgroundColor: '#fff',
+    paddingHorizontal: 6,
+    paddingVertical: 4,
+    borderRadius: 4,
+  },
+  badgeText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#dc2626',
+  },
+  columnWrapper: { justifyContent: 'space-between' },
+});

--- a/sample-apps/react-native/ExpoTikTokApp/components/Feed.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Feed.tsx
@@ -1,114 +1,24 @@
-import React from 'react';
-import {
-  ActivityResponse,
-  useFeedActivities,
-} from '@stream-io/feeds-react-native-sdk';
-import {
-  ActivityIndicator,
-  FlatList,
-  StyleSheet,
-  View,
-  Text,
-} from 'react-native';
-import { Activity } from '@/components/Activity';
-import { useCallback, useState } from 'react';
+import React, { useState } from 'react';
+import { useFeedActivities } from '@stream-io/feeds-react-native-sdk';
+import { ActivitySectionList } from '@/components/ActivitySectionList';
 import { useStableCallback } from '@/hooks/useStableCallback';
-import { LoadingIndicator, ErrorIndicator } from '@/components/Indicators';
-
-const renderItem = ({
-  item,
-  index,
-}: {
-  item: ActivityResponse;
-  index: number;
-}) => <Activity activity={item} index={index} />;
-
-const keyExtractor = (item: ActivityResponse) => item.id;
 
 export const Feed = () => {
   const [error, setError] = useState<Error | undefined>();
-  const { loadNextPage, is_loading: isLoading, activities } = useFeedActivities() ?? {};
+  const { loadNextPage, is_loading, activities, has_next_page } = useFeedActivities() ?? {};
 
-  const getNextPage = useStableCallback(() => {
+  const getNextPage = useStableCallback(async () => {
     setError(undefined);
     loadNextPage().catch(setError);
   });
 
-  const hasActivities = activities?.length && activities.length > 0;
-
-  const ListFooterComponent = useCallback(
-    () => (isLoading && hasActivities ? <ActivityIndicator /> : null),
-    [isLoading, hasActivities],
-  );
-
-  if (error) {
-    return <ErrorIndicator context="activities" />;
-  }
-
-  if (isLoading && activities?.length === 0) {
-    return <LoadingIndicator />;
-  }
-
   return (
-    <FlatList
-      // @ts-expect-error Using FlatList internal
-      strictMode={true}
-      data={activities}
-      renderItem={renderItem}
-      keyExtractor={keyExtractor}
-      numColumns={2}
-      onEndReachedThreshold={0.2}
-      onEndReached={getNextPage}
-      columnWrapperStyle={styles.columnWrapper}
-      contentContainerStyle={styles.listContent}
-      ListFooterComponent={ListFooterComponent}
-      showsVerticalScrollIndicator={false}
+    <ActivitySectionList
+      activities={activities}
+      is_loading={is_loading}
+      loadNextPage={getNextPage}
+      has_next_page={has_next_page}
+      error={error}
     />
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    paddingHorizontal: 16,
-    paddingTop: 60,
-  },
-  header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  greeting: {
-    fontSize: 18,
-    fontWeight: '600',
-  },
-  headerIcons: {
-    flexDirection: 'row',
-    gap: 16,
-  },
-  tabs: {
-    flexDirection: 'row',
-    marginBottom: 16,
-    gap: 16,
-  },
-  listContent: {
-    paddingBottom: 16,
-  },
-  badgeContainer: {
-    position: 'absolute',
-    bottom: 8,
-    left: 8,
-    backgroundColor: '#fff',
-    paddingHorizontal: 6,
-    paddingVertical: 4,
-    borderRadius: 4,
-  },
-  badgeText: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: '#dc2626',
-  },
-  columnWrapper: { justifyContent: 'space-between' },
-});

--- a/sample-apps/react-native/ExpoTikTokApp/components/Profile.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Profile.tsx
@@ -27,6 +27,6 @@ export const Profile = ({
 
 const styles = StyleSheet.create({
   feedContainer: {
-    paddingHorizontal: 16,
+    height: '100%',
   },
 });

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/ActivitySourceResultList.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/ActivitySourceResultList.tsx
@@ -1,0 +1,41 @@
+import {
+  type SearchSourceState,
+  useSearchResultsContext,
+  useStateStore,
+} from '@stream-io/feeds-react-native-sdk';
+import { ActivitySectionList } from '@/components/ActivitySectionList';
+import { useStableCallback } from '@/hooks/useStableCallback';
+
+const searchSourceSelector = (nextState: SearchSourceState) => ({
+  items: nextState.items,
+  isLoading: nextState.isLoading,
+  hasNext: nextState.hasNext,
+  error: nextState.lastQueryError,
+});
+
+export const ActivitySourceResultList = () => {
+  const searchSource = useSearchResultsContext();
+
+  const {
+    items: activities,
+    error,
+    isLoading,
+    hasNext,
+  } = useStateStore(searchSource?.state, searchSourceSelector) ?? {};
+
+  const loadMore = useStableCallback(async () => {
+    if (!isLoading && hasNext) {
+      searchSource?.search(searchSource?.searchQuery);
+    }
+  });
+
+  return (
+    <ActivitySectionList
+      activities={activities}
+      error={error}
+      is_loading={isLoading}
+      has_next_page={hasNext}
+      loadNextPage={loadMore}
+    />
+  );
+};

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/ActivitySourceResultList.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/ActivitySourceResultList.tsx
@@ -1,33 +1,14 @@
-import {
-  type SearchSourceState,
-  useSearchResultsContext,
-  useStateStore,
-} from '@stream-io/feeds-react-native-sdk';
+import { useSearchResult } from '@stream-io/feeds-react-native-sdk';
 import { ActivitySectionList } from '@/components/ActivitySectionList';
-import { useStableCallback } from '@/hooks/useStableCallback';
-
-const searchSourceSelector = (nextState: SearchSourceState) => ({
-  items: nextState.items,
-  isLoading: nextState.isLoading,
-  hasNext: nextState.hasNext,
-  error: nextState.lastQueryError,
-});
 
 export const ActivitySourceResultList = () => {
-  const searchSource = useSearchResultsContext();
-
   const {
     items: activities,
     error,
     isLoading,
     hasNext,
-  } = useStateStore(searchSource?.state, searchSourceSelector) ?? {};
-
-  const loadMore = useStableCallback(async () => {
-    if (!isLoading && hasNext) {
-      searchSource?.search(searchSource?.searchQuery);
-    }
-  });
+    loadMore,
+  } = useSearchResult();
 
   return (
     <ActivitySectionList

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/FeedSourceResultList.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/FeedSourceResultList.tsx
@@ -1,14 +1,10 @@
 import {
   Feed,
-  SearchSourceState, useFeedMetadata,
-} from '@stream-io/feeds-react-native-sdk';
-import {
-  useSearchResultsContext,
-  useStateStore,
+  useFeedMetadata,
+  useSearchResult,
 } from '@stream-io/feeds-react-native-sdk';
 import { FlatList, Image, StyleSheet, TouchableOpacity } from 'react-native';
 import { FollowButton } from '@/components/FollowButton';
-import { useStableCallback } from '@/hooks/useStableCallback';
 import { View, Text } from '@/components/Themed';
 import { useRouter } from 'expo-router';
 import { ErrorIndicator, LoadingIndicator } from '@/components/Indicators';
@@ -53,28 +49,8 @@ const renderItem = ({ item }: { item: Feed }) => {
   return <UserItem feed={item} />;
 };
 
-const searchSourceSelector = (nextState: SearchSourceState) => ({
-  items: nextState.items,
-  isLoading: nextState.isLoading,
-  hasNext: nextState.hasNext,
-  error: nextState.lastQueryError,
-});
-
 export const FeedSourceResultList = () => {
-  const searchSource = useSearchResultsContext();
-
-  const {
-    items: feeds,
-    error,
-    isLoading,
-    hasNext,
-  } = useStateStore(searchSource?.state, searchSourceSelector) ?? {};
-
-  const loadMore = useStableCallback(async () => {
-    if (!isLoading && hasNext) {
-      searchSource?.search(searchSource?.searchQuery);
-    }
-  });
+  const { items: feeds, error, isLoading, loadMore } = useSearchResult();
 
   if (error) {
     return <ErrorIndicator context="user feeds" />;

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/FeedSourceResultList.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/FeedSourceResultList.tsx
@@ -1,7 +1,6 @@
-import type {
+import {
   Feed,
-  FeedState,
-  SearchSourceState,
+  SearchSourceState, useFeedMetadata,
 } from '@stream-io/feeds-react-native-sdk';
 import {
   useSearchResultsContext,
@@ -14,18 +13,12 @@ import { View, Text } from '@/components/Themed';
 import { useRouter } from 'expo-router';
 import { ErrorIndicator, LoadingIndicator } from '@/components/Indicators';
 
-const selector = (state: FeedState) => {
-  return {
-    createdBy: state.created_by,
-  };
-};
-
 const keyExtractor = (item: Feed) => item.id;
 
 const UserSeparator = () => <View style={styles.separator} />;
 
 const UserItem = ({ feed }: { feed: Feed }) => {
-  const { createdBy } = useStateStore(feed.state, selector);
+  const { created_by: createdBy } = useFeedMetadata(feed) ?? {};
   const router = useRouter();
 
   return (

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/FeedSourceResultList.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/FeedSourceResultList.tsx
@@ -78,7 +78,7 @@ export const FeedSourceResultList = () => {
   } = useStateStore(searchSource?.state, searchSourceSelector) ?? {};
 
   const loadMore = useStableCallback(async () => {
-    if (isLoading && hasNext) {
+    if (!isLoading && hasNext) {
       searchSource?.search(searchSource?.searchQuery);
     }
   });

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/FeedSourceResultList.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/FeedSourceResultList.tsx
@@ -59,7 +59,7 @@ const renderItem = ({ item }: { item: Feed }) => {
   return <UserItem feed={item} />;
 };
 
-export const FeedList = ({ types }: { types: Array<'user'> }) => {
+export const FeedSourceResultList = ({ types }: { types: Array<'user'> }) => {
   const client = useFeedsClient();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error>();
@@ -115,7 +115,6 @@ export const FeedList = ({ types }: { types: Array<'user'> }) => {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Users</Text>
       <FlatList
         data={feeds}
         keyExtractor={keyExtractor}

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/Search.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/Search.tsx
@@ -6,7 +6,8 @@ import {
   StreamSearch,
   useFeedsClient,
 } from '@stream-io/feeds-react-native-sdk';
-import { SearchBar, SearchTabs } from '@/components/Search';
+import { SearchBar } from '@/components/Search/SearchBar';
+import { SearchTabs } from '@/components/Search/SearchTabs';
 import { SearchResults } from '@/components/Search/SearchResults';
 
 export const Search = () => {

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/Search.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/Search.tsx
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import {
+  ActivitySearchSource,
+  FeedSearchSource,
+  SearchController,
+  StreamSearch,
+  useFeedsClient,
+} from '@stream-io/feeds-react-native-sdk';
+import { SearchBar, SearchTabs } from '@/components/Search';
+import { SearchResults } from '@/components/Search/SearchResults';
+
+export const Search = () => {
+  const client = useFeedsClient();
+  const searchController = useMemo(() => {
+    if (!client) {
+      return undefined;
+    }
+
+    return new SearchController({
+      sources: [
+        new ActivitySearchSource(client, { allowEmptySearchString: true }),
+        new FeedSearchSource(client, {
+          groupId: 'user',
+          allowEmptySearchString: true,
+        }),
+      ],
+      config: { keepSingleActiveSource: true },
+    });
+  }, [client]);
+
+  return (
+    <StreamSearch searchController={searchController}>
+      <SearchBar />
+      <SearchTabs />
+      <SearchResults />
+    </StreamSearch>
+  );
+};

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchBar.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchBar.tsx
@@ -1,23 +1,24 @@
 import { View, TextInput, Pressable, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import {
-  type SearchControllerState,
-  useSearchContext, useStateStore,
+  useSearchContext,
+  useSearchQuery,
 } from '@stream-io/feeds-react-native-sdk';
-
-const selector = (nextValue: SearchControllerState) => ({
-  searchQuery: nextValue.searchQuery,
-});
 
 export const SearchBar = () => {
   const searchController = useSearchContext();
-  const { searchQuery = '' } = useStateStore(searchController?.state, selector) ?? {};
+  const { searchQuery = '' } = useSearchQuery() ?? {};
 
   return (
     <View style={styles.container}>
       <View style={styles.topRow}>
         <View style={styles.searchBox}>
-          <Ionicons name="search" size={18} color="#888" style={styles.searchIcon} />
+          <Ionicons
+            name="search"
+            size={18}
+            color="#888"
+            style={styles.searchIcon}
+          />
           <TextInput
             value={searchQuery}
             onChangeText={searchController?.search}
@@ -29,14 +30,19 @@ export const SearchBar = () => {
           />
           {!!searchQuery && (
             <Pressable onPress={searchController?.clear}>
-              <Ionicons name="close" size={18} color="#888" style={styles.clearIcon} />
+              <Ionicons
+                name="close"
+                size={18}
+                color="#888"
+                style={styles.clearIcon}
+              />
             </Pressable>
           )}
         </View>
       </View>
     </View>
   );
-}
+};
 
 const styles = StyleSheet.create({
   container: {
@@ -72,5 +78,5 @@ const styles = StyleSheet.create({
   },
   clearIcon: {
     marginLeft: 8,
-  }
+  },
 });

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchBar.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchBar.tsx
@@ -1,0 +1,76 @@
+import { View, TextInput, Pressable, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  type SearchControllerState,
+  useSearchContext, useStateStore,
+} from '@stream-io/feeds-react-native-sdk';
+
+const selector = (nextValue: SearchControllerState) => ({
+  searchQuery: nextValue.searchQuery,
+});
+
+export const SearchBar = () => {
+  const searchController = useSearchContext();
+  const { searchQuery = '' } = useStateStore(searchController?.state, selector) ?? {};
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.topRow}>
+        <View style={styles.searchBox}>
+          <Ionicons name="search" size={18} color="#888" style={styles.searchIcon} />
+          <TextInput
+            value={searchQuery}
+            onChangeText={searchController?.search}
+            style={styles.input}
+            placeholder="Search"
+            placeholderTextColor="#aaa"
+            onFocus={searchController?.activate}
+            onBlur={searchController?.exit}
+          />
+          {!!searchQuery && (
+            <Pressable onPress={searchController?.clear}>
+              <Ionicons name="close" size={18} color="#888" style={styles.clearIcon} />
+            </Pressable>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: 16,
+    paddingHorizontal: 16,
+    backgroundColor: '#fff',
+  },
+  topRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  icon: {
+    padding: 4,
+    marginRight: 8,
+  },
+  searchBox: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    paddingHorizontal: 12,
+    backgroundColor: '#f9f9f9',
+  },
+  searchIcon: {
+    marginRight: 8,
+  },
+  input: {
+    flex: 1,
+    height: 40,
+    fontSize: 16,
+  },
+  clearIcon: {
+    marginLeft: 8,
+  }
+});

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchResults.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchResults.tsx
@@ -1,20 +1,12 @@
 import {
-  SearchControllerState,
   StreamSearchResults,
-  useSearchContext,
-  useStateStore,
+  useSearchSources,
 } from '@stream-io/feeds-react-native-sdk';
 import { useMemo } from 'react';
 import { SearchResultsList } from '@/components/Search/SearchResultsList';
 
-const selector = (nextValue: SearchControllerState) => ({
-  sources: nextValue.sources,
-});
-
 export const SearchResults = () => {
-  const searchController = useSearchContext();
-  const { sources = [] } =
-    useStateStore(searchController?.state, selector) ?? {};
+  const { sources = [] } = useSearchSources() ?? {};
 
   const activeSource = useMemo(
     () => sources.find((source) => source.isActive),

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchResults.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchResults.tsx
@@ -1,0 +1,35 @@
+import {
+  SearchControllerState,
+  StreamSearchResults,
+  useSearchContext,
+  useStateStore,
+} from '@stream-io/feeds-react-native-sdk';
+import { useMemo } from 'react';
+import { SearchResultsList } from '@/components/Search/SearchResultsList';
+
+const selector = (nextValue: SearchControllerState) => ({
+  sources: nextValue.sources,
+});
+
+export const SearchResults = () => {
+  const searchController = useSearchContext();
+  const { sources = [] } =
+    useStateStore(searchController?.state, selector) ?? {};
+
+  const activeSource = useMemo(
+    () => sources.find((source) => source.isActive),
+    [sources],
+  );
+
+  console.log('ACTIVE SOURCE: ', activeSource);
+
+  if (!activeSource) {
+    return null;
+  }
+
+  return (
+    <StreamSearchResults source={activeSource}>
+      <SearchResultsList />
+    </StreamSearchResults>
+  );
+};

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchResults.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchResults.tsx
@@ -21,8 +21,6 @@ export const SearchResults = () => {
     [sources],
   );
 
-  console.log('ACTIVE SOURCE: ', activeSource);
-
   if (!activeSource) {
     return null;
   }

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchResultsList.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchResultsList.tsx
@@ -1,0 +1,23 @@
+import {
+  SearchSourceState,
+  useSearchResultsContext,
+  useStateStore,
+} from '@stream-io/feeds-react-native-sdk';
+import { View, Text } from '@/components/Themed';
+
+const selector = (nextState: SearchSourceState) => ({
+  items: nextState.items,
+});
+
+export const SearchResultsList = () => {
+  const source = useSearchResultsContext();
+  const { items } = useStateStore(source?.state, selector) ?? {};
+
+  return items
+    ? items.map((item) => (
+        <View key={item.id}>
+          <Text>{item.id}</Text>
+        </View>
+      ))
+    : null;
+};

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchResultsList.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchResultsList.tsx
@@ -4,6 +4,7 @@ import {
   useStateStore,
 } from '@stream-io/feeds-react-native-sdk';
 import { View, Text } from '@/components/Themed';
+import { FeedSourceResultList } from '@/components/Search/FeedSourceResultList';
 
 const selector = (nextState: SearchSourceState) => ({
   items: nextState.items,
@@ -13,11 +14,13 @@ export const SearchResultsList = () => {
   const source = useSearchResultsContext();
   const { items } = useStateStore(source?.state, selector) ?? {};
 
-  return items
-    ? items.map((item) => (
-        <View key={item.id}>
-          <Text>{item.id}</Text>
-        </View>
-      ))
-    : null;
+  if (!source) return null;
+
+  return source.type === 'feed'
+    ? <FeedSourceResultList />
+    : items?.map((item) => (
+      <View key={item.id}>
+        <Text>{item.id}</Text>
+      </View>
+    ));
 };

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchResultsList.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchResultsList.tsx
@@ -1,26 +1,15 @@
-import {
-  SearchSourceState,
-  useSearchResultsContext,
-  useStateStore,
-} from '@stream-io/feeds-react-native-sdk';
-import { View, Text } from '@/components/Themed';
+import { useSearchResultsContext } from '@stream-io/feeds-react-native-sdk';
 import { FeedSourceResultList } from '@/components/Search/FeedSourceResultList';
-
-const selector = (nextState: SearchSourceState) => ({
-  items: nextState.items,
-});
+import { ActivitySourceResultList } from '@/components/Search/ActivitySourceResultList';
 
 export const SearchResultsList = () => {
   const source = useSearchResultsContext();
-  const { items } = useStateStore(source?.state, selector) ?? {};
 
   if (!source) return null;
 
-  return source.type === 'feed'
-    ? <FeedSourceResultList />
-    : items?.map((item) => (
-      <View key={item.id}>
-        <Text>{item.id}</Text>
-      </View>
-    ));
+  return source.type === 'feed' ? (
+    <FeedSourceResultList />
+  ) : (
+    <ActivitySourceResultList />
+  );
 };

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchTabs.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchTabs.tsx
@@ -18,7 +18,9 @@ export const SearchTabs = () => {
   useEffect(() => {
     if (!searchController || !activeSource) return;
     searchController?.activateSource(activeSource.type);
-    void activeSource.search(searchController.searchQuery);
+    if (!activeSource.items?.length) {
+      void activeSource.search(searchController.searchQuery);
+    }
   }, [activeSource, searchController]);
 
   return (

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchTabs.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchTabs.tsx
@@ -1,0 +1,82 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  SearchControllerState,
+  useSearchContext,
+  useStateStore,
+} from '@stream-io/feeds-react-native-sdk';
+
+const tabsNameMap = {
+  feed: 'Users',
+  activity: 'Posts',
+};
+
+const selector = (nextState: SearchControllerState) => ({
+  sources: nextState.sources,
+});
+
+export const SearchTabs = () => {
+  const searchController = useSearchContext();
+  const { sources = [] } =
+    useStateStore(searchController?.state, selector) ?? {};
+  const [activeSource, setActiveSource] = useState(sources[0]);
+
+  useEffect(() => {
+    if (!searchController || !activeSource) return;
+    searchController?.activateSource(activeSource.type);
+    void activeSource.search(searchController.searchQuery);
+  }, [activeSource, searchController]);
+
+  return (
+    <View style={styles.tabsRow}>
+      {sources.map((source) => (
+        <Pressable
+          key={source.type}
+          onPress={() => setActiveSource(source)}
+          style={styles.tabButton}
+        >
+          <Text
+            style={[
+              styles.tabText,
+              activeSource.type === source.type && styles.tabTextActive,
+            ]}
+          >
+            {tabsNameMap[source.type as keyof typeof tabsNameMap] ??
+              source.type}
+          </Text>
+          {activeSource.type === source.type && (
+            <View style={styles.underline} />
+          )}
+        </Pressable>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  tabsRow: {
+    flexDirection: 'row',
+    marginTop: 20,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+  },
+  tabButton: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  tabText: {
+    fontSize: 16,
+    color: '#888',
+    fontWeight: '500',
+  },
+  tabTextActive: {
+    color: '#1a3c34',
+  },
+  underline: {
+    height: 3,
+    backgroundColor: '#1a3c34',
+    width: '100%',
+    marginTop: 6,
+    borderRadius: 999,
+  },
+});

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchTabs.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/SearchTabs.tsx
@@ -1,9 +1,8 @@
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
-  SearchControllerState,
   useSearchContext,
-  useStateStore,
+  useSearchSources,
 } from '@stream-io/feeds-react-native-sdk';
 
 const tabsNameMap = {
@@ -11,14 +10,9 @@ const tabsNameMap = {
   activity: 'Posts',
 };
 
-const selector = (nextState: SearchControllerState) => ({
-  sources: nextState.sources,
-});
-
 export const SearchTabs = () => {
   const searchController = useSearchContext();
-  const { sources = [] } =
-    useStateStore(searchController?.state, selector) ?? {};
+  const { sources = [] } = useSearchSources() ?? {};
   const [activeSource, setActiveSource] = useState(sources[0]);
 
   useEffect(() => {

--- a/sample-apps/react-native/ExpoTikTokApp/components/Search/index.ts
+++ b/sample-apps/react-native/ExpoTikTokApp/components/Search/index.ts
@@ -1,0 +1,3 @@
+export * from './Search';
+export * from './SearchBar';
+export * from './SearchTabs';

--- a/sample-apps/react-sample-app/app/components/Header.tsx
+++ b/sample-apps/react-sample-app/app/components/Header.tsx
@@ -26,7 +26,7 @@ export function Header() {
       sources: [
         new ActivitySearchSource(client),
         new UserSearchSource(client),
-        new FeedSearchSource(client),
+        new FeedSearchSource(client, { groupId: 'user' }),
       ],
       config: { keepSingleActiveSource: true },
     });


### PR DESCRIPTION
🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>

### 💡 Overview

This PR implements basic search functionality in the RN sample app as well as adding utilities for it in the `@react-bindings` package, mostly related to:

- Search controller state
- Search source state
- General searching utilities

It also addresses 2 bugs in the search implementation and introduces a new feature which allows passing an empty query string in the search sources (removing all `filters` or arguments related to it in the process). This is useful in a presearch scenario, where you'd like to have something loaded and apply search to it only after.

### 📝 Implementation notes
