### PR TITLE
fix: Change response to FeedOwnCapability instead of string

### DIFF
--- a/packages/feeds-client/src/gen/models/index.ts
+++ b/packages/feeds-client/src/gen/models/index.ts
@@ -4184,7 +4184,7 @@ export interface OwnCapabilitiesBatchRequest {
 export interface OwnCapabilitiesBatchResponse {
   duration: string;
 
-  capabilities: Record<string, string[]>;
+  capabilities: Record<string, FeedOwnCapability[]>;
 }
 
 export interface OwnUser {


### PR DESCRIPTION
🎫 Ticket: https://linear.app/stream/issue/XYZ-123

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>

### 💡 Overview

### 📝 Implementation notes
