### PR TITLE
chore: [FEEDS-708] regenerate client from spec

### DIFF
--- a/packages/feeds-client/src/gen/feeds/FeedsApi.ts
+++ b/packages/feeds-client/src/gen/feeds/FeedsApi.ts
@@ -127,6 +127,8 @@ import {
   UpdateUsersResponse,
   UpsertActivitiesRequest,
   UpsertActivitiesResponse,
+  UpsertPushPreferencesRequest,
+  UpsertPushPreferencesResponse,
   WSAuthMessage,
 } from '../models';
 import { decoders } from '../model-decoders/decoders';
@@ -726,6 +728,7 @@ export class FeedsApi {
       text: request?.text,
       visibility: request?.visibility,
       attachments: request?.attachments,
+      feeds: request?.feeds,
       filter_tags: request?.filter_tags,
       interest_tags: request?.interest_tags,
       custom: request?.custom,
@@ -2069,6 +2072,29 @@ export class FeedsApi {
     );
 
     decoders.PollVotesResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updatePushNotificationPreferences(
+    request: UpsertPushPreferencesRequest,
+  ): Promise<StreamResponse<UpsertPushPreferencesResponse>> {
+    const body = {
+      preferences: request?.preferences,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpsertPushPreferencesResponse>
+    >(
+      'POST',
+      '/api/v2/push_preferences',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpsertPushPreferencesResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/packages/feeds-client/src/gen/model-decoders/decoders.ts
+++ b/packages/feeds-client/src/gen/model-decoders/decoders.ts
@@ -1849,6 +1849,13 @@ decoders.UpsertConfigResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
+decoders.UpsertPushPreferencesResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    user_preferences: { type: 'PushPreferences', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
 decoders.User = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     ban_expires: { type: 'DatetimeType', isSingle: true },

--- a/packages/feeds-client/src/gen/models/index.ts
+++ b/packages/feeds-client/src/gen/models/index.ts
@@ -1221,6 +1221,8 @@ export interface CallEgress {
 
 export interface CallIngressResponse {
   rtmp: RTMPIngress;
+
+  srt: SRTIngress;
 }
 
 export interface CallMember {
@@ -1782,6 +1784,12 @@ export const ChannelOwnCapability = {
 
 export type ChannelOwnCapability =
   (typeof ChannelOwnCapability)[keyof typeof ChannelOwnCapability];
+
+export interface ChannelPushPreferences {
+  chat_level?: string;
+
+  disabled_until?: Date;
+}
 
 export interface ChannelResponse {
   cid: string;
@@ -2912,15 +2920,15 @@ export interface FeedUpdatedEvent {
 }
 
 export interface FeedsPreferences {
-  comment?: string;
+  comment?: 'all' | 'none';
 
-  comment_reaction?: string;
+  comment_reaction?: 'all' | 'none';
 
-  follow?: string;
+  follow?: 'all' | 'none';
 
-  mention?: string;
+  mention?: 'all' | 'none';
 
-  reaction?: string;
+  reaction?: 'all' | 'none';
 
   custom_activity_types?: Record<string, string>;
 }
@@ -4562,6 +4570,24 @@ export interface PushNotificationConfig {
   push_types?: string[];
 }
 
+export interface PushPreferenceInput {
+  call_level?: 'all' | 'none' | 'default';
+
+  channel_cid?: string;
+
+  chat_level?: 'all' | 'mentions' | 'none' | 'default';
+
+  disabled_until?: Date;
+
+  feeds_level?: 'all' | 'none' | 'default';
+
+  remove_disable?: boolean;
+
+  user_id?: string;
+
+  feeds_preferences?: FeedsPreferences;
+}
+
 export interface PushPreferences {
   call_level?: string;
 
@@ -5314,6 +5340,10 @@ export interface SFUIDLastSeen {
   process_start_time: number;
 }
 
+export interface SRTIngress {
+  address: string;
+}
+
 export interface STTEgressConfig {
   closed_captions_enabled?: boolean;
 
@@ -5777,6 +5807,8 @@ export interface UpdateActivityRequest {
 
   attachments?: Attachment[];
 
+  feeds?: string[];
+
   filter_tags?: string[];
 
   interest_tags?: string[];
@@ -6022,6 +6054,21 @@ export interface UpsertConfigResponse {
   duration: string;
 
   config?: ConfigResponse;
+}
+
+export interface UpsertPushPreferencesRequest {
+  preferences: PushPreferenceInput[];
+}
+
+export interface UpsertPushPreferencesResponse {
+  duration: string;
+
+  user_channel_preferences: Record<
+    string,
+    Record<string, ChannelPushPreferences | null>
+  >;
+
+  user_preferences: Record<string, PushPreferences>;
 }
 
 export interface User {


### PR DESCRIPTION
🎫 Ticket: https://linear.app/stream/issue/FEEDS-708/allow-mutating-activity-fids-in-updateactivity-endpoint

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>

### 💡 Overview

Adds the ability to mutate activity FIDs with controllers `UpdateActivity` and `UpdateActivityPartial` (this was already possible with `UpsertActivities`)

### 📝 Implementation notes
