### PR TITLE
fix: issue with commonjs exports

### DIFF
--- a/packages/feeds-client/package.json
+++ b/packages/feeds-client/package.json
@@ -2,7 +2,8 @@
   "name": "@stream-io/feeds-client",
   "version": "0.2.18",
   "packageManager": "yarn@3.2.4",
-  "main": "./dist/es/index.mjs",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/es/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -39,7 +40,10 @@
   "files": [
     "dist",
     "src",
-    "index.ts",
+    "!src/**/*.test.ts",
+    "react-bindings.js",
+    "react-bindings.mjs",
+    "react-bindings.d.ts",
     "package.json",
     "README.md",
     "LICENSE",

--- a/packages/feeds-client/react-bindings.d.ts
+++ b/packages/feeds-client/react-bindings.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Manual re-exports for React Native bundlers (e.g. Metro < 0.79) that do not
+ * fully support the `exports` field in package.json. These files forward to the
+ * built artifacts under `dist/`.
+ */
+export * from './dist/types/bindings/react';
+/**
+ * If we ever decide to add a `default` export to our `react-bindings` package,
+ * please make sure to uncomment the line below.
+ */
+// export { default } from './dist/types/bindings/react';

--- a/packages/feeds-client/react-bindings.js
+++ b/packages/feeds-client/react-bindings.js
@@ -1,0 +1,7 @@
+'use strict';
+/**
+ * Manual re-exports for React Native bundlers (e.g. Metro < 0.79) that do not
+ * fully support the `exports` field in package.json. These files forward to the
+ * built artifacts under `dist/`.
+ */
+module.exports = require('./dist/cjs/react-bindings.js');

--- a/packages/feeds-client/react-bindings.mjs
+++ b/packages/feeds-client/react-bindings.mjs
@@ -1,0 +1,11 @@
+/**
+ * Manual re-exports for React Native bundlers (e.g. Metro < 0.79) that do not
+ * fully support the `exports` field in package.json. These files forward to the
+ * built artifacts under `dist/`.
+ */
+export * from './dist/es/react-bindings.mjs';
+/**
+ * If we ever decide to add a `default` export to our `react-bindings` package,
+ * please make sure to uncomment the line below.
+ */
+// export { default } from './dist/es/react-bindings.mjs';


### PR DESCRIPTION
🎫 Ticket: https://linear.app/stream/issue/RN-288/react-native-sdk-is-erroring-out

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>

### 💡 Overview

This PR fixes an issue we have in `feeds-client` specifically for React Native projects that do not yet support `exports`.

An easy way to test this is to do something like `config.resolver.unstable_enablePackageExports = false;` in your `metro.config.js` file and it will fail. Even though `unstable_enablePackageExports` is available in the versions we currently support for React Native on the SDK, it is not guaranteed that libraries compatible with those versions specifically will also support `exports` and be declared `exports` compatible. This is especially available on `Expo` apps, where the default version of their `Metro` config has this turned off (until RN `0.79.0` and onwards).

Until `exports` are widely accepted and consumed, we'll rely on these proxy files that directly create the subpaths needed for `import`s/`require`s.

If `exports` are supported, the defined `./react-bindings` entrypoint will always be respected.

### 📝 Implementation notes
