### PR TITLE
feat: add `user.updated` handler

### DIFF
--- a/packages/feeds-client/index.ts
+++ b/packages/feeds-client/index.ts
@@ -1,4 +1,4 @@
-export * from './src/feeds-client';
+export * from './src/feeds-client/feeds-client';
 export * from './src/feed/feed';
 export * from './src/gen/models';
 export * from './src/types';

--- a/packages/feeds-client/src/feeds-client/event-handlers/index.ts
+++ b/packages/feeds-client/src/feeds-client/event-handlers/index.ts
@@ -1,0 +1,1 @@
+export * from './user/handle-user-updated';

--- a/packages/feeds-client/src/feeds-client/event-handlers/user/handle-user-updated.test.ts
+++ b/packages/feeds-client/src/feeds-client/event-handlers/user/handle-user-updated.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+
+import { FeedsClient, handleUserUpdated } from '../..';
+import { generateOwnUser, generateUserResponse } from '../../../test-utils';
+import { EventPayload } from '../../../types-internal';
+
+describe('handleUserUpdated', () => {
+  let feedsClient: FeedsClient;
+
+  beforeEach(() => {
+    feedsClient = new FeedsClient('mock-api-key');
+    const connectedUser = generateOwnUser();
+
+    feedsClient.state.partialNext({ connected_user: connectedUser });
+  });
+
+  it('should update the connected user in the state', () => {
+    const stateBefore = feedsClient.state.getLatestValue();
+
+    const event: EventPayload<'user.updated'> = {
+      type: 'user.updated',
+      created_at: new Date(),
+      custom: {},
+      user: {
+        ...generateUserResponse(),
+        ...stateBefore.connected_user!,
+      },
+    };
+
+    handleUserUpdated.call(feedsClient, event);
+
+    const stateAfter = feedsClient.state.getLatestValue();
+
+    expect(stateAfter.connected_user).toMatchObject({ name: event.user.name });
+  });
+
+  it('should not update the connected user if the incoming event contains other user', () => {
+    const event: EventPayload<'user.updated'> = {
+      type: 'user.updated',
+      created_at: new Date(),
+      custom: {},
+      user: generateUserResponse(),
+    };
+
+    const stateBefore = feedsClient.state.getLatestValue();
+
+    handleUserUpdated.call(feedsClient, event);
+
+    const stateAfter = feedsClient.state.getLatestValue();
+
+    expect(stateAfter.connected_user).toBe(stateBefore.connected_user);
+  });
+});

--- a/packages/feeds-client/src/feeds-client/event-handlers/user/handle-user-updated.ts
+++ b/packages/feeds-client/src/feeds-client/event-handlers/user/handle-user-updated.ts
@@ -1,0 +1,28 @@
+import type { EventPayload } from '../../../types-internal';
+import type { FeedsClient, FeedsClientState } from '../../feeds-client';
+
+export function handleUserUpdated(
+  this: FeedsClient,
+  event: EventPayload<'user.updated'>,
+) {
+  this.state.next((currentState) => {
+    let newState: FeedsClientState | undefined;
+
+    const { connected_user } = currentState;
+
+    if (connected_user && connected_user.id === event.user.id) {
+      newState ??= {
+        ...currentState,
+      };
+
+      newState.connected_user = {
+        ...connected_user,
+        ...event.user,
+      };
+    }
+
+    // TODO: update other users in user map (if/once applicable)
+
+    return newState ?? currentState;
+  });
+}

--- a/packages/feeds-client/src/feeds-client/feeds-client.ts
+++ b/packages/feeds-client/src/feeds-client/feeds-client.ts
@@ -43,6 +43,7 @@ import {
   handleWatchStarted,
   handleWatchStopped,
 } from '../feed';
+import { handleUserUpdated } from './event-handlers';
 
 export type FeedsClientState = {
   connected_user: OwnUser | undefined;
@@ -194,6 +195,10 @@ export class FeedsClient extends FeedsApi {
           const feeds = this.findActiveFeedByActivityId(activityId);
           feeds.forEach((f) => f.handleWSEvent(event));
 
+          break;
+        }
+        case 'user.updated': {
+          handleUserUpdated.call(this, event);
           break;
         }
         default: {

--- a/packages/feeds-client/src/feeds-client/feeds-client.ts
+++ b/packages/feeds-client/src/feeds-client/feeds-client.ts
@@ -1,4 +1,4 @@
-import { FeedsApi } from './gen/feeds/FeedsApi';
+import { FeedsApi } from '../gen/feeds/FeedsApi';
 import {
   ActivityResponse,
   FeedResponse,
@@ -14,27 +14,27 @@ import {
   UpdateFollowRequest,
   UserRequest,
   WSEvent,
-} from './gen/models';
-import { FeedsEvent, StreamFile, TokenOrProvider } from './types';
-import { StateStore } from './common/StateStore';
-import { TokenManager } from './common/TokenManager';
-import { ConnectionIdManager } from './common/ConnectionIdManager';
-import { StableWSConnection } from './common/real-time/StableWSConnection';
-import { EventDispatcher } from './common/EventDispatcher';
-import { ApiClient } from './common/ApiClient';
+} from '../gen/models';
+import { FeedsEvent, StreamFile, TokenOrProvider } from '../types';
+import { StateStore } from '../common/StateStore';
+import { TokenManager } from '../common/TokenManager';
+import { ConnectionIdManager } from '../common/ConnectionIdManager';
+import { StableWSConnection } from '../common/real-time/StableWSConnection';
+import { EventDispatcher } from '../common/EventDispatcher';
+import { ApiClient } from '../common/ApiClient';
 import {
   addConnectionEventListeners,
   removeConnectionEventListeners,
   streamDevToken,
-} from './common/utils';
-import { decodeWSEvent } from './gen/model-decoders/event-decoder-mapping';
+} from '../common/utils';
+import { decodeWSEvent } from '../gen/model-decoders/event-decoder-mapping';
 import {
   FeedsClientOptions,
   NetworkChangedEvent,
   StreamResponse,
-} from './common/types';
-import { ModerationClient } from './moderation-client';
-import { StreamPoll } from './common/Poll';
+} from '../common/types';
+import { ModerationClient } from '../moderation-client';
+import { StreamPoll } from '../common/Poll';
 import {
   Feed,
   handleFollowCreated,
@@ -42,7 +42,7 @@ import {
   handleFollowUpdated,
   handleWatchStarted,
   handleWatchStopped,
-} from './feed';
+} from '../feed';
 
 export type FeedsClientState = {
   connected_user: OwnUser | undefined;

--- a/packages/feeds-client/src/feeds-client/index.ts
+++ b/packages/feeds-client/src/feeds-client/index.ts
@@ -1,0 +1,2 @@
+export * from './feeds-client';
+export * from './event-handlers';

--- a/packages/feeds-client/src/test-utils/response-generators.ts
+++ b/packages/feeds-client/src/test-utils/response-generators.ts
@@ -13,6 +13,7 @@ export const generateUserResponse = (
   overrides: Partial<UserResponse> = {},
 ): UserResponse => ({
   id: `user-${getHumanId()}`,
+  name: humanId({ separator: ' ' }),
   created_at: new Date(),
   updated_at: new Date(),
   banned: false,
@@ -58,28 +59,26 @@ export const generateFeedResponse = (
   const id = overrides.id || `feed-${getHumanId()}`;
   const groupId = overrides.group_id || 'user';
   const fid = `${groupId}:${id}`;
-  const createdBy = generateUserResponse(overrides.created_by);
-  const description = humanId({
-    addAdverb: true,
-    adjectiveCount: 4,
-  });
-  const name = humanId();
 
   return {
     id,
     group_id: groupId,
     created_at: new Date(),
     updated_at: new Date(),
-    description,
-    fid,
+    description: humanId({
+      addAdverb: true,
+      adjectiveCount: 4,
+      separator: ' ',
+    }),
     follower_count: 0,
     following_count: 0,
     member_count: 0,
-    name,
+    name: humanId({ separator: ' ' }),
     pin_count: 0,
     custom: {},
     ...overrides,
-    created_by: createdBy,
+    fid,
+    created_by: generateUserResponse(overrides.created_by),
   };
 };
 


### PR DESCRIPTION
🎫 Ticket: https://linear.app/stream/issue/REACT-512

### 💡 Overview

- introduced identical folder structure for the `feeds-client` (as in `feed`)
- added client-level `user.updated` handler
