### PR TITLE
feat: ingest own capabilities from responses

### DIFF
--- a/packages/feeds-client/__integration-tests__/websocket-connection.test.ts
+++ b/packages/feeds-client/__integration-tests__/websocket-connection.test.ts
@@ -21,7 +21,7 @@ describe('WebSocket connection', () => {
     client.state.subscribe(spy);
 
     expect(spy).toHaveBeenCalledWith(
-      { connected_user: undefined, is_ws_connection_healthy: false },
+      { connected_user: undefined, is_ws_connection_healthy: false, own_capabilities_by_fid: {} },
       undefined,
     );
 

--- a/packages/feeds-client/__integration-tests__/websocket-connection.test.ts
+++ b/packages/feeds-client/__integration-tests__/websocket-connection.test.ts
@@ -21,7 +21,11 @@ describe('WebSocket connection', () => {
     client.state.subscribe(spy);
 
     expect(spy).toHaveBeenCalledWith(
-      { connected_user: undefined, is_ws_connection_healthy: false, own_capabilities_by_fid: {} },
+      {
+        connected_user: undefined,
+        is_ws_connection_healthy: false,
+        own_capabilities_by_fid: {},
+      },
       undefined,
     );
 

--- a/packages/feeds-client/src/bindings/react/hooks/feed-state-hooks/useOwnCapabilities.ts
+++ b/packages/feeds-client/src/bindings/react/hooks/feed-state-hooks/useOwnCapabilities.ts
@@ -1,84 +1,114 @@
 import { useMemo } from 'react';
-import { type Feed, type FeedState, FeedOwnCapability } from '@self';
+import { type Feed, FeedOwnCapability, type FeedsClientState } from '@self';
 import { useStateStore } from '@stream-io/state-store/react-bindings';
 import { useFeedContext } from '../../contexts/StreamFeedContext';
+import { useFeedsClient } from '../../contexts/StreamFeedsContext';
+import { useStableCallback } from '../internal';
 
 const stableEmptyArray: readonly FeedOwnCapability[] = [];
-
-const selector = (currentState: FeedState) => ({
-  oc: currentState.own_capabilities ?? stableEmptyArray,
-});
 
 type KebabToSnakeCase<S extends string> = S extends `${infer T}-${infer U}`
   ? `${T}_${KebabToSnakeCase<U>}`
   : S;
 
 export const useOwnCapabilities = (feedFromProps?: Feed) => {
+  const client = useFeedsClient();
   const feedFromContext = useFeedContext();
   const feed = feedFromProps ?? feedFromContext;
 
-  const { oc = stableEmptyArray } = useStateStore(feed?.state, selector) ?? {};
+  const selector = useStableCallback((currentState: FeedsClientState) => {
+    const fid = feed?.feed;
 
-  return useMemo(
-    () => {
-      const capabilitiesSet = new Set(oc);
-      return ({
-        can_add_activity: capabilitiesSet.has(FeedOwnCapability.ADD_ACTIVITY),
-        can_add_activity_bookmark:
-          capabilitiesSet.has(FeedOwnCapability.ADD_ACTIVITY_BOOKMARK),
-        can_add_activity_reaction:
-          capabilitiesSet.has(FeedOwnCapability.ADD_ACTIVITY_REACTION),
-        can_add_comment: capabilitiesSet.has(FeedOwnCapability.ADD_COMMENT),
-        can_add_comment_reaction:
-          capabilitiesSet.has(FeedOwnCapability.ADD_COMMENT_REACTION),
-        can_create_feed: capabilitiesSet.has(FeedOwnCapability.CREATE_FEED),
-        can_delete_any_activity:
-          capabilitiesSet.has(FeedOwnCapability.DELETE_ANY_ACTIVITY),
-        can_delete_any_comment:
-          capabilitiesSet.has(FeedOwnCapability.DELETE_ANY_COMMENT),
-        can_delete_feed: capabilitiesSet.has(FeedOwnCapability.DELETE_FEED),
-        can_delete_own_activity:
-          capabilitiesSet.has(FeedOwnCapability.DELETE_OWN_ACTIVITY),
-        can_delete_own_activity_bookmark:
-          capabilitiesSet.has(FeedOwnCapability.DELETE_OWN_ACTIVITY_BOOKMARK),
-        can_delete_own_activity_reaction:
-          capabilitiesSet.has(FeedOwnCapability.DELETE_OWN_ACTIVITY_REACTION),
-        can_delete_own_comment:
-          capabilitiesSet.has(FeedOwnCapability.DELETE_OWN_COMMENT),
-        can_delete_own_comment_reaction:
-          capabilitiesSet.has(FeedOwnCapability.DELETE_OWN_COMMENT_REACTION),
-        can_follow: capabilitiesSet.has(FeedOwnCapability.FOLLOW),
-        can_pin_activity: capabilitiesSet.has(FeedOwnCapability.PIN_ACTIVITY),
-        can_query_feed_members:
-          capabilitiesSet.has(FeedOwnCapability.QUERY_FEED_MEMBERS),
-        can_query_follows:
-          capabilitiesSet.has(FeedOwnCapability.QUERY_FOLLOWS),
-        can_read_activities:
-          capabilitiesSet.has(FeedOwnCapability.READ_ACTIVITIES),
-        can_read_feed: capabilitiesSet.has(FeedOwnCapability.READ_FEED),
-        can_unfollow: capabilitiesSet.has(FeedOwnCapability.UNFOLLOW),
-        can_update_any_activity:
-          capabilitiesSet.has(FeedOwnCapability.UPDATE_ANY_ACTIVITY),
-        can_update_any_comment:
-          capabilitiesSet.has(FeedOwnCapability.UPDATE_ANY_COMMENT),
-        can_update_feed: capabilitiesSet.has(FeedOwnCapability.UPDATE_FEED),
-        can_update_feed_followers:
-          capabilitiesSet.has(FeedOwnCapability.UPDATE_FEED_FOLLOWERS),
-        can_update_feed_members:
-          capabilitiesSet.has(FeedOwnCapability.UPDATE_FEED_MEMBERS),
-        can_update_own_activity:
-          capabilitiesSet.has(FeedOwnCapability.UPDATE_OWN_ACTIVITY),
-        can_update_own_activity_bookmark:
-          capabilitiesSet.has(FeedOwnCapability.UPDATE_OWN_ACTIVITY_BOOKMARK),
-        can_update_own_comment:
-          capabilitiesSet.has(FeedOwnCapability.UPDATE_OWN_COMMENT),
-      }) satisfies Record<
-        `can_${KebabToSnakeCase<
-          (typeof FeedOwnCapability)[keyof typeof FeedOwnCapability]
-        >}`,
-        boolean
-      >;
-    },
-    [oc],
-  );
+    if (!fid) {
+      return { feedOwnCapabilities: stableEmptyArray };
+    }
+
+    return {
+      feedOwnCapabilities:
+        currentState.own_capabilities_by_fid[fid] ?? stableEmptyArray,
+    };
+  });
+
+  const { feedOwnCapabilities = stableEmptyArray } =
+    useStateStore(client?.state, selector) ?? {};
+
+  console.log('GETTING CAPA: ', feedOwnCapabilities);
+
+  return useMemo(() => {
+    const capabilitiesSet = new Set(feedOwnCapabilities);
+    return {
+      can_add_activity: capabilitiesSet.has(FeedOwnCapability.ADD_ACTIVITY),
+      can_add_activity_bookmark: capabilitiesSet.has(
+        FeedOwnCapability.ADD_ACTIVITY_BOOKMARK,
+      ),
+      can_add_activity_reaction: capabilitiesSet.has(
+        FeedOwnCapability.ADD_ACTIVITY_REACTION,
+      ),
+      can_add_comment: capabilitiesSet.has(FeedOwnCapability.ADD_COMMENT),
+      can_add_comment_reaction: capabilitiesSet.has(
+        FeedOwnCapability.ADD_COMMENT_REACTION,
+      ),
+      can_create_feed: capabilitiesSet.has(FeedOwnCapability.CREATE_FEED),
+      can_delete_any_activity: capabilitiesSet.has(
+        FeedOwnCapability.DELETE_ANY_ACTIVITY,
+      ),
+      can_delete_any_comment: capabilitiesSet.has(
+        FeedOwnCapability.DELETE_ANY_COMMENT,
+      ),
+      can_delete_feed: capabilitiesSet.has(FeedOwnCapability.DELETE_FEED),
+      can_delete_own_activity: capabilitiesSet.has(
+        FeedOwnCapability.DELETE_OWN_ACTIVITY,
+      ),
+      can_delete_own_activity_bookmark: capabilitiesSet.has(
+        FeedOwnCapability.DELETE_OWN_ACTIVITY_BOOKMARK,
+      ),
+      can_delete_own_activity_reaction: capabilitiesSet.has(
+        FeedOwnCapability.DELETE_OWN_ACTIVITY_REACTION,
+      ),
+      can_delete_own_comment: capabilitiesSet.has(
+        FeedOwnCapability.DELETE_OWN_COMMENT,
+      ),
+      can_delete_own_comment_reaction: capabilitiesSet.has(
+        FeedOwnCapability.DELETE_OWN_COMMENT_REACTION,
+      ),
+      can_follow: capabilitiesSet.has(FeedOwnCapability.FOLLOW),
+      can_pin_activity: capabilitiesSet.has(FeedOwnCapability.PIN_ACTIVITY),
+      can_query_feed_members: capabilitiesSet.has(
+        FeedOwnCapability.QUERY_FEED_MEMBERS,
+      ),
+      can_query_follows: capabilitiesSet.has(FeedOwnCapability.QUERY_FOLLOWS),
+      can_read_activities: capabilitiesSet.has(
+        FeedOwnCapability.READ_ACTIVITIES,
+      ),
+      can_read_feed: capabilitiesSet.has(FeedOwnCapability.READ_FEED),
+      can_unfollow: capabilitiesSet.has(FeedOwnCapability.UNFOLLOW),
+      can_update_any_activity: capabilitiesSet.has(
+        FeedOwnCapability.UPDATE_ANY_ACTIVITY,
+      ),
+      can_update_any_comment: capabilitiesSet.has(
+        FeedOwnCapability.UPDATE_ANY_COMMENT,
+      ),
+      can_update_feed: capabilitiesSet.has(FeedOwnCapability.UPDATE_FEED),
+      can_update_feed_followers: capabilitiesSet.has(
+        FeedOwnCapability.UPDATE_FEED_FOLLOWERS,
+      ),
+      can_update_feed_members: capabilitiesSet.has(
+        FeedOwnCapability.UPDATE_FEED_MEMBERS,
+      ),
+      can_update_own_activity: capabilitiesSet.has(
+        FeedOwnCapability.UPDATE_OWN_ACTIVITY,
+      ),
+      can_update_own_activity_bookmark: capabilitiesSet.has(
+        FeedOwnCapability.UPDATE_OWN_ACTIVITY_BOOKMARK,
+      ),
+      can_update_own_comment: capabilitiesSet.has(
+        FeedOwnCapability.UPDATE_OWN_COMMENT,
+      ),
+    } satisfies Record<
+      `can_${KebabToSnakeCase<
+        (typeof FeedOwnCapability)[keyof typeof FeedOwnCapability]
+      >}`,
+      boolean
+    >;
+  }, [feedOwnCapabilities]);
 };

--- a/packages/feeds-client/src/bindings/react/hooks/feed-state-hooks/useOwnCapabilities.ts
+++ b/packages/feeds-client/src/bindings/react/hooks/feed-state-hooks/useOwnCapabilities.ts
@@ -32,7 +32,7 @@ export const useOwnCapabilities = (feedFromProps?: Feed) => {
   const { feedOwnCapabilities = stableEmptyArray } =
     useStateStore(client?.state, selector) ?? {};
 
-  console.log('GETTING CAPA: ', feedOwnCapabilities);
+  // console.log('GETTING CAPA: ', feed?.feed, feedOwnCapabilities);
 
   return useMemo(() => {
     const capabilitiesSet = new Set(feedOwnCapabilities);

--- a/packages/feeds-client/src/common/real-time/event-models.ts
+++ b/packages/feeds-client/src/common/real-time/event-models.ts
@@ -1,5 +1,5 @@
-import type { OwnUser } from '../../gen/models';
-import type { StreamApiError } from '../../../dist/types/common/types';
+import type { OwnUser } from '@self';
+import type { StreamApiError } from '@self';
 
 export interface ConnectionChangedEvent {
   type: 'connection.changed';

--- a/packages/feeds-client/src/common/real-time/event-models.ts
+++ b/packages/feeds-client/src/common/real-time/event-models.ts
@@ -1,4 +1,5 @@
 import type { OwnUser } from '../../gen/models';
+import type { StreamApiError } from '../../../dist/types/common/types';
 
 export interface ConnectionChangedEvent {
   type: 'connection.changed';
@@ -39,9 +40,10 @@ export interface ConnectedEvent {
 
 export enum UnhandledErrorType {
   ReconnectionReconciliation = 'reconnection-reconciliation',
+  FetchingOwnCapabilitiesOnNewActivity = 'fetching-own-capabilities-on-new-activity',
 }
 
-export type SyncFailure = { feed: string, reason: unknown };
+export type SyncFailure = { feed: string; reason: unknown };
 
 export type UnhandledErrorEvent = {
   type: 'errors.unhandled';
@@ -50,5 +52,9 @@ export type UnhandledErrorEvent = {
   | {
       error_type: UnhandledErrorType.ReconnectionReconciliation;
       failures: SyncFailure[];
+    }
+  | {
+      error_type: UnhandledErrorType.FetchingOwnCapabilitiesOnNewActivity;
+      error: StreamApiError;
     }
 );

--- a/packages/feeds-client/src/common/types.ts
+++ b/packages/feeds-client/src/common/types.ts
@@ -6,6 +6,7 @@ export type FeedsClientOptions = {
   base_url?: string;
   timeout?: number;
   configure_loggers_options?: ConfigureLoggersOptions;
+  query_batch_own_capabilties_throttling_interval?: number;
 };
 
 export type RateLimit = {

--- a/packages/feeds-client/src/feed/event-handlers/activity/handle-activity-added.ts
+++ b/packages/feeds-client/src/feed/event-handlers/activity/handle-activity-added.ts
@@ -1,7 +1,6 @@
 import type { Feed } from '../../feed';
 import type { ActivityResponse } from '../../../gen/models';
 import type { EventPayload, UpdateStateResult } from '../../../types-internal';
-import { queueBatchedOwnCapabilities } from '../../../utils/throttling/throttled-get-batched-own-capabilities';
 
 export function addActivitiesToState(
   this: Feed,

--- a/packages/feeds-client/src/feed/event-handlers/activity/handle-activity-added.ts
+++ b/packages/feeds-client/src/feed/event-handlers/activity/handle-activity-added.ts
@@ -54,7 +54,22 @@ export function handleActivityAdded(
     'start',
   );
   if (result.changed) {
-    this.client.hydratePollCache([event.activity]);
+    const activity = event.activity;
+    this.client.hydratePollCache([activity]);
+
+    const currentFeed = activity.current_feed;
+    
+    if (currentFeed) {
+      if (currentFeed?.own_capabilities) {
+        this.client.hydrateCapabilitiesCache([currentFeed]);
+      } else {
+        this.client.queryFeeds({ filter: { feed: currentFeed.feed }}).catch(error => {
+          // FIXME: move to bubbling local error event
+          console.error(error);
+        })
+      }
+    }
+
     this.state.partialNext({ activities: result.activities });
   }
 }

--- a/packages/feeds-client/src/feed/event-handlers/activity/handle-activity-added.ts
+++ b/packages/feeds-client/src/feed/event-handlers/activity/handle-activity-added.ts
@@ -1,6 +1,7 @@
 import type { Feed } from '../../feed';
 import type { ActivityResponse } from '../../../gen/models';
 import type { EventPayload, UpdateStateResult } from '../../../types-internal';
+import { queueBatchedOwnCapabilities } from '../../../utils/throttling/throttled-get-batched-own-capabilities';
 
 export function addActivitiesToState(
   this: Feed,
@@ -58,16 +59,9 @@ export function handleActivityAdded(
     this.client.hydratePollCache([activity]);
 
     const currentFeed = activity.current_feed;
-    
+
     if (currentFeed) {
-      if (currentFeed?.own_capabilities) {
-        this.client.hydrateCapabilitiesCache([currentFeed]);
-      } else {
-        this.client.queryFeeds({ filter: { feed: currentFeed.feed }}).catch(error => {
-          // FIXME: move to bubbling local error event
-          console.error(error);
-        })
-      }
+      this.client.hydrateCapabilitiesCache([currentFeed]);
     }
 
     this.state.partialNext({ activities: result.activities });

--- a/packages/feeds-client/src/feed/feed.ts
+++ b/packages/feeds-client/src/feed/feed.ts
@@ -271,7 +271,16 @@ export class Feed extends FeedApi {
     try {
       const response = await super.getOrCreate(request);
 
-      this.client.hydrateCapabilitiesCache([response.feed]);
+      console.log('RESP: ', response)
+
+      const currentActivityFeeds = [];
+      for (const activity of response.activities) {
+        if (activity.current_feed) {
+          currentActivityFeeds.push(activity.current_feed);
+        }
+      }
+
+      this.client.hydrateCapabilitiesCache([response.feed, ...currentActivityFeeds]);
 
       if (request?.next) {
         const { activities: currentActivities = [] } = this.currentState;

--- a/packages/feeds-client/src/feed/feed.ts
+++ b/packages/feeds-client/src/feed/feed.ts
@@ -57,7 +57,7 @@ import { checkHasAnotherPage, Constants, uniqueArrayMerge } from '../utils';
 
 export type FeedState = Omit<
   Partial<GetOrCreateFeedResponse & FeedResponse>,
-  'feed' | 'duration'
+  'feed' | 'own_capabilities' | 'duration'
 > & {
   /**
    * True when loading state using `getOrCreate`
@@ -270,6 +270,9 @@ export class Feed extends FeedApi {
 
     try {
       const response = await super.getOrCreate(request);
+
+      this.client.hydrateCapabilitiesCache([response.feed]);
+
       if (request?.next) {
         const { activities: currentActivities = [] } = this.currentState;
 
@@ -813,11 +816,16 @@ export class Feed extends FeedApi {
     });
   }
 
-  addActivity(request: Omit<ActivityRequest, 'feeds'>) {
-    return this.feedsApi.addActivity({
+  async addActivity(request: Omit<ActivityRequest, 'feeds'>) {
+    const response = await this.client.addActivity({
       ...request,
       feeds: [this.feed],
     });
+    const currentFeed = response.activity.current_feed;
+    if (currentFeed) {
+      this.client.hydrateCapabilitiesCache([currentFeed]);
+    }
+    return response;
   }
 
   on = this.eventDispatcher.on;

--- a/packages/feeds-client/src/feeds-client/feeds-client.ts
+++ b/packages/feeds-client/src/feeds-client/feeds-client.ts
@@ -72,13 +72,13 @@ import {
 } from '../common/real-time/event-models';
 import { updateCommentCount } from '../feed/event-handlers/comment/utils';
 import { configureLoggers } from '../utils';
-import { throttle } from '../utils/throttling';
 import {
+  throttle,
   DEFAULT_BATCH_OWN_CAPABILITIES_THROTTLING_INTERVAL,
   type GetBatchedOwnCapabilitiesThrottledCallback,
   queueBatchedOwnCapabilities,
   type ThrottledGetBatchedOwnCapabilities,
-} from '../utils/throttling/throttled-get-batched-own-capabilities';
+} from '../utils/throttling';
 
 export type FeedsClientState = {
   connected_user: OwnUser | undefined;

--- a/packages/feeds-client/src/feeds-client/feeds-client.ts
+++ b/packages/feeds-client/src/feeds-client/feeds-client.ts
@@ -16,7 +16,8 @@ import type {
   ImageUploadRequest,
   OwnUser,
   PollResponse,
-  PollVotesResponse, QueryActivitiesRequest,
+  PollVotesResponse,
+  QueryActivitiesRequest,
   QueryFeedsRequest,
   QueryPollVotesRequest,
   UpdateActivityRequest,
@@ -65,13 +66,16 @@ import {
   handleWatchStopped,
 } from '../feed';
 import { handleUserUpdated } from './event-handlers';
-import type { SyncFailure } from '../common/real-time/event-models';
-import { UnhandledErrorType } from '../common/real-time/event-models';
+import {
+  type SyncFailure,
+  UnhandledErrorType,
+} from '../common/real-time/event-models';
 import { updateCommentCount } from '../feed/event-handlers/comment/utils';
 import { configureLoggers } from '../utils';
 import { throttle, type ThrottledCallback } from '../utils/throttling';
 import {
-  queueBatchedOwnCapabilities
+  QUEUE_BATCH_OWN_CAPABILITIES_THROTTLING_INTERVAL,
+  queueBatchedOwnCapabilities,
 } from '../utils/throttling/throttled-get-batched-own-capabilities';
 
 export type FeedsClientState = {
@@ -281,16 +285,15 @@ export class FeedsClient extends FeedsApi {
   }
 
   public hydrateCapabilitiesCache(feedResponses: FeedResponse[]) {
-    let ownCapabilitiesCache = this.state.getLatestValue().own_capabilities_by_fid;
+    let ownCapabilitiesCache =
+      this.state.getLatestValue().own_capabilities_by_fid;
 
     const capabilitiesToFetchQueue: string[] = [];
 
     for (const feedResponse of feedResponses) {
       const { feed, own_capabilities } = feedResponse;
 
-      if (
-        !Object.prototype.hasOwnProperty.call(ownCapabilitiesCache, feed)
-      ) {
+      if (!Object.prototype.hasOwnProperty.call(ownCapabilitiesCache, feed)) {
         if (own_capabilities) {
           ownCapabilitiesCache = {
             ...ownCapabilitiesCache,
@@ -546,15 +549,17 @@ export class FeedsClient extends FeedsApi {
 
   protected throttledGetBatchedOwnCapabilities = throttle(
     ((feeds: string[], callback: (feeds: string[]) => void | Promise<void>) => {
-      this.queryFeeds({ filter: { feed: { $in: feeds } }}).catch(error => {
-        // FIXME: move to bubbling local error event
+      this.queryFeeds({ filter: { feed: { $in: feeds } } }).catch((error) => {
+        this.eventDispatcher.dispatch({
+          type: 'errors.unhandled',
+          error_type: UnhandledErrorType.FetchingOwnCapabilitiesOnNewActivity,
+          error,
+        });
         console.error(error);
-      })
+      });
       callback(feeds);
-      // FIXME: use proper type
     }) as ThrottledCallback,
-    // FIXME: use const
-    2000,
+    QUEUE_BATCH_OWN_CAPABILITIES_THROTTLING_INTERVAL,
     { trailing: true },
   );
 
@@ -585,7 +590,9 @@ export class FeedsClient extends FeedsApi {
 
   async queryActivities(request?: QueryActivitiesRequest) {
     const response = await super.queryActivities(request);
-    const activityCurrentFeeds = response.activities.map(activity => activity.current_feed);
+    const activityCurrentFeeds = response.activities.map(
+      (activity) => activity.current_feed,
+    );
     const feedsToHydrateFrom = [];
 
     for (const feed of activityCurrentFeeds) {

--- a/packages/feeds-client/src/feeds-client/feeds-client.ts
+++ b/packages/feeds-client/src/feeds-client/feeds-client.ts
@@ -72,10 +72,12 @@ import {
 } from '../common/real-time/event-models';
 import { updateCommentCount } from '../feed/event-handlers/comment/utils';
 import { configureLoggers } from '../utils';
-import { throttle, type ThrottledCallback } from '../utils/throttling';
+import { throttle } from '../utils/throttling';
 import {
-  QUEUE_BATCH_OWN_CAPABILITIES_THROTTLING_INTERVAL,
+  DEFAULT_BATCH_OWN_CAPABILITIES_THROTTLING_INTERVAL,
+  type GetBatchedOwnCapabilitiesThrottledCallback,
   queueBatchedOwnCapabilities,
+  type ThrottledGetBatchedOwnCapabilities,
 } from '../utils/throttling/throttled-get-batched-own-capabilities';
 
 export type FeedsClientState = {
@@ -104,6 +106,8 @@ export class FeedsClient extends FeedsApi {
 
   private healthyConnectionChangedEventCount = 0;
 
+  protected throttledGetBatchOwnCapabilities!: ThrottledGetBatchedOwnCapabilities;
+
   constructor(apiKey: string, options?: FeedsClientOptions) {
     const tokenManager = new TokenManager();
     const connectionIdManager = new ConnectionIdManager();
@@ -123,6 +127,11 @@ export class FeedsClient extends FeedsApi {
     this.tokenManager = tokenManager;
     this.connectionIdManager = connectionIdManager;
     this.polls_by_id = new Map();
+
+    this.setGetBatchOwnCapabilitiesThrottlingInterval(
+      options?.query_batch_own_capabilties_throttling_interval ??
+        DEFAULT_BATCH_OWN_CAPABILITIES_THROTTLING_INTERVAL,
+    );
 
     configureLoggers(options?.configure_loggers_options);
 
@@ -238,6 +247,30 @@ export class FeedsClient extends FeedsApi {
       }
     });
   }
+
+  private setGetBatchOwnCapabilitiesThrottlingInterval = (
+    throttlingMs: number,
+  ) => {
+    this.throttledGetBatchOwnCapabilities =
+      throttle<GetBatchedOwnCapabilitiesThrottledCallback>(
+        (feeds, callback) => {
+          // TODO: Replace this with the actual getBatchCapabilities endpoint when it is ready
+          this.queryFeeds({ filter: { feed: { $in: feeds } } }).catch(
+            (error) => {
+              this.eventDispatcher.dispatch({
+                type: 'errors.unhandled',
+                error_type:
+                  UnhandledErrorType.FetchingOwnCapabilitiesOnNewActivity,
+                error,
+              });
+            },
+          );
+          callback(feeds);
+        },
+        throttlingMs,
+        { trailing: true },
+      );
+  };
 
   private recoverOnReconnect = async () => {
     this.healthyConnectionChangedEventCount++;
@@ -546,23 +579,6 @@ export class FeedsClient extends FeedsApi {
   feed = (groupId: string, id: string) => {
     return this.getOrCreateActiveFeed(groupId, id);
   };
-
-  protected throttledGetBatchedOwnCapabilities = throttle(
-    ((feeds: string[], callback: (feeds: string[]) => void | Promise<void>) => {
-      // TODO: Replace this with the actual getBatchCapabilities endpoint when it is ready
-      this.queryFeeds({ filter: { feed: { $in: feeds } } }).catch((error) => {
-        this.eventDispatcher.dispatch({
-          type: 'errors.unhandled',
-          error_type: UnhandledErrorType.FetchingOwnCapabilitiesOnNewActivity,
-          error,
-        });
-        console.error(error);
-      });
-      callback(feeds);
-    }) as ThrottledCallback,
-    QUEUE_BATCH_OWN_CAPABILITIES_THROTTLING_INTERVAL,
-    { trailing: true },
-  );
 
   async queryFeeds(request?: QueryFeedsRequest) {
     const response = await this._queryFeeds(request);

--- a/packages/feeds-client/src/feeds-client/feeds-client.ts
+++ b/packages/feeds-client/src/feeds-client/feeds-client.ts
@@ -16,7 +16,7 @@ import type {
   ImageUploadRequest,
   OwnUser,
   PollResponse,
-  PollVotesResponse,
+  PollVotesResponse, QueryActivitiesRequest,
   QueryFeedsRequest,
   QueryPollVotesRequest,
   UpdateActivityRequest,
@@ -65,17 +65,15 @@ import {
   handleWatchStopped,
 } from '../feed';
 import { handleUserUpdated } from './event-handlers';
-import type {
-  SyncFailure} from '../common/real-time/event-models';
-import {
-  UnhandledErrorType,
-} from '../common/real-time/event-models';
+import type { SyncFailure } from '../common/real-time/event-models';
+import { UnhandledErrorType } from '../common/real-time/event-models';
 import { updateCommentCount } from '../feed/event-handlers/comment/utils';
 import { configureLoggers } from '../utils/logger';
 
 export type FeedsClientState = {
   connected_user: OwnUser | undefined;
   is_ws_connection_healthy: boolean;
+  own_capabilities_by_fid: Record<string, FeedResponse['own_capabilities']>;
 };
 
 type FID = string;
@@ -111,6 +109,7 @@ export class FeedsClient extends FeedsApi {
     this.state = new StateStore<FeedsClientState>({
       connected_user: undefined,
       is_ws_connection_healthy: false,
+      own_capabilities_by_fid: {},
     });
     this.moderation = new ModerationClient(apiClient);
     this.tokenManager = tokenManager;
@@ -275,6 +274,27 @@ export class FeedsClient extends FeedsApi {
         pollFromCache.reinitializeState(pollResponse);
       }
     }
+  }
+
+  public hydrateCapabilitiesCache(feedResponses: FeedResponse[]) {
+    let ownCapabilitiesCache = {
+      ...this.state.getLatestValue().own_capabilities_by_fid,
+    };
+    for (const feedResponse of feedResponses) {
+      const { feed, own_capabilities } = feedResponse;
+
+      if (
+        !Object.prototype.hasOwnProperty.call(ownCapabilitiesCache, feed) &&
+        own_capabilities
+      ) {
+        ownCapabilitiesCache = {
+          ...ownCapabilitiesCache,
+          [feed]: own_capabilities,
+        };
+      }
+    }
+
+    this.state.partialNext({ own_capabilities_by_fid: ownCapabilitiesCache });
   }
 
   connectUser = async (user: UserRequest, tokenProvider: TokenOrProvider) => {
@@ -496,9 +516,14 @@ export class FeedsClient extends FeedsApi {
 
     this.connectionIdManager.reset();
     this.tokenManager.reset();
+
+    // clear all caches
+    this.polls_by_id.clear();
+
     this.state.partialNext({
       connected_user: undefined,
       is_ws_connection_healthy: false,
+      own_capabilities_by_fid: {},
     });
   };
 
@@ -512,7 +537,9 @@ export class FeedsClient extends FeedsApi {
   async queryFeeds(request?: QueryFeedsRequest) {
     const response = await this._queryFeeds(request);
 
-    const feeds = response.feeds.map((feedResponse) =>
+    const feedResponses = response.feeds;
+
+    const feeds = feedResponses.map((feedResponse) =>
       this.getOrCreateActiveFeed(
         feedResponse.group_id,
         feedResponse.id,
@@ -521,6 +548,8 @@ export class FeedsClient extends FeedsApi {
       ),
     );
 
+    this.hydrateCapabilitiesCache(feedResponses);
+
     return {
       feeds,
       next: response.next,
@@ -528,6 +557,22 @@ export class FeedsClient extends FeedsApi {
       metadata: response.metadata,
       duration: response.duration,
     };
+  }
+
+  async queryActivities(request?: QueryActivitiesRequest) {
+    const response = await super.queryActivities(request);
+    const activityCurrentFeeds = response.activities.map(activity => activity.current_feed);
+    const feedsToHydrateFrom = [];
+
+    for (const feed of activityCurrentFeeds) {
+      if (feed) {
+        feedsToHydrateFrom.push(feed);
+      }
+    }
+
+    this.hydrateCapabilitiesCache(feedsToHydrateFrom);
+
+    return response;
   }
 
   updateNetworkConnectionStatus = (

--- a/packages/feeds-client/src/feeds-client/feeds-client.ts
+++ b/packages/feeds-client/src/feeds-client/feeds-client.ts
@@ -549,6 +549,7 @@ export class FeedsClient extends FeedsApi {
 
   protected throttledGetBatchedOwnCapabilities = throttle(
     ((feeds: string[], callback: (feeds: string[]) => void | Promise<void>) => {
+      // TODO: Replace this with the actual getBatchCapabilities endpoint when it is ready
       this.queryFeeds({ filter: { feed: { $in: feeds } } }).catch((error) => {
         this.eventDispatcher.dispatch({
           type: 'errors.unhandled',

--- a/packages/feeds-client/src/feeds-client/feeds-client.ts
+++ b/packages/feeds-client/src/feeds-client/feeds-client.ts
@@ -68,7 +68,11 @@ import { handleUserUpdated } from './event-handlers';
 import type { SyncFailure } from '../common/real-time/event-models';
 import { UnhandledErrorType } from '../common/real-time/event-models';
 import { updateCommentCount } from '../feed/event-handlers/comment/utils';
-import { configureLoggers } from '../utils/logger';
+import { configureLoggers } from '../utils';
+import { throttle, type ThrottledCallback } from '../utils/throttling';
+import {
+  queueBatchedOwnCapabilities
+} from '../utils/throttling/throttled-get-batched-own-capabilities';
 
 export type FeedsClientState = {
   connected_user: OwnUser | undefined;
@@ -277,22 +281,28 @@ export class FeedsClient extends FeedsApi {
   }
 
   public hydrateCapabilitiesCache(feedResponses: FeedResponse[]) {
-    let ownCapabilitiesCache = {
-      ...this.state.getLatestValue().own_capabilities_by_fid,
-    };
+    let ownCapabilitiesCache = this.state.getLatestValue().own_capabilities_by_fid;
+
+    const capabilitiesToFetchQueue: string[] = [];
+
     for (const feedResponse of feedResponses) {
       const { feed, own_capabilities } = feedResponse;
 
       if (
-        !Object.prototype.hasOwnProperty.call(ownCapabilitiesCache, feed) &&
-        own_capabilities
+        !Object.prototype.hasOwnProperty.call(ownCapabilitiesCache, feed)
       ) {
-        ownCapabilitiesCache = {
-          ...ownCapabilitiesCache,
-          [feed]: own_capabilities,
-        };
+        if (own_capabilities) {
+          ownCapabilitiesCache = {
+            ...ownCapabilitiesCache,
+            [feed]: own_capabilities,
+          };
+        } else {
+          capabilitiesToFetchQueue.push(feed);
+        }
       }
     }
+
+    queueBatchedOwnCapabilities.bind(this)({ feeds: capabilitiesToFetchQueue });
 
     this.state.partialNext({ own_capabilities_by_fid: ownCapabilitiesCache });
   }
@@ -533,6 +543,20 @@ export class FeedsClient extends FeedsApi {
   feed = (groupId: string, id: string) => {
     return this.getOrCreateActiveFeed(groupId, id);
   };
+
+  protected throttledGetBatchedOwnCapabilities = throttle(
+    ((feeds: string[], callback: (feeds: string[]) => void | Promise<void>) => {
+      this.queryFeeds({ filter: { feed: { $in: feeds } }}).catch(error => {
+        // FIXME: move to bubbling local error event
+        console.error(error);
+      })
+      callback(feeds);
+      // FIXME: use proper type
+    }) as ThrottledCallback,
+    // FIXME: use const
+    2000,
+    { trailing: true },
+  );
 
   async queryFeeds(request?: QueryFeedsRequest) {
     const response = await this._queryFeeds(request);

--- a/packages/feeds-client/src/utils/throttling/index.ts
+++ b/packages/feeds-client/src/utils/throttling/index.ts
@@ -1,0 +1,1 @@
+export * from './throttle';

--- a/packages/feeds-client/src/utils/throttling/index.ts
+++ b/packages/feeds-client/src/utils/throttling/index.ts
@@ -1,1 +1,2 @@
 export * from './throttle';
+export * from './throttled-get-batched-own-capabilities'

--- a/packages/feeds-client/src/utils/throttling/throttle.test.ts
+++ b/packages/feeds-client/src/utils/throttling/throttle.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ThrottledCallback } from './throttle';
+import { throttle } from './throttle';
+
+const advance = (ms: number) => vi.advanceTimersByTime(ms);
+
+describe('throttle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('leading:true, trailing:false (default): fires immediately, drops during window, fires again after window on next call', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200);
+
+    t('a');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenLastCalledWith('a');
+
+    t('b');
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    advance(199);
+    t('c');
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    advance(1);
+    t('d');
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith('d');
+  });
+
+  it('leading:true, trailing:true: first call fires immediately; subsequent calls within window schedule one trailing with latest args', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, { trailing: true });
+
+    t('a');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenLastCalledWith('a');
+
+    advance(50);
+    t('b');
+    advance(50);
+    t('c');
+    advance(99);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    advance(1);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith('c');
+  });
+
+  it('leading:true, trailing:true: no double-invoke at boundary (new leading cancels pending trailing)', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, { trailing: true });
+
+    t('a');
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    advance(190);
+    t('b');
+    t('c');
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(200);
+    t('d');
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith('d');
+
+    // even if we advance timers now, there should be no extra trailing (canceled)
+    vi.runOnlyPendingTimers();
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('leading:true, trailing:true: single call does not later trigger trailing (guard against double with same args)', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, { trailing: true });
+
+    t('a');
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // wait past the window; no additional calls should happen
+    vi.runAllTimers();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('leading:true, trailing:true: trailing uses the latest args within the window', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, { trailing: true });
+
+    t('a');
+    advance(50);
+    t('b');
+    advance(50);
+    t('c');
+    advance(100);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith('c');
+  });
+
+  it('leading:false, trailing:true: does not call immediately; calls once at end of window with latest args', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, {
+      leading: false,
+      trailing: true,
+    });
+
+    t('a');
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    advance(50);
+    t('b');
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    advance(150);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenLastCalledWith('b');
+
+    // next window:
+    advance(50);
+    t('c');
+    expect(spy).toHaveBeenCalledTimes(1);
+    advance(99);
+    expect(spy).toHaveBeenCalledTimes(1);
+    advance(51);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith('c');
+  });
+
+  it('leading:false, trailing:false: never calls', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, {
+      leading: false,
+      trailing: false,
+    });
+
+    t('a');
+    t('b');
+    advance(1000);
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+
+  it('preserves `this` on trailing (apply)', () => {
+    const seen: any[] = [];
+    const obj = {
+      x: 42,
+      fn(this: any, v: string) {
+        seen.push([this, v]);
+      },
+    };
+    const throttled = throttle(obj.fn, 200, { leading: false, trailing: true });
+
+    // Call as a method so `this` is obj
+    (obj as any).call = throttled;
+    (obj as any).call('hello'); // t=0
+    advance(200); // trailing fires
+
+    expect(seen.length).toBe(1);
+    expect(seen[0][0]).toBe(obj);
+    expect(seen[0][1]).toBe('hello');
+  });
+
+  it('schedules trailing for the exact remaining time, not the full timeout', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, { trailing: true });
+
+    t('a');
+    advance(50);
+    t('b');
+
+    advance(149);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    advance(1);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith('b');
+  });
+
+  it('after a trailing fires, a call inside the next window does NOT invoke immediately (still throttled)', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, { trailing: true });
+
+    t('a');
+    advance(200);
+
+    t('b');
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith('b');
+
+    advance(50);
+    t('c');
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    // trailing should kick in at t=400 with 'c'
+    advance(150);
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenLastCalledWith('c');
+  });
+
+  it('does not fire trailing after a new leading crosses the boundary (no boundary double)', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, { trailing: true });
+
+    t('a');
+    advance(180);
+    t('b');
+    // cross the boundary and call immediately, which should:
+    // - clear pending trailing
+    // - call leading just once
+    vi.setSystemTime(200);
+    t('c');
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(1, 'a');
+    expect(spy).toHaveBeenNthCalledWith(2, 'c');
+
+    // even if we advance timers, no extra trailing should occur
+    vi.runOnlyPendingTimers();
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('multiple calls in a burst within a window still produce at most one trailing (latest args)', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, { trailing: true });
+
+    t(1);
+    for (let i = 2; i <= 10; i++) t(i);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    advance(200);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith(10);
+  });
+
+  it('does not accidentally schedule trailing when leading:false and trailing:false', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, {
+      leading: false,
+      trailing: false,
+    });
+
+    for (let i = 0; i < 10; i++) t(i);
+    advance(1000);
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+
+  it('leading:true, trailing:true: next call well after window leads immediately, not waiting for any lingering timer', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, { trailing: true });
+
+    t('a');
+    advance(200);
+
+    t('b');
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith('b');
+  });
+
+  it('works with different timeouts (sanity check)', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 50, { trailing: true });
+
+    t(1);
+    advance(30);
+    t(2);
+    advance(19);
+    expect(spy).toHaveBeenCalledTimes(1);
+    advance(1);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith(2);
+
+    // next cycle:
+    advance(10);
+    t(3);
+    advance(39);
+    expect(spy).toHaveBeenCalledTimes(2);
+    advance(1);
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenLastCalledWith(3);
+  });
+
+  it('does not leak extra invocations after long idle periods', () => {
+    const spy = vi.fn();
+    const t = throttle(spy as ThrottledCallback, 200, { trailing: true });
+
+    t('a');
+    advance(180);
+    t('b');
+
+    advance(20);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    // wait a long time; nothing else should fire
+    advance(10000);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should have correct total invocations on spamming a lot of calls with leading and trailing', () => {
+    const spy = vi.fn();
+    const calls = 200;
+
+    const t = throttle(spy, 2000, { trailing: true });
+
+    for (let i = 0; i < calls; i++) {
+      t(i);
+      if (i < calls - 1) vi.advanceTimersByTime(100);
+    }
+    expect(spy).toHaveBeenCalledTimes(10);
+
+    // one pending trailing for 20000ms is still queued; flush it
+    vi.runAllTimers();
+
+    expect(spy).toHaveBeenCalledTimes(11);
+    expect(spy).toHaveBeenLastCalledWith(199);
+  });
+});

--- a/packages/feeds-client/src/utils/throttling/throttle.ts
+++ b/packages/feeds-client/src/utils/throttling/throttle.ts
@@ -3,17 +3,12 @@ export type ThrottledCallback = (...args: unknown[]) => unknown;
 /**
  * Throttle a function so it runs at most once per `timeout` ms.
  *
- * - single–timer approach: we keep one pending timer for the trailing edge
  * - `leading`: fire immediately when the window opens
  * - `trailing`: remember the latest args/this and fire once when the window closes
- * - avoids boundary double-invoke: if we just led with the same args, we clear the stored ones
- * - preserves `this` on trailing (uses `fn.apply(this, args)`)
  *
  * defaults: `{ leading: true, trailing: false }`
- * (lodash’s default is `{ leading: true, trailing: true }` — enable `trailing` if you want that)
  *
  * notes:
- * - uses `Date.now()`; if you need a monotonic clock, swap in `performance.now()`
  * - make one throttled instance and reuse it; re-creating it resets internal state
  *
  * @typeParam T - the function type being throttled

--- a/packages/feeds-client/src/utils/throttling/throttle.ts
+++ b/packages/feeds-client/src/utils/throttling/throttle.ts
@@ -1,0 +1,34 @@
+export type ThrottledCallback = (...args: unknown[]) => unknown;
+
+// works exactly the same as lodash.throttle
+export const throttle = <T extends ThrottledCallback>(
+  fn: T,
+  timeout = 200,
+  { leading = true, trailing = false }: { leading?: boolean; trailing?: boolean } = {},
+) => {
+  let runningTimeout: null | NodeJS.Timeout = null;
+  let storedArgs: Parameters<T> | null = null;
+
+  return (...args: Parameters<T>) => {
+    if (runningTimeout) {
+      if (trailing) storedArgs = args;
+      return;
+    }
+
+    if (leading) fn(...args);
+
+    const timeoutHandler = () => {
+      if (storedArgs) {
+        fn(...storedArgs);
+        storedArgs = null;
+        runningTimeout = setTimeout(timeoutHandler, timeout);
+
+        return;
+      }
+
+      runningTimeout = null;
+    };
+
+    runningTimeout = setTimeout(timeoutHandler, timeout);
+  };
+};

--- a/packages/feeds-client/src/utils/throttling/throttle.ts
+++ b/packages/feeds-client/src/utils/throttling/throttle.ts
@@ -1,5 +1,10 @@
 export type ThrottledCallback = (...args: unknown[]) => unknown;
 
+// export type ThrottledFunction<T extends unknown[]> = (this: unknown, ...args: T) => void;
+
+export type ThrottledFunction<T extends unknown[]> =
+  ((...args: T) => void);
+
 /**
  * Throttle a function so it runs at most once per `timeout` ms.
  *
@@ -24,17 +29,17 @@ export type ThrottledCallback = (...args: unknown[]) => unknown;
  * const sendThrottled = throttle(send, 2000, { leading: true, trailing: true });
  * // call `sendThrottled` freely; it won’t invoke `send` more than once every 2s
  */
-export const throttle = <T extends ThrottledCallback>(
-  fn: T,
+export const throttle = <T extends unknown[]>(
+  fn: (...args: T) => void,
   timeout = 200,
   { leading = true, trailing = false }: { leading?: boolean; trailing?: boolean } = {},
 ) => {
   let timer: NodeJS.Timeout | null = null;
-  let storedArgs: Parameters<T> | null = null;
+  let storedArgs: T | null = null;
   let storedThis: unknown = null;
   let lastInvokeTime = 0; // timestamp of last actual invocation
 
-  const invoke = (args: Parameters<T>, thisArg: unknown) => {
+  const invoke = (args: T, thisArg: unknown) => {
     lastInvokeTime = Date.now();
     fn.apply(thisArg, args);
   };
@@ -51,7 +56,7 @@ export const throttle = <T extends ThrottledCallback>(
     }, delay);
   };
 
-  return function (this: any, ...args: Parameters<T>) {
+  return function (this: unknown, ...args: T) {
     const now = Date.now();
 
     // if we have never invoked and `leading` is `false`, treat `lastInvokeTime` as now

--- a/packages/feeds-client/src/utils/throttling/throttle.ts
+++ b/packages/feeds-client/src/utils/throttling/throttle.ts
@@ -1,7 +1,5 @@
 export type ThrottledCallback = (...args: unknown[]) => unknown;
 
-// export type ThrottledFunction<T extends unknown[]> = (this: unknown, ...args: T) => void;
-
 export type ThrottledFunction<T extends unknown[]> =
   ((...args: T) => void);
 
@@ -37,7 +35,7 @@ export const throttle = <T extends unknown[]>(
   let timer: NodeJS.Timeout | null = null;
   let storedArgs: T | null = null;
   let storedThis: unknown = null;
-  let lastInvokeTime = 0; // timestamp of last actual invocation
+  let lastInvokeTime: number | undefined; // timestamp of last actual invocation
 
   const invoke = (args: T, thisArg: unknown) => {
     lastInvokeTime = Date.now();
@@ -59,10 +57,12 @@ export const throttle = <T extends unknown[]>(
   return function (this: unknown, ...args: T) {
     const now = Date.now();
 
-    // if we have never invoked and `leading` is `false`, treat `lastInvokeTime` as now
-    if (lastInvokeTime === 0 && !leading) lastInvokeTime = now;
+    const hasBeenInvoked = lastInvokeTime != null;
 
-    const timeSinceLast = now - lastInvokeTime;
+    // if we have never invoked and `leading` is `false`, treat `lastInvokeTime` as now
+    if (!hasBeenInvoked && !leading) lastInvokeTime = now;
+
+    const timeSinceLast = hasBeenInvoked ? (now - lastInvokeTime!) : timeout;
     const remaining = timeout - timeSinceLast;
 
     // capture latest args for possible trailing invocation

--- a/packages/feeds-client/src/utils/throttling/throttle.ts
+++ b/packages/feeds-client/src/utils/throttling/throttle.ts
@@ -1,34 +1,113 @@
 export type ThrottledCallback = (...args: unknown[]) => unknown;
 
-// works exactly the same as lodash.throttle
+/**
+ * Throttle a function so it runs at most once per `timeout` ms.
+ *
+ * - single–timer approach: we keep one pending timer for the trailing edge
+ * - `leading`: fire immediately when the window opens
+ * - `trailing`: remember the latest args/this and fire once when the window closes
+ * - avoids boundary double-invoke: if we just led with the same args, we clear the stored ones
+ * - preserves `this` on trailing (uses `fn.apply(this, args)`)
+ *
+ * defaults: `{ leading: true, trailing: false }`
+ * (lodash’s default is `{ leading: true, trailing: true }` — enable `trailing` if you want that)
+ *
+ * notes:
+ * - uses `Date.now()`; if you need a monotonic clock, swap in `performance.now()`
+ * - make one throttled instance and reuse it; re-creating it resets internal state
+ *
+ * @typeParam T - the function type being throttled
+ * @param fn - function to throttle
+ * @param timeout - minimum time between invocations (ms)
+ * @param options - behavior switches
+ * @param options.leading - call on the leading edge (default: true)
+ * @param options.trailing - call once at the end of the window with the latest args (default: false)
+ * @returns a throttled function with the same call signature as `fn`
+ *
+ * @example
+ * const send = (payload: Data) => api.post('/endpoint', payload);
+ * const sendThrottled = throttle(send, 2000, { leading: true, trailing: true });
+ * // call `sendThrottled` freely; it won’t invoke `send` more than once every 2s
+ */
 export const throttle = <T extends ThrottledCallback>(
   fn: T,
   timeout = 200,
   { leading = true, trailing = false }: { leading?: boolean; trailing?: boolean } = {},
 ) => {
-  let runningTimeout: null | NodeJS.Timeout = null;
+  let timer: NodeJS.Timeout | null = null;
   let storedArgs: Parameters<T> | null = null;
+  let storedThis: unknown = null;
+  let lastInvokeTime = 0; // timestamp of last actual invocation
 
-  return (...args: Parameters<T>) => {
-    if (runningTimeout) {
-      if (trailing) storedArgs = args;
+  const invoke = (args: Parameters<T>, thisArg: unknown) => {
+    lastInvokeTime = Date.now();
+    fn.apply(thisArg, args);
+  };
+
+  const scheduleTrailing = (delay: number) => {
+    if (timer) return;
+    timer = setTimeout(() => {
+      timer = null;
+      if (trailing && storedArgs) {
+        invoke(storedArgs, storedThis);
+        storedArgs = null;
+        storedThis = null;
+      }
+    }, delay);
+  };
+
+  return function (this: any, ...args: Parameters<T>) {
+    const now = Date.now();
+
+    // if we have never invoked and `leading` is `false`, treat `lastInvokeTime` as now
+    if (lastInvokeTime === 0 && !leading) lastInvokeTime = now;
+
+    const timeSinceLast = now - lastInvokeTime;
+    const remaining = timeout - timeSinceLast;
+
+    // capture latest args for possible trailing invocation
+    if (trailing) {
+      storedArgs = args;
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      storedThis = this;
+    }
+
+    // if enough time has passed, invoke immediately
+    if (remaining <= 0) {
+      // if there's a pending timer, clear it because we're invoking now
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+
+      // leading: call now
+      if (leading) {
+        // if trailing is also `true`, we've already stored args above;
+        // make sure we don't call the same args twice
+        if (trailing) {
+          // if the `storedArgs` are exactly the args we're about to call,
+          // clear storedArgs to avoid double invocation by trailing (comparing
+          // by reference is fine because the `args` array is new each call)
+          if (storedArgs === args) {
+            storedArgs = null;
+            storedThis = null;
+          }
+        }
+        invoke(args, this);
+      } else {
+        // not leading but trailing: schedule a trailing call after `timeout`
+        if (trailing) scheduleTrailing(timeout);
+      }
+
       return;
     }
 
-    if (leading) fn(...args);
-
-    const timeoutHandler = () => {
-      if (storedArgs) {
-        fn(...storedArgs);
-        storedArgs = null;
-        runningTimeout = setTimeout(timeoutHandler, timeout);
-
-        return;
-      }
-
-      runningTimeout = null;
-    };
-
-    runningTimeout = setTimeout(timeoutHandler, timeout);
+    // not enough time passed: we're in cooldown, so if
+    // trailing is requested, ensure a trailing invocation
+    // is scheduled at the end of the remaining time
+    if (trailing && !timer) {
+      scheduleTrailing(remaining);
+    }
+    // if `trailing` is `false`, we simply drop the call (throttle)
   };
 };

--- a/packages/feeds-client/src/utils/throttling/throttled-get-batched-own-capabilities.ts
+++ b/packages/feeds-client/src/utils/throttling/throttled-get-batched-own-capabilities.ts
@@ -1,11 +1,20 @@
 import type { FeedsClient } from '@self';
+import type { ThrottledFunction } from './throttle';
 
 // TODO: This should be replaced with the actual type once backend implements it
 export type GetBatchedOwnCapabilities = {
   feeds: string[];
 };
 
-export const QUEUE_BATCH_OWN_CAPABILITIES_THROTTLING_INTERVAL = 2000;
+export type GetBatchedOwnCapabilitiesThrottledCallback = [
+  feeds: string[],
+  callback: (feedsToClear: string[]) => void | Promise<void>,
+];
+
+export type ThrottledGetBatchedOwnCapabilities =
+  ThrottledFunction<GetBatchedOwnCapabilitiesThrottledCallback>;
+
+export const DEFAULT_BATCH_OWN_CAPABILITIES_THROTTLING_INTERVAL = 2000;
 
 const queuedFeeds: Set<string> = new Set();
 
@@ -18,10 +27,13 @@ export function queueBatchedOwnCapabilities(
   }
 
   if (queuedFeeds.size > 0) {
-    this.throttledGetBatchedOwnCapabilities([...queuedFeeds], (feedsToClear: string[]) => {
-      for (const feed of feedsToClear) {
-        queuedFeeds.delete(feed);
-      }
-    });
+    this.throttledGetBatchOwnCapabilities(
+      [...queuedFeeds],
+      (feedsToClear: string[]) => {
+        for (const feed of feedsToClear) {
+          queuedFeeds.delete(feed);
+        }
+      },
+    );
   }
 }

--- a/packages/feeds-client/src/utils/throttling/throttled-get-batched-own-capabilities.ts
+++ b/packages/feeds-client/src/utils/throttling/throttled-get-batched-own-capabilities.ts
@@ -1,0 +1,25 @@
+import type { FeedsClient } from '@self';
+
+// TODO: This should be replaced with the actual type once backend implements it
+export type GetBatchedOwnCapabilities = {
+  feeds: string[];
+};
+
+const queuedFeeds: Set<string> = new Set();
+
+export function queueBatchedOwnCapabilities(
+  this: FeedsClient,
+  { feeds }: GetBatchedOwnCapabilities,
+) {
+  for (const feed of feeds) {
+    queuedFeeds.add(feed);
+  }
+
+  if (queuedFeeds.size > 0) {
+    this.throttledGetBatchedOwnCapabilities([...queuedFeeds], (feedsToClear: string[]) => {
+      for (const feed of feedsToClear) {
+        queuedFeeds.delete(feed);
+      }
+    });
+  }
+}

--- a/packages/feeds-client/src/utils/throttling/throttled-get-batched-own-capabilities.ts
+++ b/packages/feeds-client/src/utils/throttling/throttled-get-batched-own-capabilities.ts
@@ -5,6 +5,8 @@ export type GetBatchedOwnCapabilities = {
   feeds: string[];
 };
 
+export const QUEUE_BATCH_OWN_CAPABILITIES_THROTTLING_INTERVAL = 2000;
+
 const queuedFeeds: Set<string> = new Set();
 
 export function queueBatchedOwnCapabilities(

--- a/sample-apps/react-native/ExpoTikTokApp/components/activity-composer/ActivityComposer.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/activity-composer/ActivityComposer.tsx
@@ -155,21 +155,25 @@ export const ActivityComposer = () => {
           : {}),
         ...(mentionedUsers ? { mentioned_user_ids: mentionedUsers } : {}),
       };
-      if (editingActivity) {
-        await client?.updateActivity({
-          ...activityData,
-          id: editingActivity.id,
-        });
-      } else if (hasHashtags) {
-        await client?.addActivity({
-          ...activityData,
-          feeds: [
-            feed.feed,
-            ...createdHashtagFeeds.map((hashtagFeed) => hashtagFeed.feed),
-          ],
-        });
-      } else {
-        await feed.addActivity(activityData);
+
+      for (let i = 1; i < 4; i++) {
+        activityData.text = `${i}. ${activityData.text}`;
+        if (editingActivity) {
+          await client?.updateActivity({
+            ...activityData,
+            id: editingActivity.id,
+          });
+        } else if (hasHashtags) {
+          await client?.addActivity({
+            ...activityData,
+            feeds: [
+              feed.feed,
+              ...createdHashtagFeeds.map((hashtagFeed) => hashtagFeed.feed),
+            ],
+          });
+        } else {
+          await feed.addActivity(activityData);
+        }
       }
 
       setMedia([]);

--- a/sample-apps/react-native/ExpoTikTokApp/components/activity-composer/ActivityComposer.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/activity-composer/ActivityComposer.tsx
@@ -156,24 +156,21 @@ export const ActivityComposer = () => {
         ...(mentionedUsers ? { mentioned_user_ids: mentionedUsers } : {}),
       };
 
-      for (let i = 1; i < 4; i++) {
-        activityData.text = `${i}. ${activityData.text}`;
-        if (editingActivity) {
-          await client?.updateActivity({
-            ...activityData,
-            id: editingActivity.id,
-          });
-        } else if (hasHashtags) {
-          await client?.addActivity({
-            ...activityData,
-            feeds: [
-              feed.feed,
-              ...createdHashtagFeeds.map((hashtagFeed) => hashtagFeed.feed),
-            ],
-          });
-        } else {
-          await feed.addActivity(activityData);
-        }
+      if (editingActivity) {
+        await client?.updateActivity({
+          ...activityData,
+          id: editingActivity.id,
+        });
+      } else if (hasHashtags) {
+        await client?.addActivity({
+          ...activityData,
+          feeds: [
+            feed.feed,
+            ...createdHashtagFeeds.map((hashtagFeed) => hashtagFeed.feed),
+          ],
+        });
+      } else {
+        await feed.addActivity(activityData);
       }
 
       setMedia([]);

--- a/sample-apps/react-native/ExpoTikTokApp/components/common/Reaction.tsx
+++ b/sample-apps/react-native/ExpoTikTokApp/components/common/Reaction.tsx
@@ -42,9 +42,9 @@ export const Reaction = ({
   type: IconType;
   entity: ActivityResponse | CommentResponse;
 } & Partial<IconProps>) => {
-  const ownCapabilities = useOwnCapabilities();
-
   const isComment = isCommentResponse(entity);
+  const ownCapabilities = useOwnCapabilities(isComment ? undefined : entity.current_feed);
+
   const hasOwnReaction = useMemo(
     () => !!entity.own_reactions?.find((r) => r.type === type),
     [entity.own_reactions, type],


### PR DESCRIPTION
🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>

### 💡 Overview

Draft PR for now until I finish writing integration tests for this. 

Noteworthy things (very rough overview, will write in more detail):

- Reimplements throttling as the `Chat` implementation was broken (would often end up in timeout loops and skip on queries altogether)
- Lifts the capabilities state upwards (on the `client`) as we have no other way to consume it properly
- Updates hooks
- On `activities` not containing `own_capabilities`, it fetches them in a throttled manner

TO-DOs:

- [ ] Swap out `queryFeeds` with the new `own_capabilities` endpoint whenever it's added on the backend
- [ ] Integration tests
- [ ] Change `useOwnCapabilities` so that it simply returns the `state` directly (forwards compatibility)
- [ ] Update docs

### 📝 Implementation notes
