### PR TITLE
fix: add missing current_feed when updating from WS event

### DIFF
--- a/packages/feeds-client/src/feed/event-handlers/activity-updater.ts
+++ b/packages/feeds-client/src/feed/event-handlers/activity-updater.ts
@@ -7,6 +7,14 @@ export const updateActivity = ({
   currentActivity: ActivityResponse;
   newActivtiy: ActivityResponse;
 }) => {
+  if (
+    !newActivtiy.current_feed &&
+    newActivtiy.feeds.length === 1 &&
+    currentActivity.current_feed
+  ) {
+    newActivtiy.current_feed = currentActivity.current_feed;
+  }
+
   return {
     ...newActivtiy,
     own_reactions: currentActivity.own_reactions,

--- a/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-added.ts
+++ b/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-added.ts
@@ -22,6 +22,14 @@ const sharedUpdateActivity = ({
     newOwnBookmarks = [...newOwnBookmarks, event.bookmark];
   }
 
+  if (
+    !event.bookmark.activity.current_feed &&
+    event.bookmark.activity.feeds.length === 1 &&
+    currentActivity.current_feed
+  ) {
+    event.bookmark.activity.current_feed = currentActivity.current_feed;
+  }
+
   return {
     ...event.bookmark.activity,
     own_bookmarks: newOwnBookmarks,

--- a/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-deleted.ts
+++ b/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-deleted.ts
@@ -38,6 +38,14 @@ const sharedUpdateActivity = ({
     );
   }
 
+  if (
+    !event.bookmark.activity.current_feed &&
+    event.bookmark.activity.feeds.length === 1 &&
+    currentActivity.current_feed
+  ) {
+    event.bookmark.activity.current_feed = currentActivity.current_feed;
+  }
+
   return {
     ...event.bookmark.activity,
     own_bookmarks: newOwnBookmarks,


### PR DESCRIPTION
🎫 Ticket:https://linear.app/stream/issue/REACT-651/add-missing-current-feed-to-ws-event

📑 Docs: https://github.com/GetStream/docs-content/pull/<id>

### 💡 Overview

### 📝 Implementation notes
