### PR TITLE
feat!: regenerate OpenAPI SDK with breaking model export changes

### DIFF
--- a/packages/feeds-client/src/gen/feeds/FeedApi.ts
+++ b/packages/feeds-client/src/gen/feeds/FeedApi.ts
@@ -1,152 +1,118 @@
-import type { StreamResponse, FeedsApi } from '../../gen-imports';
-import type {
-  AcceptFeedMemberInviteRequest,
-  AcceptFeedMemberInviteResponse,
-  DeleteFeedResponse,
-  GetOrCreateFeedRequest,
-  GetOrCreateFeedResponse,
-  MarkActivityRequest,
-  PinActivityRequest,
-  PinActivityResponse,
-  QueryFeedMembersRequest,
-  QueryFeedMembersResponse,
-  QueryPinnedActivitiesRequest,
-  QueryPinnedActivitiesResponse,
-  RejectFeedMemberInviteRequest,
-  RejectFeedMemberInviteResponse,
-  Response,
-  UnpinActivityResponse,
-  UpdateFeedMembersRequest,
-  UpdateFeedMembersResponse,
-  UpdateFeedRequest,
-  UpdateFeedResponse,
-} from '../models';
+import { StreamResponse, FeedsApi } from '../../gen-imports';
+import {  AIImageConfig,  AIImageLabelDefinition,  AITextConfig,  AIVideoConfig,  APIError,  AWSRekognitionRule,  AcceptFeedMemberInviteRequest,  AcceptFeedMemberInviteResponse,  AcceptFollowRequest,  AcceptFollowResponse,  Action,  ActionLogResponse,  ActionSequence,  ActivityAddedEvent,  ActivityDeletedEvent,  ActivityFeedbackEvent,  ActivityFeedbackEventPayload,  ActivityFeedbackRequest,  ActivityFeedbackResponse,  ActivityFilterConfig,  ActivityMarkEvent,  ActivityPinResponse,  ActivityPinnedEvent,  ActivityProcessorConfig,  ActivityReactionAddedEvent,  ActivityReactionDeletedEvent,  ActivityReactionUpdatedEvent,  ActivityRemovedFromFeedEvent,  ActivityRequest,  ActivityResponse,  ActivityRestoredEvent,  ActivitySelectorConfig,  ActivityUnpinnedEvent,  ActivityUpdatedEvent,  AddActivityRequest,  AddActivityResponse,  AddBookmarkRequest,  AddBookmarkResponse,  AddCommentBookmarkRequest,  AddCommentBookmarkResponse,  AddCommentReactionRequest,  AddCommentReactionResponse,  AddCommentRequest,  AddCommentResponse,  AddCommentsBatchRequest,  AddCommentsBatchResponse,  AddFolderRequest,  AddReactionRequest,  AddReactionResponse,  AddUserGroupMembersRequest,  AddUserGroupMembersResponse,  AggregatedActivityResponse,  AggregationConfig,  AppEventResponse,  AppResponseFields,  AppUpdatedEvent,  AppealItemResponse,  AppealRequest,  AppealResponse,  Attachment,  AutomodPlatformCircumventionConfig,  AutomodRule,  AutomodSemanticFiltersConfig,  AutomodSemanticFiltersRule,  AutomodToxicityConfig,  BanActionRequestPayload,  BanInfoResponse,  BanOptions,  BanRequest,  BanResponse,  BlockActionRequestPayload,  BlockListConfig,  BlockListOptions,  BlockListResponse,  BlockListRule,  BlockUsersRequest,  BlockUsersResponse,  BlockedUserResponse,  BodyguardProfileSummary,  BodyguardRule,  BodyguardSeverityRule,  BookmarkAddedEvent,  BookmarkDeletedEvent,  BookmarkFolderDeletedEvent,  BookmarkFolderResponse,  BookmarkFolderUpdatedEvent,  BookmarkResponse,  BookmarkUpdatedEvent,  BulkDeleteActionConfigRequest,  BulkDeleteActionConfigResponse,  BulkUpsertActionConfigRequest,  BulkUpsertActionConfigResponse,  BypassActionRequest,  CallActionOptions,  CallCustomPropertyParameters,  CallResponse,  CallRuleActionSequence,  CallTypeRuleParameters,  CallViolationCountParameters,  CastPollVoteRequest,  ChangeFeedVisibilityRequest,  ChangeFeedVisibilityResponse,  ChannelConfigWithInfo,  ChannelMemberResponse,  ChannelMessageCountRuleParameters,  ChannelMute,  ChannelOwnCapability,  ChannelPushPreferencesResponse,  ChannelResponse,  ChatDraftPayloadResponse,  ChatDraftResponse,  ChatMessageResponse,  ChatModerationV2Response,  ChatPreferences,  ChatPreferencesInput,  ChatPreferencesResponse,  ChatReactionGroupResponse,  ChatReactionGroupUserResponse,  ChatReactionResponse,  ChatReminderResponseData,  ChatSharedLocationResponseData,  ClosedCaptionRuleParameters,  CollectionRequest,  CollectionResponse,  Command,  CommentAddedEvent,  CommentDeletedEvent,  CommentReactionAddedEvent,  CommentReactionDeletedEvent,  CommentReactionUpdatedEvent,  CommentResponse,  CommentRestoredEvent,  CommentUpdatedEvent,  ConfigResponse,  ConnectUserDetailsRequest,  ContentCountRuleParameters,  CreateBlockListRequest,  CreateBlockListResponse,  CreateCollectionsRequest,  CreateCollectionsResponse,  CreateDeviceRequest,  CreateFeedsBatchRequest,  CreateFeedsBatchResponse,  CreateGuestRequest,  CreateGuestResponse,  CreatePollOptionRequest,  CreatePollRequest,  CreateUserGroupRequest,  CreateUserGroupResponse,  CustomActionRequestPayload,  Data,  DecayFunctionConfig,  DeleteActionConfigResponse,  DeleteActivitiesRequest,  DeleteActivitiesResponse,  DeleteActivityReactionResponse,  DeleteActivityRequestPayload,  DeleteActivityResponse,  DeleteBookmarkFolderResponse,  DeleteBookmarkResponse,  DeleteCollectionsResponse,  DeleteCommentBookmarkResponse,  DeleteCommentReactionResponse,  DeleteCommentRequestPayload,  DeleteCommentResponse,  DeleteFeedResponse,  DeleteMessageRequestPayload,  DeleteModerationConfigResponse,  DeleteReactionRequestPayload,  DeleteUserRequestPayload,  DeliveryReceiptsResponse,  DeviceResponse,  DraftPayloadResponse,  DraftResponse,  EnrichedActivity,  EnrichedCollectionResponse,  EnrichedReaction,  EnrichmentOptions,  EntityCreatorResponse,  EscalatePayload,  EscalationMetadata,  FeedCreatedEvent,  FeedDeletedEvent,  FeedGroup,  FeedGroupChangedEvent,  FeedGroupDeletedEvent,  FeedGroupRestoredEvent,  FeedInput,  FeedMemberAddedEvent,  FeedMemberRemovedEvent,  FeedMemberRequest,  FeedMemberResponse,  FeedMemberUpdatedEvent,  FeedOwnCapability,  FeedOwnData,  FeedRequest,  FeedResponse,  FeedSuggestionResponse,  FeedUpdatedEvent,  FeedsActivityLocation,  FeedsBookmarkResponse,  FeedsEnrichedCollectionResponse,  FeedsFeedResponse,  FeedsNotificationComment,  FeedsNotificationContext,  FeedsNotificationParentActivity,  FeedsNotificationTarget,  FeedsNotificationTrigger,  FeedsPreferences,  FeedsPreferencesResponse,  FeedsReactionGroupResponse,  FeedsReactionResponse,  FeedsV3ActivityResponse,  FeedsV3CommentResponse,  Field,  FileUploadConfig,  FileUploadRequest,  FileUploadResponse,  FilterConfigResponse,  FlagCountRuleParameters,  FlagRequest,  FlagResponse,  FlagUserOptions,  FollowBatchRequest,  FollowBatchResponse,  FollowCreatedEvent,  FollowDeletedEvent,  FollowRequest,  FollowResponse,  FollowUpdatedEvent,  FriendReactionsOptions,  FullUserResponse,  GetActionConfigResponse,  GetActivityResponse,  GetAppealResponse,  GetApplicationResponse,  GetBlockedUsersResponse,  GetCommentRepliesResponse,  GetCommentResponse,  GetCommentsResponse,  GetConfigResponse,  GetFollowSuggestionsResponse,  GetOGResponse,  GetOrCreateFeedRequest,  GetOrCreateFeedResponse,  GetUserGroupResponse,  GoogleVisionConfig,  HarmConfig,  HealthCheckEvent,  ImageContentParameters,  ImageData,  ImageRuleParameters,  ImageSize,  ImageUploadRequest,  ImageUploadResponse,  Images,  KeyframeRuleParameters,  LLMConfig,  LLMRule,  LabelThresholds,  ListBlockListResponse,  ListDevicesResponse,  ListUserGroupsResponse,  Location,  MarkActivityRequest,  MarkReviewedRequestPayload,  MembershipLevelResponse,  MessageResponse,  ModerationActionConfigResponse,  ModerationCustomActionEvent,  ModerationFlagResponse,  ModerationFlaggedEvent,  ModerationMarkReviewedEvent,  ModerationPayload,  ModerationPayloadResponse,  ModerationV2Response,  MuteRequest,  MuteResponse,  NotificationComment,  NotificationConfig,  NotificationContext,  NotificationFeedUpdatedEvent,  NotificationParentActivity,  NotificationStatusResponse,  NotificationTarget,  NotificationTrigger,  OCRRule,  OnlyUserID,  OwnBatchRequest,  OwnBatchResponse,  OwnUserResponse,  PagerRequest,  PagerResponse,  PinActivityRequest,  PinActivityResponse,  PollClosedFeedEvent,  PollDeletedFeedEvent,  PollOptionInput,  PollOptionRequest,  PollOptionResponse,  PollOptionResponseData,  PollResponse,  PollResponseData,  PollUpdatedFeedEvent,  PollVoteCastedFeedEvent,  PollVoteChangedFeedEvent,  PollVoteRemovedFeedEvent,  PollVoteResponse,  PollVoteResponseData,  PollVotesResponse,  PrivacySettingsResponse,  PushNotificationConfig,  PushPreferenceInput,  PushPreferencesResponse,  QueryActivitiesRequest,  QueryActivitiesResponse,  QueryActivityReactionsRequest,  QueryActivityReactionsResponse,  QueryAppealsRequest,  QueryAppealsResponse,  QueryBookmarkFoldersRequest,  QueryBookmarkFoldersResponse,  QueryBookmarksRequest,  QueryBookmarksResponse,  QueryCollectionsRequest,  QueryCollectionsResponse,  QueryCommentReactionsRequest,  QueryCommentReactionsResponse,  QueryCommentsRequest,  QueryCommentsResponse,  QueryFeedMembersRequest,  QueryFeedMembersResponse,  QueryFeedsRequest,  QueryFeedsResponse,  QueryFollowsRequest,  QueryFollowsResponse,  QueryModerationConfigsRequest,  QueryModerationConfigsResponse,  QueryPinnedActivitiesRequest,  QueryPinnedActivitiesResponse,  QueryPollVotesRequest,  QueryPollsRequest,  QueryPollsResponse,  QueryReviewQueueRequest,  QueryReviewQueueResponse,  QueryUsersPayload,  QueryUsersResponse,  RankingConfig,  Reaction,  ReactionGroupResponse,  ReactionGroupUserResponse,  ReactionResponse,  ReadCollectionsResponse,  ReadReceiptsResponse,  RejectAppealRequestPayload,  RejectFeedMemberInviteRequest,  RejectFeedMemberInviteResponse,  RejectFollowRequest,  RejectFollowResponse,  ReminderResponseData,  RemoveUserGroupMembersRequest,  RemoveUserGroupMembersResponse,  RepliesMeta,  Response,  RestoreActionRequestPayload,  RestoreActivityRequest,  RestoreActivityResponse,  RestoreCommentRequest,  RestoreCommentResponse,  ReviewQueueItemResponse,  RuleBuilderAction,  RuleBuilderCondition,  RuleBuilderConditionGroup,  RuleBuilderConfig,  RuleBuilderRule,  SearchUserGroupsResponse,  ShadowBlockActionRequestPayload,  SharedLocationResponse,  SharedLocationResponseData,  SharedLocationsResponse,  SingleFollowResponse,  SortParam,  SortParamRequest,  StoriesConfig,  StoriesFeedUpdatedEvent,  SubmitActionRequest,  SubmitActionResponse,  TextContentParameters,  TextRuleParameters,  ThreadedCommentResponse,  Thresholds,  Time,  TrackActivityMetricsEvent,  TrackActivityMetricsEventResult,  TrackActivityMetricsRequest,  TrackActivityMetricsResponse,  TypingIndicatorsResponse,  UnbanActionRequestPayload,  UnblockActionRequestPayload,  UnblockUsersRequest,  UnblockUsersResponse,  UnfollowBatchRequest,  UnfollowBatchResponse,  UnfollowPair,  UnfollowResponse,  UnpinActivityResponse,  UpdateActivityPartialRequest,  UpdateActivityPartialResponse,  UpdateActivityRequest,  UpdateActivityResponse,  UpdateBlockListRequest,  UpdateBlockListResponse,  UpdateBookmarkFolderRequest,  UpdateBookmarkFolderResponse,  UpdateBookmarkRequest,  UpdateBookmarkResponse,  UpdateCollectionRequest,  UpdateCollectionsRequest,  UpdateCollectionsResponse,  UpdateCommentBookmarkRequest,  UpdateCommentBookmarkResponse,  UpdateCommentPartialRequest,  UpdateCommentPartialResponse,  UpdateCommentRequest,  UpdateCommentResponse,  UpdateFeedMembersRequest,  UpdateFeedMembersResponse,  UpdateFeedRequest,  UpdateFeedResponse,  UpdateFollowRequest,  UpdateFollowResponse,  UpdateLiveLocationRequest,  UpdatePollOptionRequest,  UpdatePollPartialRequest,  UpdatePollRequest,  UpdateUserGroupRequest,  UpdateUserGroupResponse,  UpdateUserPartialRequest,  UpdateUsersPartialRequest,  UpdateUsersRequest,  UpdateUsersResponse,  UpsertActionConfigItem,  UpsertActionConfigRequest,  UpsertActionConfigResponse,  UpsertActivitiesRequest,  UpsertActivitiesResponse,  UpsertConfigRequest,  UpsertConfigResponse,  UpsertPushPreferencesRequest,  UpsertPushPreferencesResponse,  User,  UserBannedEvent,  UserCreatedWithinParameters,  UserCustomPropertyParameters,  UserDeactivatedEvent,  UserGroupMember,  UserGroupResponse,  UserIdenticalContentCountParameters,  UserMuteResponse,  UserReactivatedEvent,  UserRequest,  UserResponse,  UserResponseCommonFields,  UserResponsePrivacyFields,  UserRoleParameters,  UserRuleParameters,  UserUnbannedEvent,  UserUpdatedEvent,  VelocityFilterConfig,  VelocityFilterConfigRule,  VideoCallRuleConfig,  VideoContentParameters,  VideoEndCallRequestPayload,  VideoKickUserRequestPayload,  VideoRuleParameters,  VoteData,  WSAuthMessage,  WSClientEvent,  WSEvent,  } from '../models';
 
 export class FeedApi {
-  constructor(
-    protected feedsApi: FeedsApi,
-    public readonly group: string,
-    public readonly id: string,
+    constructor(
+        protected feedsApi: FeedsApi,
+        public readonly  group : string,
+        public  readonly id: string, 
   ) {}
 
-  delete(request?: {
-    hard_delete?: boolean;
-  }): Promise<StreamResponse<DeleteFeedResponse>> {
-    return this.feedsApi.deleteFeed({
-      feed_id: this.id,
-      feed_group_id: this.group,
-      ...request,
-    });
-  }
 
-  getOrCreate(
-    request?: GetOrCreateFeedRequest & { connection_id?: string },
-  ): Promise<StreamResponse<GetOrCreateFeedResponse>> {
-    return this.feedsApi.getOrCreateFeed({
-      feed_id: this.id,
-      feed_group_id: this.group,
-      ...request,
-    });
-  }
 
-  update(
-    request?: UpdateFeedRequest,
-  ): Promise<StreamResponse<UpdateFeedResponse>> {
-    return this.feedsApi.updateFeed({
-      feed_id: this.id,
-      feed_group_id: this.group,
-      ...request,
-    });
-  }
+    delete(request?: 
+    
+    
+    {hard_delete?: boolean,
+    }
+    ): Promise<StreamResponse<DeleteFeedResponse>> {
+        
+        return this.feedsApi.deleteFeed( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
 
-  markActivity(
-    request?: MarkActivityRequest,
-  ): Promise<StreamResponse<Response>> {
-    return this.feedsApi.markActivity({
-      feed_id: this.id,
-      feed_group_id: this.group,
-      ...request,
-    });
-  }
+    getOrCreate(request?: GetOrCreateFeedRequest 
+     & 
+    
+    {connection_id?: string,
+    }
+    ): Promise<StreamResponse<GetOrCreateFeedResponse>> {
+        
+        return this.feedsApi.getOrCreateFeed( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
 
-  unpinActivity(request: {
-    activity_id: string;
-    enrich_own_fields?: boolean;
-  }): Promise<StreamResponse<UnpinActivityResponse>> {
-    return this.feedsApi.unpinActivity({
-      feed_id: this.id,
-      feed_group_id: this.group,
-      ...request,
-    });
-  }
+    update(request?: UpdateFeedRequest 
+    
+    ): Promise<StreamResponse<UpdateFeedResponse>> {
+        
+        return this.feedsApi.updateFeed( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
 
-  pinActivity(
-    request: PinActivityRequest & { activity_id: string },
-  ): Promise<StreamResponse<PinActivityResponse>> {
-    return this.feedsApi.pinActivity({
-      feed_id: this.id,
-      feed_group_id: this.group,
-      ...request,
-    });
-  }
+    markActivity(request?: MarkActivityRequest 
+    
+    ): Promise<StreamResponse<Response>> {
+        
+        return this.feedsApi.markActivity( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
 
-  updateFeedMembers(
-    request: UpdateFeedMembersRequest,
-  ): Promise<StreamResponse<UpdateFeedMembersResponse>> {
-    return this.feedsApi.updateFeedMembers({
-      feed_id: this.id,
-      feed_group_id: this.group,
-      ...request,
-    });
-  }
+    unpinActivity(request: 
+    
+    
+    {activity_id: string,enrich_own_fields?: boolean,
+    }
+    ): Promise<StreamResponse<UnpinActivityResponse>> {
+        
+        return this.feedsApi.unpinActivity( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
 
-  acceptFeedMemberInvite(
-    request?: AcceptFeedMemberInviteRequest,
-  ): Promise<StreamResponse<AcceptFeedMemberInviteResponse>> {
-    return this.feedsApi.acceptFeedMemberInvite({
-      feed_id: this.id,
-      feed_group_id: this.group,
-      ...request,
-    });
-  }
+    pinActivity(request: PinActivityRequest 
+     & 
+    
+    {activity_id: string,
+    }
+    ): Promise<StreamResponse<PinActivityResponse>> {
+        
+        return this.feedsApi.pinActivity( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
 
-  queryFeedMembers(
-    request?: QueryFeedMembersRequest,
-  ): Promise<StreamResponse<QueryFeedMembersResponse>> {
-    return this.feedsApi.queryFeedMembers({
-      feed_id: this.id,
-      feed_group_id: this.group,
-      ...request,
-    });
-  }
+    changeFeedVisibility(request: ChangeFeedVisibilityRequest 
+    
+    ): Promise<StreamResponse<ChangeFeedVisibilityResponse>> {
+        
+        return this.feedsApi.changeFeedVisibility( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
 
-  rejectFeedMemberInvite(
-    request?: RejectFeedMemberInviteRequest,
-  ): Promise<StreamResponse<RejectFeedMemberInviteResponse>> {
-    return this.feedsApi.rejectFeedMemberInvite({
-      feed_id: this.id,
-      feed_group_id: this.group,
-      ...request,
-    });
-  }
+    updateFeedMembers(request: UpdateFeedMembersRequest 
+    
+    ): Promise<StreamResponse<UpdateFeedMembersResponse>> {
+        
+        return this.feedsApi.updateFeedMembers( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
 
-  queryPinnedActivities(
-    request?: QueryPinnedActivitiesRequest,
-  ): Promise<StreamResponse<QueryPinnedActivitiesResponse>> {
-    return this.feedsApi.queryPinnedActivities({
-      feed_id: this.id,
-      feed_group_id: this.group,
-      ...request,
-    });
-  }
+    acceptFeedMemberInvite(request?: AcceptFeedMemberInviteRequest 
+    
+    ): Promise<StreamResponse<AcceptFeedMemberInviteResponse>> {
+        
+        return this.feedsApi.acceptFeedMemberInvite( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
 
-  stopWatching(request?: {
-    connection_id?: string;
-  }): Promise<StreamResponse<Response>> {
-    return this.feedsApi.stopWatchingFeed({
-      feed_id: this.id,
-      feed_group_id: this.group,
-      ...request,
-    });
-  }
+    queryFeedMembers(request?: QueryFeedMembersRequest 
+    
+    ): Promise<StreamResponse<QueryFeedMembersResponse>> {
+        
+        return this.feedsApi.queryFeedMembers( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
+
+    rejectFeedMemberInvite(request?: RejectFeedMemberInviteRequest 
+    
+    ): Promise<StreamResponse<RejectFeedMemberInviteResponse>> {
+        
+        return this.feedsApi.rejectFeedMemberInvite( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
+
+    queryPinnedActivities(request?: QueryPinnedActivitiesRequest 
+    
+    ): Promise<StreamResponse<QueryPinnedActivitiesResponse>> {
+        
+        return this.feedsApi.queryPinnedActivities( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
+
+    stopWatching(request?: 
+    
+    
+    {connection_id?: string,
+    }
+    ): Promise<StreamResponse<Response>> {
+        
+        return this.feedsApi.stopWatchingFeed( { feed_id: this.id, feed_group_id: this.group,...request} ) 
+    }
 }

--- a/packages/feeds-client/src/gen/feeds/FeedApi.ts
+++ b/packages/feeds-client/src/gen/feeds/FeedApi.ts
@@ -1,118 +1,164 @@
-import { StreamResponse, FeedsApi } from '../../gen-imports';
-import {  AIImageConfig,  AIImageLabelDefinition,  AITextConfig,  AIVideoConfig,  APIError,  AWSRekognitionRule,  AcceptFeedMemberInviteRequest,  AcceptFeedMemberInviteResponse,  AcceptFollowRequest,  AcceptFollowResponse,  Action,  ActionLogResponse,  ActionSequence,  ActivityAddedEvent,  ActivityDeletedEvent,  ActivityFeedbackEvent,  ActivityFeedbackEventPayload,  ActivityFeedbackRequest,  ActivityFeedbackResponse,  ActivityFilterConfig,  ActivityMarkEvent,  ActivityPinResponse,  ActivityPinnedEvent,  ActivityProcessorConfig,  ActivityReactionAddedEvent,  ActivityReactionDeletedEvent,  ActivityReactionUpdatedEvent,  ActivityRemovedFromFeedEvent,  ActivityRequest,  ActivityResponse,  ActivityRestoredEvent,  ActivitySelectorConfig,  ActivityUnpinnedEvent,  ActivityUpdatedEvent,  AddActivityRequest,  AddActivityResponse,  AddBookmarkRequest,  AddBookmarkResponse,  AddCommentBookmarkRequest,  AddCommentBookmarkResponse,  AddCommentReactionRequest,  AddCommentReactionResponse,  AddCommentRequest,  AddCommentResponse,  AddCommentsBatchRequest,  AddCommentsBatchResponse,  AddFolderRequest,  AddReactionRequest,  AddReactionResponse,  AddUserGroupMembersRequest,  AddUserGroupMembersResponse,  AggregatedActivityResponse,  AggregationConfig,  AppEventResponse,  AppResponseFields,  AppUpdatedEvent,  AppealItemResponse,  AppealRequest,  AppealResponse,  Attachment,  AutomodPlatformCircumventionConfig,  AutomodRule,  AutomodSemanticFiltersConfig,  AutomodSemanticFiltersRule,  AutomodToxicityConfig,  BanActionRequestPayload,  BanInfoResponse,  BanOptions,  BanRequest,  BanResponse,  BlockActionRequestPayload,  BlockListConfig,  BlockListOptions,  BlockListResponse,  BlockListRule,  BlockUsersRequest,  BlockUsersResponse,  BlockedUserResponse,  BodyguardProfileSummary,  BodyguardRule,  BodyguardSeverityRule,  BookmarkAddedEvent,  BookmarkDeletedEvent,  BookmarkFolderDeletedEvent,  BookmarkFolderResponse,  BookmarkFolderUpdatedEvent,  BookmarkResponse,  BookmarkUpdatedEvent,  BulkDeleteActionConfigRequest,  BulkDeleteActionConfigResponse,  BulkUpsertActionConfigRequest,  BulkUpsertActionConfigResponse,  BypassActionRequest,  CallActionOptions,  CallCustomPropertyParameters,  CallResponse,  CallRuleActionSequence,  CallTypeRuleParameters,  CallViolationCountParameters,  CastPollVoteRequest,  ChangeFeedVisibilityRequest,  ChangeFeedVisibilityResponse,  ChannelConfigWithInfo,  ChannelMemberResponse,  ChannelMessageCountRuleParameters,  ChannelMute,  ChannelOwnCapability,  ChannelPushPreferencesResponse,  ChannelResponse,  ChatDraftPayloadResponse,  ChatDraftResponse,  ChatMessageResponse,  ChatModerationV2Response,  ChatPreferences,  ChatPreferencesInput,  ChatPreferencesResponse,  ChatReactionGroupResponse,  ChatReactionGroupUserResponse,  ChatReactionResponse,  ChatReminderResponseData,  ChatSharedLocationResponseData,  ClosedCaptionRuleParameters,  CollectionRequest,  CollectionResponse,  Command,  CommentAddedEvent,  CommentDeletedEvent,  CommentReactionAddedEvent,  CommentReactionDeletedEvent,  CommentReactionUpdatedEvent,  CommentResponse,  CommentRestoredEvent,  CommentUpdatedEvent,  ConfigResponse,  ConnectUserDetailsRequest,  ContentCountRuleParameters,  CreateBlockListRequest,  CreateBlockListResponse,  CreateCollectionsRequest,  CreateCollectionsResponse,  CreateDeviceRequest,  CreateFeedsBatchRequest,  CreateFeedsBatchResponse,  CreateGuestRequest,  CreateGuestResponse,  CreatePollOptionRequest,  CreatePollRequest,  CreateUserGroupRequest,  CreateUserGroupResponse,  CustomActionRequestPayload,  Data,  DecayFunctionConfig,  DeleteActionConfigResponse,  DeleteActivitiesRequest,  DeleteActivitiesResponse,  DeleteActivityReactionResponse,  DeleteActivityRequestPayload,  DeleteActivityResponse,  DeleteBookmarkFolderResponse,  DeleteBookmarkResponse,  DeleteCollectionsResponse,  DeleteCommentBookmarkResponse,  DeleteCommentReactionResponse,  DeleteCommentRequestPayload,  DeleteCommentResponse,  DeleteFeedResponse,  DeleteMessageRequestPayload,  DeleteModerationConfigResponse,  DeleteReactionRequestPayload,  DeleteUserRequestPayload,  DeliveryReceiptsResponse,  DeviceResponse,  DraftPayloadResponse,  DraftResponse,  EnrichedActivity,  EnrichedCollectionResponse,  EnrichedReaction,  EnrichmentOptions,  EntityCreatorResponse,  EscalatePayload,  EscalationMetadata,  FeedCreatedEvent,  FeedDeletedEvent,  FeedGroup,  FeedGroupChangedEvent,  FeedGroupDeletedEvent,  FeedGroupRestoredEvent,  FeedInput,  FeedMemberAddedEvent,  FeedMemberRemovedEvent,  FeedMemberRequest,  FeedMemberResponse,  FeedMemberUpdatedEvent,  FeedOwnCapability,  FeedOwnData,  FeedRequest,  FeedResponse,  FeedSuggestionResponse,  FeedUpdatedEvent,  FeedsActivityLocation,  FeedsBookmarkResponse,  FeedsEnrichedCollectionResponse,  FeedsFeedResponse,  FeedsNotificationComment,  FeedsNotificationContext,  FeedsNotificationParentActivity,  FeedsNotificationTarget,  FeedsNotificationTrigger,  FeedsPreferences,  FeedsPreferencesResponse,  FeedsReactionGroupResponse,  FeedsReactionResponse,  FeedsV3ActivityResponse,  FeedsV3CommentResponse,  Field,  FileUploadConfig,  FileUploadRequest,  FileUploadResponse,  FilterConfigResponse,  FlagCountRuleParameters,  FlagRequest,  FlagResponse,  FlagUserOptions,  FollowBatchRequest,  FollowBatchResponse,  FollowCreatedEvent,  FollowDeletedEvent,  FollowRequest,  FollowResponse,  FollowUpdatedEvent,  FriendReactionsOptions,  FullUserResponse,  GetActionConfigResponse,  GetActivityResponse,  GetAppealResponse,  GetApplicationResponse,  GetBlockedUsersResponse,  GetCommentRepliesResponse,  GetCommentResponse,  GetCommentsResponse,  GetConfigResponse,  GetFollowSuggestionsResponse,  GetOGResponse,  GetOrCreateFeedRequest,  GetOrCreateFeedResponse,  GetUserGroupResponse,  GoogleVisionConfig,  HarmConfig,  HealthCheckEvent,  ImageContentParameters,  ImageData,  ImageRuleParameters,  ImageSize,  ImageUploadRequest,  ImageUploadResponse,  Images,  KeyframeRuleParameters,  LLMConfig,  LLMRule,  LabelThresholds,  ListBlockListResponse,  ListDevicesResponse,  ListUserGroupsResponse,  Location,  MarkActivityRequest,  MarkReviewedRequestPayload,  MembershipLevelResponse,  MessageResponse,  ModerationActionConfigResponse,  ModerationCustomActionEvent,  ModerationFlagResponse,  ModerationFlaggedEvent,  ModerationMarkReviewedEvent,  ModerationPayload,  ModerationPayloadResponse,  ModerationV2Response,  MuteRequest,  MuteResponse,  NotificationComment,  NotificationConfig,  NotificationContext,  NotificationFeedUpdatedEvent,  NotificationParentActivity,  NotificationStatusResponse,  NotificationTarget,  NotificationTrigger,  OCRRule,  OnlyUserID,  OwnBatchRequest,  OwnBatchResponse,  OwnUserResponse,  PagerRequest,  PagerResponse,  PinActivityRequest,  PinActivityResponse,  PollClosedFeedEvent,  PollDeletedFeedEvent,  PollOptionInput,  PollOptionRequest,  PollOptionResponse,  PollOptionResponseData,  PollResponse,  PollResponseData,  PollUpdatedFeedEvent,  PollVoteCastedFeedEvent,  PollVoteChangedFeedEvent,  PollVoteRemovedFeedEvent,  PollVoteResponse,  PollVoteResponseData,  PollVotesResponse,  PrivacySettingsResponse,  PushNotificationConfig,  PushPreferenceInput,  PushPreferencesResponse,  QueryActivitiesRequest,  QueryActivitiesResponse,  QueryActivityReactionsRequest,  QueryActivityReactionsResponse,  QueryAppealsRequest,  QueryAppealsResponse,  QueryBookmarkFoldersRequest,  QueryBookmarkFoldersResponse,  QueryBookmarksRequest,  QueryBookmarksResponse,  QueryCollectionsRequest,  QueryCollectionsResponse,  QueryCommentReactionsRequest,  QueryCommentReactionsResponse,  QueryCommentsRequest,  QueryCommentsResponse,  QueryFeedMembersRequest,  QueryFeedMembersResponse,  QueryFeedsRequest,  QueryFeedsResponse,  QueryFollowsRequest,  QueryFollowsResponse,  QueryModerationConfigsRequest,  QueryModerationConfigsResponse,  QueryPinnedActivitiesRequest,  QueryPinnedActivitiesResponse,  QueryPollVotesRequest,  QueryPollsRequest,  QueryPollsResponse,  QueryReviewQueueRequest,  QueryReviewQueueResponse,  QueryUsersPayload,  QueryUsersResponse,  RankingConfig,  Reaction,  ReactionGroupResponse,  ReactionGroupUserResponse,  ReactionResponse,  ReadCollectionsResponse,  ReadReceiptsResponse,  RejectAppealRequestPayload,  RejectFeedMemberInviteRequest,  RejectFeedMemberInviteResponse,  RejectFollowRequest,  RejectFollowResponse,  ReminderResponseData,  RemoveUserGroupMembersRequest,  RemoveUserGroupMembersResponse,  RepliesMeta,  Response,  RestoreActionRequestPayload,  RestoreActivityRequest,  RestoreActivityResponse,  RestoreCommentRequest,  RestoreCommentResponse,  ReviewQueueItemResponse,  RuleBuilderAction,  RuleBuilderCondition,  RuleBuilderConditionGroup,  RuleBuilderConfig,  RuleBuilderRule,  SearchUserGroupsResponse,  ShadowBlockActionRequestPayload,  SharedLocationResponse,  SharedLocationResponseData,  SharedLocationsResponse,  SingleFollowResponse,  SortParam,  SortParamRequest,  StoriesConfig,  StoriesFeedUpdatedEvent,  SubmitActionRequest,  SubmitActionResponse,  TextContentParameters,  TextRuleParameters,  ThreadedCommentResponse,  Thresholds,  Time,  TrackActivityMetricsEvent,  TrackActivityMetricsEventResult,  TrackActivityMetricsRequest,  TrackActivityMetricsResponse,  TypingIndicatorsResponse,  UnbanActionRequestPayload,  UnblockActionRequestPayload,  UnblockUsersRequest,  UnblockUsersResponse,  UnfollowBatchRequest,  UnfollowBatchResponse,  UnfollowPair,  UnfollowResponse,  UnpinActivityResponse,  UpdateActivityPartialRequest,  UpdateActivityPartialResponse,  UpdateActivityRequest,  UpdateActivityResponse,  UpdateBlockListRequest,  UpdateBlockListResponse,  UpdateBookmarkFolderRequest,  UpdateBookmarkFolderResponse,  UpdateBookmarkRequest,  UpdateBookmarkResponse,  UpdateCollectionRequest,  UpdateCollectionsRequest,  UpdateCollectionsResponse,  UpdateCommentBookmarkRequest,  UpdateCommentBookmarkResponse,  UpdateCommentPartialRequest,  UpdateCommentPartialResponse,  UpdateCommentRequest,  UpdateCommentResponse,  UpdateFeedMembersRequest,  UpdateFeedMembersResponse,  UpdateFeedRequest,  UpdateFeedResponse,  UpdateFollowRequest,  UpdateFollowResponse,  UpdateLiveLocationRequest,  UpdatePollOptionRequest,  UpdatePollPartialRequest,  UpdatePollRequest,  UpdateUserGroupRequest,  UpdateUserGroupResponse,  UpdateUserPartialRequest,  UpdateUsersPartialRequest,  UpdateUsersRequest,  UpdateUsersResponse,  UpsertActionConfigItem,  UpsertActionConfigRequest,  UpsertActionConfigResponse,  UpsertActivitiesRequest,  UpsertActivitiesResponse,  UpsertConfigRequest,  UpsertConfigResponse,  UpsertPushPreferencesRequest,  UpsertPushPreferencesResponse,  User,  UserBannedEvent,  UserCreatedWithinParameters,  UserCustomPropertyParameters,  UserDeactivatedEvent,  UserGroupMember,  UserGroupResponse,  UserIdenticalContentCountParameters,  UserMuteResponse,  UserReactivatedEvent,  UserRequest,  UserResponse,  UserResponseCommonFields,  UserResponsePrivacyFields,  UserRoleParameters,  UserRuleParameters,  UserUnbannedEvent,  UserUpdatedEvent,  VelocityFilterConfig,  VelocityFilterConfigRule,  VideoCallRuleConfig,  VideoContentParameters,  VideoEndCallRequestPayload,  VideoKickUserRequestPayload,  VideoRuleParameters,  VoteData,  WSAuthMessage,  WSClientEvent,  WSEvent,  } from '../models';
+import type { StreamResponse, FeedsApi } from '../../gen-imports';
+import type {
+  AcceptFeedMemberInviteRequest,
+  AcceptFeedMemberInviteResponse,
+  ChangeFeedVisibilityRequest,
+  ChangeFeedVisibilityResponse,
+  DeleteFeedResponse,
+  GetOrCreateFeedRequest,
+  GetOrCreateFeedResponse,
+  MarkActivityRequest,
+  PinActivityRequest,
+  PinActivityResponse,
+  QueryFeedMembersRequest,
+  QueryFeedMembersResponse,
+  QueryPinnedActivitiesRequest,
+  QueryPinnedActivitiesResponse,
+  RejectFeedMemberInviteRequest,
+  RejectFeedMemberInviteResponse,
+  Response,
+  UnpinActivityResponse,
+  UpdateFeedMembersRequest,
+  UpdateFeedMembersResponse,
+  UpdateFeedRequest,
+  UpdateFeedResponse,
+} from '../models';
 
 export class FeedApi {
-    constructor(
-        protected feedsApi: FeedsApi,
-        public readonly  group : string,
-        public  readonly id: string, 
+  constructor(
+    protected feedsApi: FeedsApi,
+    public readonly group: string,
+    public readonly id: string,
   ) {}
 
+  delete(request?: {
+    hard_delete?: boolean;
+  }): Promise<StreamResponse<DeleteFeedResponse>> {
+    return this.feedsApi.deleteFeed({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 
+  getOrCreate(
+    request?: GetOrCreateFeedRequest & { connection_id?: string },
+  ): Promise<StreamResponse<GetOrCreateFeedResponse>> {
+    return this.feedsApi.getOrCreateFeed({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 
-    delete(request?: 
-    
-    
-    {hard_delete?: boolean,
-    }
-    ): Promise<StreamResponse<DeleteFeedResponse>> {
-        
-        return this.feedsApi.deleteFeed( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
+  update(
+    request?: UpdateFeedRequest,
+  ): Promise<StreamResponse<UpdateFeedResponse>> {
+    return this.feedsApi.updateFeed({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 
-    getOrCreate(request?: GetOrCreateFeedRequest 
-     & 
-    
-    {connection_id?: string,
-    }
-    ): Promise<StreamResponse<GetOrCreateFeedResponse>> {
-        
-        return this.feedsApi.getOrCreateFeed( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
+  markActivity(
+    request?: MarkActivityRequest,
+  ): Promise<StreamResponse<Response>> {
+    return this.feedsApi.markActivity({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 
-    update(request?: UpdateFeedRequest 
-    
-    ): Promise<StreamResponse<UpdateFeedResponse>> {
-        
-        return this.feedsApi.updateFeed( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
+  unpinActivity(request: {
+    activity_id: string;
+    enrich_own_fields?: boolean;
+  }): Promise<StreamResponse<UnpinActivityResponse>> {
+    return this.feedsApi.unpinActivity({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 
-    markActivity(request?: MarkActivityRequest 
-    
-    ): Promise<StreamResponse<Response>> {
-        
-        return this.feedsApi.markActivity( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
+  pinActivity(
+    request: PinActivityRequest & { activity_id: string },
+  ): Promise<StreamResponse<PinActivityResponse>> {
+    return this.feedsApi.pinActivity({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 
-    unpinActivity(request: 
-    
-    
-    {activity_id: string,enrich_own_fields?: boolean,
-    }
-    ): Promise<StreamResponse<UnpinActivityResponse>> {
-        
-        return this.feedsApi.unpinActivity( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
+  changeFeedVisibility(
+    request: ChangeFeedVisibilityRequest,
+  ): Promise<StreamResponse<ChangeFeedVisibilityResponse>> {
+    return this.feedsApi.changeFeedVisibility({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 
-    pinActivity(request: PinActivityRequest 
-     & 
-    
-    {activity_id: string,
-    }
-    ): Promise<StreamResponse<PinActivityResponse>> {
-        
-        return this.feedsApi.pinActivity( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
+  updateFeedMembers(
+    request: UpdateFeedMembersRequest,
+  ): Promise<StreamResponse<UpdateFeedMembersResponse>> {
+    return this.feedsApi.updateFeedMembers({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 
-    changeFeedVisibility(request: ChangeFeedVisibilityRequest 
-    
-    ): Promise<StreamResponse<ChangeFeedVisibilityResponse>> {
-        
-        return this.feedsApi.changeFeedVisibility( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
+  acceptFeedMemberInvite(
+    request?: AcceptFeedMemberInviteRequest,
+  ): Promise<StreamResponse<AcceptFeedMemberInviteResponse>> {
+    return this.feedsApi.acceptFeedMemberInvite({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 
-    updateFeedMembers(request: UpdateFeedMembersRequest 
-    
-    ): Promise<StreamResponse<UpdateFeedMembersResponse>> {
-        
-        return this.feedsApi.updateFeedMembers( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
+  queryFeedMembers(
+    request?: QueryFeedMembersRequest,
+  ): Promise<StreamResponse<QueryFeedMembersResponse>> {
+    return this.feedsApi.queryFeedMembers({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 
-    acceptFeedMemberInvite(request?: AcceptFeedMemberInviteRequest 
-    
-    ): Promise<StreamResponse<AcceptFeedMemberInviteResponse>> {
-        
-        return this.feedsApi.acceptFeedMemberInvite( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
+  rejectFeedMemberInvite(
+    request?: RejectFeedMemberInviteRequest,
+  ): Promise<StreamResponse<RejectFeedMemberInviteResponse>> {
+    return this.feedsApi.rejectFeedMemberInvite({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 
-    queryFeedMembers(request?: QueryFeedMembersRequest 
-    
-    ): Promise<StreamResponse<QueryFeedMembersResponse>> {
-        
-        return this.feedsApi.queryFeedMembers( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
+  queryPinnedActivities(
+    request?: QueryPinnedActivitiesRequest,
+  ): Promise<StreamResponse<QueryPinnedActivitiesResponse>> {
+    return this.feedsApi.queryPinnedActivities({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 
-    rejectFeedMemberInvite(request?: RejectFeedMemberInviteRequest 
-    
-    ): Promise<StreamResponse<RejectFeedMemberInviteResponse>> {
-        
-        return this.feedsApi.rejectFeedMemberInvite( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
-
-    queryPinnedActivities(request?: QueryPinnedActivitiesRequest 
-    
-    ): Promise<StreamResponse<QueryPinnedActivitiesResponse>> {
-        
-        return this.feedsApi.queryPinnedActivities( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
-
-    stopWatching(request?: 
-    
-    
-    {connection_id?: string,
-    }
-    ): Promise<StreamResponse<Response>> {
-        
-        return this.feedsApi.stopWatchingFeed( { feed_id: this.id, feed_group_id: this.group,...request} ) 
-    }
+  stopWatching(request?: {
+    connection_id?: string;
+  }): Promise<StreamResponse<Response>> {
+    return this.feedsApi.stopWatchingFeed({
+      feed_id: this.id,
+      feed_group_id: this.group,
+      ...request,
+    });
+  }
 }

--- a/packages/feeds-client/src/gen/feeds/FeedsApi.ts
+++ b/packages/feeds-client/src/gen/feeds/FeedsApi.ts
@@ -1,3061 +1,2128 @@
-import type { ApiClient, StreamResponse } from '../../gen-imports';
-import type {
-  AcceptFeedMemberInviteRequest,
-  AcceptFeedMemberInviteResponse,
-  AcceptFollowRequest,
-  AcceptFollowResponse,
-  ActivityFeedbackRequest,
-  ActivityFeedbackResponse,
-  AddActivityRequest,
-  AddActivityResponse,
-  AddBookmarkRequest,
-  AddBookmarkResponse,
-  AddCommentBookmarkRequest,
-  AddCommentBookmarkResponse,
-  AddCommentReactionRequest,
-  AddCommentReactionResponse,
-  AddCommentRequest,
-  AddCommentResponse,
-  AddCommentsBatchRequest,
-  AddCommentsBatchResponse,
-  AddReactionRequest,
-  AddReactionResponse,
-  AddUserGroupMembersRequest,
-  AddUserGroupMembersResponse,
-  BlockUsersRequest,
-  BlockUsersResponse,
-  CastPollVoteRequest,
-  CreateBlockListRequest,
-  CreateBlockListResponse,
-  CreateCollectionsRequest,
-  CreateCollectionsResponse,
-  CreateDeviceRequest,
-  CreateFeedsBatchRequest,
-  CreateFeedsBatchResponse,
-  CreateGuestRequest,
-  CreateGuestResponse,
-  CreatePollOptionRequest,
-  CreatePollRequest,
-  CreateUserGroupRequest,
-  CreateUserGroupResponse,
-  DeleteActivitiesRequest,
-  DeleteActivitiesResponse,
-  DeleteActivityReactionResponse,
-  DeleteActivityResponse,
-  DeleteBookmarkFolderResponse,
-  DeleteBookmarkResponse,
-  DeleteCollectionsResponse,
-  DeleteCommentBookmarkResponse,
-  DeleteCommentReactionResponse,
-  DeleteCommentResponse,
-  DeleteFeedResponse,
-  FileUploadRequest,
-  FileUploadResponse,
-  FollowBatchRequest,
-  FollowBatchResponse,
-  FollowRequest,
-  GetActivityResponse,
-  GetApplicationResponse,
-  GetBlockedUsersResponse,
-  GetCommentRepliesResponse,
-  GetCommentResponse,
-  GetCommentsResponse,
-  GetFollowSuggestionsResponse,
-  GetOGResponse,
-  GetOrCreateFeedRequest,
-  GetOrCreateFeedResponse,
-  GetUserGroupResponse,
-  ImageUploadRequest,
-  ImageUploadResponse,
-  ListBlockListResponse,
-  ListDevicesResponse,
-  ListUserGroupsResponse,
-  MarkActivityRequest,
-  OwnBatchRequest,
-  OwnBatchResponse,
-  PinActivityRequest,
-  PinActivityResponse,
-  PollOptionResponse,
-  PollResponse,
-  PollVoteResponse,
-  PollVotesResponse,
-  QueryActivitiesRequest,
-  QueryActivitiesResponse,
-  QueryActivityReactionsRequest,
-  QueryActivityReactionsResponse,
-  QueryBookmarkFoldersRequest,
-  QueryBookmarkFoldersResponse,
-  QueryBookmarksRequest,
-  QueryBookmarksResponse,
-  QueryCollectionsRequest,
-  QueryCollectionsResponse,
-  QueryCommentReactionsRequest,
-  QueryCommentReactionsResponse,
-  QueryCommentsRequest,
-  QueryCommentsResponse,
-  QueryFeedMembersRequest,
-  QueryFeedMembersResponse,
-  QueryFeedsRequest,
-  QueryFeedsResponse,
-  QueryFollowsRequest,
-  QueryFollowsResponse,
-  QueryPinnedActivitiesRequest,
-  QueryPinnedActivitiesResponse,
-  QueryPollVotesRequest,
-  QueryPollsRequest,
-  QueryPollsResponse,
-  QueryUsersPayload,
-  QueryUsersResponse,
-  ReadCollectionsResponse,
-  RejectFeedMemberInviteRequest,
-  RejectFeedMemberInviteResponse,
-  RejectFollowRequest,
-  RejectFollowResponse,
-  RemoveUserGroupMembersRequest,
-  RemoveUserGroupMembersResponse,
-  Response,
-  RestoreActivityRequest,
-  RestoreActivityResponse,
-  RestoreCommentRequest,
-  RestoreCommentResponse,
-  SearchUserGroupsResponse,
-  SharedLocationResponse,
-  SharedLocationsResponse,
-  SingleFollowResponse,
-  TrackActivityMetricsRequest,
-  TrackActivityMetricsResponse,
-  UnblockUsersRequest,
-  UnblockUsersResponse,
-  UnfollowBatchRequest,
-  UnfollowBatchResponse,
-  UnfollowResponse,
-  UnpinActivityResponse,
-  UpdateActivityPartialRequest,
-  UpdateActivityPartialResponse,
-  UpdateActivityRequest,
-  UpdateActivityResponse,
-  UpdateBlockListRequest,
-  UpdateBlockListResponse,
-  UpdateBookmarkFolderRequest,
-  UpdateBookmarkFolderResponse,
-  UpdateBookmarkRequest,
-  UpdateBookmarkResponse,
-  UpdateCollectionsRequest,
-  UpdateCollectionsResponse,
-  UpdateCommentBookmarkRequest,
-  UpdateCommentBookmarkResponse,
-  UpdateCommentPartialRequest,
-  UpdateCommentPartialResponse,
-  UpdateCommentRequest,
-  UpdateCommentResponse,
-  UpdateFeedMembersRequest,
-  UpdateFeedMembersResponse,
-  UpdateFeedRequest,
-  UpdateFeedResponse,
-  UpdateFollowRequest,
-  UpdateFollowResponse,
-  UpdateLiveLocationRequest,
-  UpdatePollOptionRequest,
-  UpdatePollPartialRequest,
-  UpdatePollRequest,
-  UpdateUserGroupRequest,
-  UpdateUserGroupResponse,
-  UpdateUsersPartialRequest,
-  UpdateUsersRequest,
-  UpdateUsersResponse,
-  UpsertActivitiesRequest,
-  UpsertActivitiesResponse,
-  UpsertPushPreferencesRequest,
-  UpsertPushPreferencesResponse,
-  WSAuthMessage,
-} from '../models';
-import { decoders } from '../model-decoders/decoders';
+import { ApiClient, StreamResponse } from '../../gen-imports';
+import {  AIImageConfig,  AIImageLabelDefinition,  AITextConfig,  AIVideoConfig,  APIError,  AWSRekognitionRule,  AcceptFeedMemberInviteRequest,  AcceptFeedMemberInviteResponse,  AcceptFollowRequest,  AcceptFollowResponse,  Action,  ActionLogResponse,  ActionSequence,  ActivityAddedEvent,  ActivityDeletedEvent,  ActivityFeedbackEvent,  ActivityFeedbackEventPayload,  ActivityFeedbackRequest,  ActivityFeedbackResponse,  ActivityFilterConfig,  ActivityMarkEvent,  ActivityPinResponse,  ActivityPinnedEvent,  ActivityProcessorConfig,  ActivityReactionAddedEvent,  ActivityReactionDeletedEvent,  ActivityReactionUpdatedEvent,  ActivityRemovedFromFeedEvent,  ActivityRequest,  ActivityResponse,  ActivityRestoredEvent,  ActivitySelectorConfig,  ActivityUnpinnedEvent,  ActivityUpdatedEvent,  AddActivityRequest,  AddActivityResponse,  AddBookmarkRequest,  AddBookmarkResponse,  AddCommentBookmarkRequest,  AddCommentBookmarkResponse,  AddCommentReactionRequest,  AddCommentReactionResponse,  AddCommentRequest,  AddCommentResponse,  AddCommentsBatchRequest,  AddCommentsBatchResponse,  AddFolderRequest,  AddReactionRequest,  AddReactionResponse,  AddUserGroupMembersRequest,  AddUserGroupMembersResponse,  AggregatedActivityResponse,  AggregationConfig,  AppEventResponse,  AppResponseFields,  AppUpdatedEvent,  AppealItemResponse,  AppealRequest,  AppealResponse,  Attachment,  AutomodPlatformCircumventionConfig,  AutomodRule,  AutomodSemanticFiltersConfig,  AutomodSemanticFiltersRule,  AutomodToxicityConfig,  BanActionRequestPayload,  BanInfoResponse,  BanOptions,  BanRequest,  BanResponse,  BlockActionRequestPayload,  BlockListConfig,  BlockListOptions,  BlockListResponse,  BlockListRule,  BlockUsersRequest,  BlockUsersResponse,  BlockedUserResponse,  BodyguardProfileSummary,  BodyguardRule,  BodyguardSeverityRule,  BookmarkAddedEvent,  BookmarkDeletedEvent,  BookmarkFolderDeletedEvent,  BookmarkFolderResponse,  BookmarkFolderUpdatedEvent,  BookmarkResponse,  BookmarkUpdatedEvent,  BulkDeleteActionConfigRequest,  BulkDeleteActionConfigResponse,  BulkUpsertActionConfigRequest,  BulkUpsertActionConfigResponse,  BypassActionRequest,  CallActionOptions,  CallCustomPropertyParameters,  CallResponse,  CallRuleActionSequence,  CallTypeRuleParameters,  CallViolationCountParameters,  CastPollVoteRequest,  ChangeFeedVisibilityRequest,  ChangeFeedVisibilityResponse,  ChannelConfigWithInfo,  ChannelMemberResponse,  ChannelMessageCountRuleParameters,  ChannelMute,  ChannelOwnCapability,  ChannelPushPreferencesResponse,  ChannelResponse,  ChatDraftPayloadResponse,  ChatDraftResponse,  ChatMessageResponse,  ChatModerationV2Response,  ChatPreferences,  ChatPreferencesInput,  ChatPreferencesResponse,  ChatReactionGroupResponse,  ChatReactionGroupUserResponse,  ChatReactionResponse,  ChatReminderResponseData,  ChatSharedLocationResponseData,  ClosedCaptionRuleParameters,  CollectionRequest,  CollectionResponse,  Command,  CommentAddedEvent,  CommentDeletedEvent,  CommentReactionAddedEvent,  CommentReactionDeletedEvent,  CommentReactionUpdatedEvent,  CommentResponse,  CommentRestoredEvent,  CommentUpdatedEvent,  ConfigResponse,  ConnectUserDetailsRequest,  ContentCountRuleParameters,  CreateBlockListRequest,  CreateBlockListResponse,  CreateCollectionsRequest,  CreateCollectionsResponse,  CreateDeviceRequest,  CreateFeedsBatchRequest,  CreateFeedsBatchResponse,  CreateGuestRequest,  CreateGuestResponse,  CreatePollOptionRequest,  CreatePollRequest,  CreateUserGroupRequest,  CreateUserGroupResponse,  CustomActionRequestPayload,  Data,  DecayFunctionConfig,  DeleteActionConfigResponse,  DeleteActivitiesRequest,  DeleteActivitiesResponse,  DeleteActivityReactionResponse,  DeleteActivityRequestPayload,  DeleteActivityResponse,  DeleteBookmarkFolderResponse,  DeleteBookmarkResponse,  DeleteCollectionsResponse,  DeleteCommentBookmarkResponse,  DeleteCommentReactionResponse,  DeleteCommentRequestPayload,  DeleteCommentResponse,  DeleteFeedResponse,  DeleteMessageRequestPayload,  DeleteModerationConfigResponse,  DeleteReactionRequestPayload,  DeleteUserRequestPayload,  DeliveryReceiptsResponse,  DeviceResponse,  DraftPayloadResponse,  DraftResponse,  EnrichedActivity,  EnrichedCollectionResponse,  EnrichedReaction,  EnrichmentOptions,  EntityCreatorResponse,  EscalatePayload,  EscalationMetadata,  FeedCreatedEvent,  FeedDeletedEvent,  FeedGroup,  FeedGroupChangedEvent,  FeedGroupDeletedEvent,  FeedGroupRestoredEvent,  FeedInput,  FeedMemberAddedEvent,  FeedMemberRemovedEvent,  FeedMemberRequest,  FeedMemberResponse,  FeedMemberUpdatedEvent,  FeedOwnCapability,  FeedOwnData,  FeedRequest,  FeedResponse,  FeedSuggestionResponse,  FeedUpdatedEvent,  FeedsActivityLocation,  FeedsBookmarkResponse,  FeedsEnrichedCollectionResponse,  FeedsFeedResponse,  FeedsNotificationComment,  FeedsNotificationContext,  FeedsNotificationParentActivity,  FeedsNotificationTarget,  FeedsNotificationTrigger,  FeedsPreferences,  FeedsPreferencesResponse,  FeedsReactionGroupResponse,  FeedsReactionResponse,  FeedsV3ActivityResponse,  FeedsV3CommentResponse,  Field,  FileUploadConfig,  FileUploadRequest,  FileUploadResponse,  FilterConfigResponse,  FlagCountRuleParameters,  FlagRequest,  FlagResponse,  FlagUserOptions,  FollowBatchRequest,  FollowBatchResponse,  FollowCreatedEvent,  FollowDeletedEvent,  FollowRequest,  FollowResponse,  FollowUpdatedEvent,  FriendReactionsOptions,  FullUserResponse,  GetActionConfigResponse,  GetActivityResponse,  GetAppealResponse,  GetApplicationResponse,  GetBlockedUsersResponse,  GetCommentRepliesResponse,  GetCommentResponse,  GetCommentsResponse,  GetConfigResponse,  GetFollowSuggestionsResponse,  GetOGResponse,  GetOrCreateFeedRequest,  GetOrCreateFeedResponse,  GetUserGroupResponse,  GoogleVisionConfig,  HarmConfig,  HealthCheckEvent,  ImageContentParameters,  ImageData,  ImageRuleParameters,  ImageSize,  ImageUploadRequest,  ImageUploadResponse,  Images,  KeyframeRuleParameters,  LLMConfig,  LLMRule,  LabelThresholds,  ListBlockListResponse,  ListDevicesResponse,  ListUserGroupsResponse,  Location,  MarkActivityRequest,  MarkReviewedRequestPayload,  MembershipLevelResponse,  MessageResponse,  ModerationActionConfigResponse,  ModerationCustomActionEvent,  ModerationFlagResponse,  ModerationFlaggedEvent,  ModerationMarkReviewedEvent,  ModerationPayload,  ModerationPayloadResponse,  ModerationV2Response,  MuteRequest,  MuteResponse,  NotificationComment,  NotificationConfig,  NotificationContext,  NotificationFeedUpdatedEvent,  NotificationParentActivity,  NotificationStatusResponse,  NotificationTarget,  NotificationTrigger,  OCRRule,  OnlyUserID,  OwnBatchRequest,  OwnBatchResponse,  OwnUserResponse,  PagerRequest,  PagerResponse,  PinActivityRequest,  PinActivityResponse,  PollClosedFeedEvent,  PollDeletedFeedEvent,  PollOptionInput,  PollOptionRequest,  PollOptionResponse,  PollOptionResponseData,  PollResponse,  PollResponseData,  PollUpdatedFeedEvent,  PollVoteCastedFeedEvent,  PollVoteChangedFeedEvent,  PollVoteRemovedFeedEvent,  PollVoteResponse,  PollVoteResponseData,  PollVotesResponse,  PrivacySettingsResponse,  PushNotificationConfig,  PushPreferenceInput,  PushPreferencesResponse,  QueryActivitiesRequest,  QueryActivitiesResponse,  QueryActivityReactionsRequest,  QueryActivityReactionsResponse,  QueryAppealsRequest,  QueryAppealsResponse,  QueryBookmarkFoldersRequest,  QueryBookmarkFoldersResponse,  QueryBookmarksRequest,  QueryBookmarksResponse,  QueryCollectionsRequest,  QueryCollectionsResponse,  QueryCommentReactionsRequest,  QueryCommentReactionsResponse,  QueryCommentsRequest,  QueryCommentsResponse,  QueryFeedMembersRequest,  QueryFeedMembersResponse,  QueryFeedsRequest,  QueryFeedsResponse,  QueryFollowsRequest,  QueryFollowsResponse,  QueryModerationConfigsRequest,  QueryModerationConfigsResponse,  QueryPinnedActivitiesRequest,  QueryPinnedActivitiesResponse,  QueryPollVotesRequest,  QueryPollsRequest,  QueryPollsResponse,  QueryReviewQueueRequest,  QueryReviewQueueResponse,  QueryUsersPayload,  QueryUsersResponse,  RankingConfig,  Reaction,  ReactionGroupResponse,  ReactionGroupUserResponse,  ReactionResponse,  ReadCollectionsResponse,  ReadReceiptsResponse,  RejectAppealRequestPayload,  RejectFeedMemberInviteRequest,  RejectFeedMemberInviteResponse,  RejectFollowRequest,  RejectFollowResponse,  ReminderResponseData,  RemoveUserGroupMembersRequest,  RemoveUserGroupMembersResponse,  RepliesMeta,  Response,  RestoreActionRequestPayload,  RestoreActivityRequest,  RestoreActivityResponse,  RestoreCommentRequest,  RestoreCommentResponse,  ReviewQueueItemResponse,  RuleBuilderAction,  RuleBuilderCondition,  RuleBuilderConditionGroup,  RuleBuilderConfig,  RuleBuilderRule,  SearchUserGroupsResponse,  ShadowBlockActionRequestPayload,  SharedLocationResponse,  SharedLocationResponseData,  SharedLocationsResponse,  SingleFollowResponse,  SortParam,  SortParamRequest,  StoriesConfig,  StoriesFeedUpdatedEvent,  SubmitActionRequest,  SubmitActionResponse,  TextContentParameters,  TextRuleParameters,  ThreadedCommentResponse,  Thresholds,  Time,  TrackActivityMetricsEvent,  TrackActivityMetricsEventResult,  TrackActivityMetricsRequest,  TrackActivityMetricsResponse,  TypingIndicatorsResponse,  UnbanActionRequestPayload,  UnblockActionRequestPayload,  UnblockUsersRequest,  UnblockUsersResponse,  UnfollowBatchRequest,  UnfollowBatchResponse,  UnfollowPair,  UnfollowResponse,  UnpinActivityResponse,  UpdateActivityPartialRequest,  UpdateActivityPartialResponse,  UpdateActivityRequest,  UpdateActivityResponse,  UpdateBlockListRequest,  UpdateBlockListResponse,  UpdateBookmarkFolderRequest,  UpdateBookmarkFolderResponse,  UpdateBookmarkRequest,  UpdateBookmarkResponse,  UpdateCollectionRequest,  UpdateCollectionsRequest,  UpdateCollectionsResponse,  UpdateCommentBookmarkRequest,  UpdateCommentBookmarkResponse,  UpdateCommentPartialRequest,  UpdateCommentPartialResponse,  UpdateCommentRequest,  UpdateCommentResponse,  UpdateFeedMembersRequest,  UpdateFeedMembersResponse,  UpdateFeedRequest,  UpdateFeedResponse,  UpdateFollowRequest,  UpdateFollowResponse,  UpdateLiveLocationRequest,  UpdatePollOptionRequest,  UpdatePollPartialRequest,  UpdatePollRequest,  UpdateUserGroupRequest,  UpdateUserGroupResponse,  UpdateUserPartialRequest,  UpdateUsersPartialRequest,  UpdateUsersRequest,  UpdateUsersResponse,  UpsertActionConfigItem,  UpsertActionConfigRequest,  UpsertActionConfigResponse,  UpsertActivitiesRequest,  UpsertActivitiesResponse,  UpsertConfigRequest,  UpsertConfigResponse,  UpsertPushPreferencesRequest,  UpsertPushPreferencesResponse,  User,  UserBannedEvent,  UserCreatedWithinParameters,  UserCustomPropertyParameters,  UserDeactivatedEvent,  UserGroupMember,  UserGroupResponse,  UserIdenticalContentCountParameters,  UserMuteResponse,  UserReactivatedEvent,  UserRequest,  UserResponse,  UserResponseCommonFields,  UserResponsePrivacyFields,  UserRoleParameters,  UserRuleParameters,  UserUnbannedEvent,  UserUpdatedEvent,  VelocityFilterConfig,  VelocityFilterConfigRule,  VideoCallRuleConfig,  VideoContentParameters,  VideoEndCallRequestPayload,  VideoKickUserRequestPayload,  VideoRuleParameters,  VoteData,  WSAuthMessage,  WSClientEvent,  WSEvent,  } from '../models';
+import { decoders } from '../model-decoders/decoders'
 
 export class FeedsApi {
-  constructor(public readonly apiClient: ApiClient) {}
 
-  async getApp(): Promise<StreamResponse<GetApplicationResponse>> {
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetApplicationResponse>
-    >('GET', '/api/v2/app', undefined, undefined);
+    constructor(public readonly apiClient: ApiClient) {}
 
-    decoders.GetApplicationResponse?.(response.body);
+    
+    async getApp (): Promise<StreamResponse<GetApplicationResponse>> {
+        
 
-    return { ...response.body, metadata: response.metadata };
-  }
+        const response = await this.apiClient.sendRequest<StreamResponse<GetApplicationResponse>>('GET', '/api/v2/app',  undefined ,  undefined  );
 
-  async listBlockLists(request?: {
-    team?: string;
-  }): Promise<StreamResponse<ListBlockListResponse>> {
-    const queryParams = {
-      team: request?.team,
-    };
+       decoders["GetApplicationResponse"]?.(response.body);
 
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<ListBlockListResponse>
-    >('GET', '/api/v2/blocklists', undefined, queryParams);
-
-    decoders.ListBlockListResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async createBlockList(
-    request: CreateBlockListRequest,
-  ): Promise<StreamResponse<CreateBlockListResponse>> {
-    const body = {
-      name: request?.name,
-      words: request?.words,
-      is_leet_check_enabled: request?.is_leet_check_enabled,
-      is_plural_check_enabled: request?.is_plural_check_enabled,
-      team: request?.team,
-      type: request?.type,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<CreateBlockListResponse>
-    >(
-      'POST',
-      '/api/v2/blocklists',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.CreateBlockListResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteBlockList(request: {
-    name: string;
-    team?: string;
-  }): Promise<StreamResponse<Response>> {
-    const queryParams = {
-      team: request?.team,
-    };
-    const pathParams = {
-      name: request?.name,
-    };
-
-    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
-      'DELETE',
-      '/api/v2/blocklists/{name}',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.Response?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateBlockList(
-    request: UpdateBlockListRequest & { name: string },
-  ): Promise<StreamResponse<UpdateBlockListResponse>> {
-    const pathParams = {
-      name: request?.name,
-    };
-    const body = {
-      is_leet_check_enabled: request?.is_leet_check_enabled,
-      is_plural_check_enabled: request?.is_plural_check_enabled,
-      team: request?.team,
-      words: request?.words,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateBlockListResponse>
-    >(
-      'PUT',
-      '/api/v2/blocklists/{name}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateBlockListResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteDevice(request: {
-    id: string;
-  }): Promise<StreamResponse<Response>> {
-    const queryParams = {
-      id: request?.id,
-    };
-
-    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
-      'DELETE',
-      '/api/v2/devices',
-      undefined,
-      queryParams,
-    );
-
-    decoders.Response?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async listDevices(): Promise<StreamResponse<ListDevicesResponse>> {
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<ListDevicesResponse>
-    >('GET', '/api/v2/devices', undefined, undefined);
-
-    decoders.ListDevicesResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async createDevice(
-    request: CreateDeviceRequest,
-  ): Promise<StreamResponse<Response>> {
-    const body = {
-      id: request?.id,
-      push_provider: request?.push_provider,
-      push_provider_name: request?.push_provider_name,
-      voip_token: request?.voip_token,
-    };
-
-    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
-      'POST',
-      '/api/v2/devices',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.Response?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async addActivity(
-    request: AddActivityRequest,
-  ): Promise<StreamResponse<AddActivityResponse>> {
-    const body = {
-      type: request?.type,
-      feeds: request?.feeds,
-      copy_custom_to_notification: request?.copy_custom_to_notification,
-      create_notification_activity: request?.create_notification_activity,
-      enrich_own_fields: request?.enrich_own_fields,
-      expires_at: request?.expires_at,
-      id: request?.id,
-      parent_id: request?.parent_id,
-      poll_id: request?.poll_id,
-      restrict_replies: request?.restrict_replies,
-      skip_enrich_url: request?.skip_enrich_url,
-      skip_push: request?.skip_push,
-      text: request?.text,
-      visibility: request?.visibility,
-      visibility_tag: request?.visibility_tag,
-      attachments: request?.attachments,
-      collection_refs: request?.collection_refs,
-      filter_tags: request?.filter_tags,
-      interest_tags: request?.interest_tags,
-      mentioned_user_ids: request?.mentioned_user_ids,
-      custom: request?.custom,
-      location: request?.location,
-      search_data: request?.search_data,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<AddActivityResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/activities',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.AddActivityResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async upsertActivities(
-    request: UpsertActivitiesRequest,
-  ): Promise<StreamResponse<UpsertActivitiesResponse>> {
-    const body = {
-      activities: request?.activities,
-      enrich_own_fields: request?.enrich_own_fields,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpsertActivitiesResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/activities/batch',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpsertActivitiesResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteActivities(
-    request: DeleteActivitiesRequest,
-  ): Promise<StreamResponse<DeleteActivitiesResponse>> {
-    const body = {
-      ids: request?.ids,
-      delete_notification_activity: request?.delete_notification_activity,
-      hard_delete: request?.hard_delete,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteActivitiesResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/activities/delete',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.DeleteActivitiesResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async trackActivityMetrics(
-    request: TrackActivityMetricsRequest,
-  ): Promise<StreamResponse<TrackActivityMetricsResponse>> {
-    const body = {
-      events: request?.events,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<TrackActivityMetricsResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/activities/metrics/track',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.TrackActivityMetricsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryActivities(
-    request?: QueryActivitiesRequest,
-  ): Promise<StreamResponse<QueryActivitiesResponse>> {
-    const body = {
-      enrich_own_fields: request?.enrich_own_fields,
-      include_soft_deleted_activities: request?.include_soft_deleted_activities,
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryActivitiesResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/activities/query',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryActivitiesResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteBookmark(request: {
-    activity_id: string;
-    folder_id?: string;
-  }): Promise<StreamResponse<DeleteBookmarkResponse>> {
-    const queryParams = {
-      folder_id: request?.folder_id,
-    };
-    const pathParams = {
-      activity_id: request?.activity_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteBookmarkResponse>
-    >(
-      'DELETE',
-      '/api/v2/feeds/activities/{activity_id}/bookmarks',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.DeleteBookmarkResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateBookmark(
-    request: UpdateBookmarkRequest & { activity_id: string },
-  ): Promise<StreamResponse<UpdateBookmarkResponse>> {
-    const pathParams = {
-      activity_id: request?.activity_id,
-    };
-    const body = {
-      folder_id: request?.folder_id,
-      new_folder_id: request?.new_folder_id,
-      custom: request?.custom,
-      new_folder: request?.new_folder,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateBookmarkResponse>
-    >(
-      'PATCH',
-      '/api/v2/feeds/activities/{activity_id}/bookmarks',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateBookmarkResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async addBookmark(
-    request: AddBookmarkRequest & { activity_id: string },
-  ): Promise<StreamResponse<AddBookmarkResponse>> {
-    const pathParams = {
-      activity_id: request?.activity_id,
-    };
-    const body = {
-      folder_id: request?.folder_id,
-      custom: request?.custom,
-      new_folder: request?.new_folder,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<AddBookmarkResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/activities/{activity_id}/bookmarks',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.AddBookmarkResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async activityFeedback(
-    request: ActivityFeedbackRequest & { activity_id: string },
-  ): Promise<StreamResponse<ActivityFeedbackResponse>> {
-    const pathParams = {
-      activity_id: request?.activity_id,
-    };
-    const body = {
-      hide: request?.hide,
-      show_less: request?.show_less,
-      show_more: request?.show_more,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<ActivityFeedbackResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/activities/{activity_id}/feedback',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.ActivityFeedbackResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async castPollVote(
-    request: CastPollVoteRequest & { activity_id: string; poll_id: string },
-  ): Promise<StreamResponse<PollVoteResponse>> {
-    const pathParams = {
-      activity_id: request?.activity_id,
-      poll_id: request?.poll_id,
-    };
-    const body = {
-      vote: request?.vote,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<PollVoteResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/activities/{activity_id}/polls/{poll_id}/vote',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.PollVoteResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deletePollVote(request: {
-    activity_id: string;
-    poll_id: string;
-    vote_id: string;
-    user_id?: string;
-  }): Promise<StreamResponse<PollVoteResponse>> {
-    const queryParams = {
-      user_id: request?.user_id,
-    };
-    const pathParams = {
-      activity_id: request?.activity_id,
-      poll_id: request?.poll_id,
-      vote_id: request?.vote_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<PollVoteResponse>
-    >(
-      'DELETE',
-      '/api/v2/feeds/activities/{activity_id}/polls/{poll_id}/vote/{vote_id}',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.PollVoteResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async addActivityReaction(
-    request: AddReactionRequest & { activity_id: string },
-  ): Promise<StreamResponse<AddReactionResponse>> {
-    const pathParams = {
-      activity_id: request?.activity_id,
-    };
-    const body = {
-      type: request?.type,
-      copy_custom_to_notification: request?.copy_custom_to_notification,
-      create_notification_activity: request?.create_notification_activity,
-      enforce_unique: request?.enforce_unique,
-      skip_push: request?.skip_push,
-      custom: request?.custom,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<AddReactionResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/activities/{activity_id}/reactions',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.AddReactionResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryActivityReactions(
-    request: QueryActivityReactionsRequest & { activity_id: string },
-  ): Promise<StreamResponse<QueryActivityReactionsResponse>> {
-    const pathParams = {
-      activity_id: request?.activity_id,
-    };
-    const body = {
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryActivityReactionsResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/activities/{activity_id}/reactions/query',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryActivityReactionsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteActivityReaction(request: {
-    activity_id: string;
-    type: string;
-    delete_notification_activity?: boolean;
-  }): Promise<StreamResponse<DeleteActivityReactionResponse>> {
-    const queryParams = {
-      delete_notification_activity: request?.delete_notification_activity,
-    };
-    const pathParams = {
-      activity_id: request?.activity_id,
-      type: request?.type,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteActivityReactionResponse>
-    >(
-      'DELETE',
-      '/api/v2/feeds/activities/{activity_id}/reactions/{type}',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.DeleteActivityReactionResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteActivity(request: {
-    id: string;
-    hard_delete?: boolean;
-    delete_notification_activity?: boolean;
-  }): Promise<StreamResponse<DeleteActivityResponse>> {
-    const queryParams = {
-      hard_delete: request?.hard_delete,
-      delete_notification_activity: request?.delete_notification_activity,
-    };
-    const pathParams = {
-      id: request?.id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteActivityResponse>
-    >('DELETE', '/api/v2/feeds/activities/{id}', pathParams, queryParams);
-
-    decoders.DeleteActivityResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getActivity(request: {
-    id: string;
-  }): Promise<StreamResponse<GetActivityResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetActivityResponse>
-    >('GET', '/api/v2/feeds/activities/{id}', pathParams, undefined);
-
-    decoders.GetActivityResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateActivityPartial(
-    request: UpdateActivityPartialRequest & { id: string },
-  ): Promise<StreamResponse<UpdateActivityPartialResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-    const body = {
-      copy_custom_to_notification: request?.copy_custom_to_notification,
-      enrich_own_fields: request?.enrich_own_fields,
-      handle_mention_notifications: request?.handle_mention_notifications,
-      run_activity_processors: request?.run_activity_processors,
-      unset: request?.unset,
-      set: request?.set,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateActivityPartialResponse>
-    >(
-      'PATCH',
-      '/api/v2/feeds/activities/{id}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateActivityPartialResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateActivity(
-    request: UpdateActivityRequest & { id: string },
-  ): Promise<StreamResponse<UpdateActivityResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-    const body = {
-      copy_custom_to_notification: request?.copy_custom_to_notification,
-      enrich_own_fields: request?.enrich_own_fields,
-      expires_at: request?.expires_at,
-      handle_mention_notifications: request?.handle_mention_notifications,
-      poll_id: request?.poll_id,
-      restrict_replies: request?.restrict_replies,
-      run_activity_processors: request?.run_activity_processors,
-      skip_enrich_url: request?.skip_enrich_url,
-      text: request?.text,
-      visibility: request?.visibility,
-      visibility_tag: request?.visibility_tag,
-      attachments: request?.attachments,
-      collection_refs: request?.collection_refs,
-      feeds: request?.feeds,
-      filter_tags: request?.filter_tags,
-      interest_tags: request?.interest_tags,
-      mentioned_user_ids: request?.mentioned_user_ids,
-      custom: request?.custom,
-      location: request?.location,
-      search_data: request?.search_data,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateActivityResponse>
-    >(
-      'PUT',
-      '/api/v2/feeds/activities/{id}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateActivityResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async restoreActivity(
-    request: RestoreActivityRequest & {
-      id: string;
-      enrich_own_fields?: boolean;
-    },
-  ): Promise<StreamResponse<RestoreActivityResponse>> {
-    const queryParams = {
-      enrich_own_fields: request?.enrich_own_fields,
-    };
-    const pathParams = {
-      id: request?.id,
-    };
-    const body = {};
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<RestoreActivityResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/activities/{id}/restore',
-      pathParams,
-      queryParams,
-      body,
-      'application/json',
-    );
-
-    decoders.RestoreActivityResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryBookmarkFolders(
-    request?: QueryBookmarkFoldersRequest,
-  ): Promise<StreamResponse<QueryBookmarkFoldersResponse>> {
-    const body = {
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryBookmarkFoldersResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/bookmark_folders/query',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryBookmarkFoldersResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteBookmarkFolder(request: {
-    folder_id: string;
-  }): Promise<StreamResponse<DeleteBookmarkFolderResponse>> {
-    const pathParams = {
-      folder_id: request?.folder_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteBookmarkFolderResponse>
-    >(
-      'DELETE',
-      '/api/v2/feeds/bookmark_folders/{folder_id}',
-      pathParams,
-      undefined,
-    );
-
-    decoders.DeleteBookmarkFolderResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateBookmarkFolder(
-    request: UpdateBookmarkFolderRequest & { folder_id: string },
-  ): Promise<StreamResponse<UpdateBookmarkFolderResponse>> {
-    const pathParams = {
-      folder_id: request?.folder_id,
-    };
-    const body = {
-      name: request?.name,
-      custom: request?.custom,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateBookmarkFolderResponse>
-    >(
-      'PATCH',
-      '/api/v2/feeds/bookmark_folders/{folder_id}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateBookmarkFolderResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryBookmarks(
-    request?: QueryBookmarksRequest,
-  ): Promise<StreamResponse<QueryBookmarksResponse>> {
-    const body = {
-      enrich_own_fields: request?.enrich_own_fields,
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryBookmarksResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/bookmarks/query',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryBookmarksResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteCollections(request: {
-    collection_refs: string[];
-  }): Promise<StreamResponse<DeleteCollectionsResponse>> {
-    const queryParams = {
-      collection_refs: request?.collection_refs,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteCollectionsResponse>
-    >('DELETE', '/api/v2/feeds/collections', undefined, queryParams);
-
-    decoders.DeleteCollectionsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async readCollections(request?: {
-    collection_refs?: string[];
-  }): Promise<StreamResponse<ReadCollectionsResponse>> {
-    const queryParams = {
-      collection_refs: request?.collection_refs,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<ReadCollectionsResponse>
-    >('GET', '/api/v2/feeds/collections', undefined, queryParams);
-
-    decoders.ReadCollectionsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateCollections(
-    request: UpdateCollectionsRequest,
-  ): Promise<StreamResponse<UpdateCollectionsResponse>> {
-    const body = {
-      collections: request?.collections,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateCollectionsResponse>
-    >(
-      'PATCH',
-      '/api/v2/feeds/collections',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateCollectionsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async createCollections(
-    request: CreateCollectionsRequest,
-  ): Promise<StreamResponse<CreateCollectionsResponse>> {
-    const body = {
-      collections: request?.collections,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<CreateCollectionsResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/collections',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.CreateCollectionsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryCollections(
-    request?: QueryCollectionsRequest,
-  ): Promise<StreamResponse<QueryCollectionsResponse>> {
-    const body = {
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryCollectionsResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/collections/query',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryCollectionsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getComments(request: {
-    object_id: string;
-    object_type: string;
-    depth?: number;
-    sort?: string;
-    replies_limit?: number;
-    id_around?: string;
-    limit?: number;
-    prev?: string;
-    next?: string;
-  }): Promise<StreamResponse<GetCommentsResponse>> {
-    const queryParams = {
-      object_id: request?.object_id,
-      object_type: request?.object_type,
-      depth: request?.depth,
-      sort: request?.sort,
-      replies_limit: request?.replies_limit,
-      id_around: request?.id_around,
-      limit: request?.limit,
-      prev: request?.prev,
-      next: request?.next,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetCommentsResponse>
-    >('GET', '/api/v2/feeds/comments', undefined, queryParams);
-
-    decoders.GetCommentsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async addComment(
-    request?: AddCommentRequest,
-  ): Promise<StreamResponse<AddCommentResponse>> {
-    const body = {
-      comment: request?.comment,
-      copy_custom_to_notification: request?.copy_custom_to_notification,
-      create_notification_activity: request?.create_notification_activity,
-      id: request?.id,
-      object_id: request?.object_id,
-      object_type: request?.object_type,
-      parent_id: request?.parent_id,
-      skip_enrich_url: request?.skip_enrich_url,
-      skip_push: request?.skip_push,
-      attachments: request?.attachments,
-      mentioned_user_ids: request?.mentioned_user_ids,
-      custom: request?.custom,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<AddCommentResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/comments',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.AddCommentResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async addCommentsBatch(
-    request: AddCommentsBatchRequest,
-  ): Promise<StreamResponse<AddCommentsBatchResponse>> {
-    const body = {
-      comments: request?.comments,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<AddCommentsBatchResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/comments/batch',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.AddCommentsBatchResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryComments(
-    request: QueryCommentsRequest,
-  ): Promise<StreamResponse<QueryCommentsResponse>> {
-    const body = {
-      filter: request?.filter,
-      id_around: request?.id_around,
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryCommentsResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/comments/query',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryCommentsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteCommentBookmark(request: {
-    comment_id: string;
-    folder_id?: string;
-  }): Promise<StreamResponse<DeleteCommentBookmarkResponse>> {
-    const queryParams = {
-      folder_id: request?.folder_id,
-    };
-    const pathParams = {
-      comment_id: request?.comment_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteCommentBookmarkResponse>
-    >(
-      'DELETE',
-      '/api/v2/feeds/comments/{comment_id}/bookmarks',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.DeleteCommentBookmarkResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateCommentBookmark(
-    request: UpdateCommentBookmarkRequest & { comment_id: string },
-  ): Promise<StreamResponse<UpdateCommentBookmarkResponse>> {
-    const pathParams = {
-      comment_id: request?.comment_id,
-    };
-    const body = {
-      folder_id: request?.folder_id,
-      new_folder_id: request?.new_folder_id,
-      custom: request?.custom,
-      new_folder: request?.new_folder,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateCommentBookmarkResponse>
-    >(
-      'PATCH',
-      '/api/v2/feeds/comments/{comment_id}/bookmarks',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateCommentBookmarkResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async addCommentBookmark(
-    request: AddCommentBookmarkRequest & { comment_id: string },
-  ): Promise<StreamResponse<AddCommentBookmarkResponse>> {
-    const pathParams = {
-      comment_id: request?.comment_id,
-    };
-    const body = {
-      folder_id: request?.folder_id,
-      custom: request?.custom,
-      new_folder: request?.new_folder,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<AddCommentBookmarkResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/comments/{comment_id}/bookmarks',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.AddCommentBookmarkResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteComment(request: {
-    id: string;
-    hard_delete?: boolean;
-    delete_notification_activity?: boolean;
-  }): Promise<StreamResponse<DeleteCommentResponse>> {
-    const queryParams = {
-      hard_delete: request?.hard_delete,
-      delete_notification_activity: request?.delete_notification_activity,
-    };
-    const pathParams = {
-      id: request?.id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteCommentResponse>
-    >('DELETE', '/api/v2/feeds/comments/{id}', pathParams, queryParams);
-
-    decoders.DeleteCommentResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getComment(request: {
-    id: string;
-  }): Promise<StreamResponse<GetCommentResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetCommentResponse>
-    >('GET', '/api/v2/feeds/comments/{id}', pathParams, undefined);
-
-    decoders.GetCommentResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateComment(
-    request: UpdateCommentRequest & { id: string },
-  ): Promise<StreamResponse<UpdateCommentResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-    const body = {
-      comment: request?.comment,
-      copy_custom_to_notification: request?.copy_custom_to_notification,
-      handle_mention_notifications: request?.handle_mention_notifications,
-      skip_enrich_url: request?.skip_enrich_url,
-      skip_push: request?.skip_push,
-      attachments: request?.attachments,
-      mentioned_user_ids: request?.mentioned_user_ids,
-      custom: request?.custom,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateCommentResponse>
-    >(
-      'PATCH',
-      '/api/v2/feeds/comments/{id}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateCommentResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateCommentPartial(
-    request: UpdateCommentPartialRequest & { id: string },
-  ): Promise<StreamResponse<UpdateCommentPartialResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-    const body = {
-      copy_custom_to_notification: request?.copy_custom_to_notification,
-      handle_mention_notifications: request?.handle_mention_notifications,
-      skip_enrich_url: request?.skip_enrich_url,
-      skip_push: request?.skip_push,
-      unset: request?.unset,
-      set: request?.set,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateCommentPartialResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/comments/{id}/partial',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateCommentPartialResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async addCommentReaction(
-    request: AddCommentReactionRequest & { id: string },
-  ): Promise<StreamResponse<AddCommentReactionResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-    const body = {
-      type: request?.type,
-      copy_custom_to_notification: request?.copy_custom_to_notification,
-      create_notification_activity: request?.create_notification_activity,
-      enforce_unique: request?.enforce_unique,
-      skip_push: request?.skip_push,
-      custom: request?.custom,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<AddCommentReactionResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/comments/{id}/reactions',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.AddCommentReactionResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryCommentReactions(
-    request: QueryCommentReactionsRequest & { id: string },
-  ): Promise<StreamResponse<QueryCommentReactionsResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-    const body = {
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryCommentReactionsResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/comments/{id}/reactions/query',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryCommentReactionsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteCommentReaction(request: {
-    id: string;
-    type: string;
-    delete_notification_activity?: boolean;
-  }): Promise<StreamResponse<DeleteCommentReactionResponse>> {
-    const queryParams = {
-      delete_notification_activity: request?.delete_notification_activity,
-    };
-    const pathParams = {
-      id: request?.id,
-      type: request?.type,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteCommentReactionResponse>
-    >(
-      'DELETE',
-      '/api/v2/feeds/comments/{id}/reactions/{type}',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.DeleteCommentReactionResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getCommentReplies(request: {
-    id: string;
-    depth?: number;
-    sort?: string;
-    replies_limit?: number;
-    id_around?: string;
-    limit?: number;
-    prev?: string;
-    next?: string;
-  }): Promise<StreamResponse<GetCommentRepliesResponse>> {
-    const queryParams = {
-      depth: request?.depth,
-      sort: request?.sort,
-      replies_limit: request?.replies_limit,
-      id_around: request?.id_around,
-      limit: request?.limit,
-      prev: request?.prev,
-      next: request?.next,
-    };
-    const pathParams = {
-      id: request?.id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetCommentRepliesResponse>
-    >('GET', '/api/v2/feeds/comments/{id}/replies', pathParams, queryParams);
-
-    decoders.GetCommentRepliesResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async restoreComment(
-    request: RestoreCommentRequest & { id: string },
-  ): Promise<StreamResponse<RestoreCommentResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-    const body = {};
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<RestoreCommentResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/comments/{id}/restore',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.RestoreCommentResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteFeed(request: {
-    feed_group_id: string;
-    feed_id: string;
-    hard_delete?: boolean;
-  }): Promise<StreamResponse<DeleteFeedResponse>> {
-    const queryParams = {
-      hard_delete: request?.hard_delete,
-    };
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-      feed_id: request?.feed_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteFeedResponse>
-    >(
-      'DELETE',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.DeleteFeedResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getOrCreateFeed(
-    request: GetOrCreateFeedRequest & {
-      feed_group_id: string;
-      feed_id: string;
-      connection_id?: string;
-    },
-  ): Promise<StreamResponse<GetOrCreateFeedResponse>> {
-    const queryParams = {
-      connection_id: request?.connection_id,
-    };
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-      feed_id: request?.feed_id,
-    };
-    const body = {
-      id_around: request?.id_around,
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      view: request?.view,
-      watch: request?.watch,
-      data: request?.data,
-      enrichment_options: request?.enrichment_options,
-      external_ranking: request?.external_ranking,
-      filter: request?.filter,
-      followers_pagination: request?.followers_pagination,
-      following_pagination: request?.following_pagination,
-      friend_reactions_options: request?.friend_reactions_options,
-      interest_weights: request?.interest_weights,
-      member_pagination: request?.member_pagination,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetOrCreateFeedResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}',
-      pathParams,
-      queryParams,
-      body,
-      'application/json',
-    );
-
-    decoders.GetOrCreateFeedResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateFeed(
-    request: UpdateFeedRequest & { feed_group_id: string; feed_id: string },
-  ): Promise<StreamResponse<UpdateFeedResponse>> {
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-      feed_id: request?.feed_id,
-    };
-    const body = {
-      clear_location: request?.clear_location,
-      description: request?.description,
-      enrich_own_fields: request?.enrich_own_fields,
-      name: request?.name,
-      filter_tags: request?.filter_tags,
-      custom: request?.custom,
-      location: request?.location,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateFeedResponse>
-    >(
-      'PUT',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateFeedResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async markActivity(
-    request: MarkActivityRequest & { feed_group_id: string; feed_id: string },
-  ): Promise<StreamResponse<Response>> {
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-      feed_id: request?.feed_id,
-    };
-    const body = {
-      mark_all_read: request?.mark_all_read,
-      mark_all_seen: request?.mark_all_seen,
-      mark_read: request?.mark_read,
-      mark_seen: request?.mark_seen,
-      mark_watched: request?.mark_watched,
-    };
-
-    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
-      'POST',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/mark/batch',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.Response?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async unpinActivity(request: {
-    feed_group_id: string;
-    feed_id: string;
-    activity_id: string;
-    enrich_own_fields?: boolean;
-  }): Promise<StreamResponse<UnpinActivityResponse>> {
-    const queryParams = {
-      enrich_own_fields: request?.enrich_own_fields,
-    };
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-      feed_id: request?.feed_id,
-      activity_id: request?.activity_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UnpinActivityResponse>
-    >(
-      'DELETE',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/{activity_id}/pin',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.UnpinActivityResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async pinActivity(
-    request: PinActivityRequest & {
-      feed_group_id: string;
-      feed_id: string;
-      activity_id: string;
-    },
-  ): Promise<StreamResponse<PinActivityResponse>> {
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-      feed_id: request?.feed_id,
-      activity_id: request?.activity_id,
-    };
-    const body = {
-      enrich_own_fields: request?.enrich_own_fields,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<PinActivityResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/{activity_id}/pin',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.PinActivityResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateFeedMembers(
-    request: UpdateFeedMembersRequest & {
-      feed_group_id: string;
-      feed_id: string;
-    },
-  ): Promise<StreamResponse<UpdateFeedMembersResponse>> {
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-      feed_id: request?.feed_id,
-    };
-    const body = {
-      operation: request?.operation,
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      members: request?.members,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateFeedMembersResponse>
-    >(
-      'PATCH',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateFeedMembersResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async acceptFeedMemberInvite(
-    request: AcceptFeedMemberInviteRequest & {
-      feed_id: string;
-      feed_group_id: string;
-    },
-  ): Promise<StreamResponse<AcceptFeedMemberInviteResponse>> {
-    const pathParams = {
-      feed_id: request?.feed_id,
-      feed_group_id: request?.feed_group_id,
-    };
-    const body = {};
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<AcceptFeedMemberInviteResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/accept',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.AcceptFeedMemberInviteResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryFeedMembers(
-    request: QueryFeedMembersRequest & {
-      feed_group_id: string;
-      feed_id: string;
-    },
-  ): Promise<StreamResponse<QueryFeedMembersResponse>> {
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-      feed_id: request?.feed_id,
-    };
-    const body = {
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryFeedMembersResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/query',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryFeedMembersResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async rejectFeedMemberInvite(
-    request: RejectFeedMemberInviteRequest & {
-      feed_group_id: string;
-      feed_id: string;
-    },
-  ): Promise<StreamResponse<RejectFeedMemberInviteResponse>> {
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-      feed_id: request?.feed_id,
-    };
-    const body = {};
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<RejectFeedMemberInviteResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/reject',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.RejectFeedMemberInviteResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryPinnedActivities(
-    request: QueryPinnedActivitiesRequest & {
-      feed_group_id: string;
-      feed_id: string;
-    },
-  ): Promise<StreamResponse<QueryPinnedActivitiesResponse>> {
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-      feed_id: request?.feed_id,
-    };
-    const body = {
-      enrich_own_fields: request?.enrich_own_fields,
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryPinnedActivitiesResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/pinned_activities/query',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryPinnedActivitiesResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async stopWatchingFeed(request: {
-    feed_group_id: string;
-    feed_id: string;
-    connection_id?: string;
-  }): Promise<StreamResponse<Response>> {
-    const queryParams = {
-      connection_id: request?.connection_id,
-    };
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-      feed_id: request?.feed_id,
-    };
-
-    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
-      'DELETE',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/watch',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.Response?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getFollowSuggestions(request: {
-    feed_group_id: string;
-    limit?: number;
-  }): Promise<StreamResponse<GetFollowSuggestionsResponse>> {
-    const queryParams = {
-      limit: request?.limit,
-    };
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetFollowSuggestionsResponse>
-    >(
-      'GET',
-      '/api/v2/feeds/feed_groups/{feed_group_id}/follow_suggestions',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.GetFollowSuggestionsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async createFeedsBatch(
-    request: CreateFeedsBatchRequest,
-  ): Promise<StreamResponse<CreateFeedsBatchResponse>> {
-    const body = {
-      feeds: request?.feeds,
-      enrich_own_fields: request?.enrich_own_fields,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<CreateFeedsBatchResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feeds/batch',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.CreateFeedsBatchResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async ownBatch(
-    request: OwnBatchRequest & { connection_id?: string },
-  ): Promise<StreamResponse<OwnBatchResponse>> {
-    const queryParams = {
-      connection_id: request?.connection_id,
-    };
-    const body = {
-      feeds: request?.feeds,
-      fields: request?.fields,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<OwnBatchResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feeds/own/batch',
-      undefined,
-      queryParams,
-      body,
-      'application/json',
-    );
-
-    decoders.OwnBatchResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  protected async _queryFeeds(
-    request?: QueryFeedsRequest & { connection_id?: string },
-  ): Promise<StreamResponse<QueryFeedsResponse>> {
-    const queryParams = {
-      connection_id: request?.connection_id,
-    };
-    const body = {
-      enrich_own_fields: request?.enrich_own_fields,
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      watch: request?.watch,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryFeedsResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feeds/query',
-      undefined,
-      queryParams,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryFeedsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateFollow(
-    request: UpdateFollowRequest,
-  ): Promise<StreamResponse<UpdateFollowResponse>> {
-    const body = {
-      source: request?.source,
-      target: request?.target,
-      activity_copy_limit: request?.activity_copy_limit,
-      copy_custom_to_notification: request?.copy_custom_to_notification,
-      create_notification_activity: request?.create_notification_activity,
-      enrich_own_fields: request?.enrich_own_fields,
-      follower_role: request?.follower_role,
-      push_preference: request?.push_preference,
-      skip_push: request?.skip_push,
-      custom: request?.custom,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateFollowResponse>
-    >(
-      'PATCH',
-      '/api/v2/feeds/follows',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateFollowResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async follow(
-    request: FollowRequest,
-  ): Promise<StreamResponse<SingleFollowResponse>> {
-    const body = {
-      source: request?.source,
-      target: request?.target,
-      activity_copy_limit: request?.activity_copy_limit,
-      copy_custom_to_notification: request?.copy_custom_to_notification,
-      create_notification_activity: request?.create_notification_activity,
-      enrich_own_fields: request?.enrich_own_fields,
-      push_preference: request?.push_preference,
-      skip_push: request?.skip_push,
-      custom: request?.custom,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<SingleFollowResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/follows',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.SingleFollowResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async acceptFollow(
-    request: AcceptFollowRequest,
-  ): Promise<StreamResponse<AcceptFollowResponse>> {
-    const body = {
-      source: request?.source,
-      target: request?.target,
-      follower_role: request?.follower_role,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<AcceptFollowResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/follows/accept',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.AcceptFollowResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async followBatch(
-    request: FollowBatchRequest,
-  ): Promise<StreamResponse<FollowBatchResponse>> {
-    const body = {
-      follows: request?.follows,
-      enrich_own_fields: request?.enrich_own_fields,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<FollowBatchResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/follows/batch',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.FollowBatchResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getOrCreateFollows(
-    request: FollowBatchRequest,
-  ): Promise<StreamResponse<FollowBatchResponse>> {
-    const body = {
-      follows: request?.follows,
-      enrich_own_fields: request?.enrich_own_fields,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<FollowBatchResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/follows/batch/upsert',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.FollowBatchResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryFollows(
-    request?: QueryFollowsRequest,
-  ): Promise<StreamResponse<QueryFollowsResponse>> {
-    const body = {
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryFollowsResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/follows/query',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryFollowsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async rejectFollow(
-    request: RejectFollowRequest,
-  ): Promise<StreamResponse<RejectFollowResponse>> {
-    const body = {
-      source: request?.source,
-      target: request?.target,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<RejectFollowResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/follows/reject',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.RejectFollowResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async unfollow(request: {
-    source: string;
-    target: string;
-    delete_notification_activity?: boolean;
-    keep_history?: boolean;
-    enrich_own_fields?: boolean;
-  }): Promise<StreamResponse<UnfollowResponse>> {
-    const queryParams = {
-      delete_notification_activity: request?.delete_notification_activity,
-      keep_history: request?.keep_history,
-      enrich_own_fields: request?.enrich_own_fields,
-    };
-    const pathParams = {
-      source: request?.source,
-      target: request?.target,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UnfollowResponse>
-    >(
-      'DELETE',
-      '/api/v2/feeds/follows/{source}/{target}',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.UnfollowResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getOrCreateUnfollows(
-    request: UnfollowBatchRequest,
-  ): Promise<StreamResponse<UnfollowBatchResponse>> {
-    const body = {
-      follows: request?.follows,
-      delete_notification_activity: request?.delete_notification_activity,
-      enrich_own_fields: request?.enrich_own_fields,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UnfollowBatchResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/unfollow/batch/upsert',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UnfollowBatchResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async createGuest(
-    request: CreateGuestRequest,
-  ): Promise<StreamResponse<CreateGuestResponse>> {
-    const body = {
-      user: request?.user,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<CreateGuestResponse>
-    >('POST', '/api/v2/guest', undefined, undefined, body, 'application/json');
-
-    decoders.CreateGuestResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async longPoll(request?: {
-    connection_id?: string;
-    json?: WSAuthMessage;
-  }): Promise<StreamResponse<{}>> {
-    const queryParams = {
-      connection_id: request?.connection_id,
-      json: request?.json,
-    };
-
-    const response = await this.apiClient.sendRequest<StreamResponse<{}>>(
-      'GET',
-      '/api/v2/longpoll',
-      undefined,
-      queryParams,
-    );
-
-    decoders['{}']?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getOG(request: {
-    url: string;
-  }): Promise<StreamResponse<GetOGResponse>> {
-    const queryParams = {
-      url: request?.url,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetOGResponse>
-    >('GET', '/api/v2/og', undefined, queryParams);
-
-    decoders.GetOGResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async createPoll(
-    request: CreatePollRequest,
-  ): Promise<StreamResponse<PollResponse>> {
-    const body = {
-      name: request?.name,
-      allow_answers: request?.allow_answers,
-      allow_user_suggested_options: request?.allow_user_suggested_options,
-      description: request?.description,
-      enforce_unique_vote: request?.enforce_unique_vote,
-      id: request?.id,
-      is_closed: request?.is_closed,
-      max_votes_allowed: request?.max_votes_allowed,
-      voting_visibility: request?.voting_visibility,
-      options: request?.options,
-      custom: request?.custom,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<PollResponse>
-    >('POST', '/api/v2/polls', undefined, undefined, body, 'application/json');
-
-    decoders.PollResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updatePoll(
-    request: UpdatePollRequest,
-  ): Promise<StreamResponse<PollResponse>> {
-    const body = {
-      id: request?.id,
-      name: request?.name,
-      allow_answers: request?.allow_answers,
-      allow_user_suggested_options: request?.allow_user_suggested_options,
-      description: request?.description,
-      enforce_unique_vote: request?.enforce_unique_vote,
-      is_closed: request?.is_closed,
-      max_votes_allowed: request?.max_votes_allowed,
-      voting_visibility: request?.voting_visibility,
-      options: request?.options,
-      custom: request?.custom,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<PollResponse>
-    >('PUT', '/api/v2/polls', undefined, undefined, body, 'application/json');
-
-    decoders.PollResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryPolls(
-    request?: QueryPollsRequest & { user_id?: string },
-  ): Promise<StreamResponse<QueryPollsResponse>> {
-    const queryParams = {
-      user_id: request?.user_id,
-    };
-    const body = {
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryPollsResponse>
-    >(
-      'POST',
-      '/api/v2/polls/query',
-      undefined,
-      queryParams,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryPollsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deletePoll(request: {
-    poll_id: string;
-    user_id?: string;
-  }): Promise<StreamResponse<Response>> {
-    const queryParams = {
-      user_id: request?.user_id,
-    };
-    const pathParams = {
-      poll_id: request?.poll_id,
-    };
-
-    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
-      'DELETE',
-      '/api/v2/polls/{poll_id}',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.Response?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getPoll(request: {
-    poll_id: string;
-    user_id?: string;
-  }): Promise<StreamResponse<PollResponse>> {
-    const queryParams = {
-      user_id: request?.user_id,
-    };
-    const pathParams = {
-      poll_id: request?.poll_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<PollResponse>
-    >('GET', '/api/v2/polls/{poll_id}', pathParams, queryParams);
-
-    decoders.PollResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updatePollPartial(
-    request: UpdatePollPartialRequest & { poll_id: string },
-  ): Promise<StreamResponse<PollResponse>> {
-    const pathParams = {
-      poll_id: request?.poll_id,
-    };
-    const body = {
-      unset: request?.unset,
-      set: request?.set,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<PollResponse>
-    >(
-      'PATCH',
-      '/api/v2/polls/{poll_id}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.PollResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async createPollOption(
-    request: CreatePollOptionRequest & { poll_id: string },
-  ): Promise<StreamResponse<PollOptionResponse>> {
-    const pathParams = {
-      poll_id: request?.poll_id,
-    };
-    const body = {
-      text: request?.text,
-      custom: request?.custom,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<PollOptionResponse>
-    >(
-      'POST',
-      '/api/v2/polls/{poll_id}/options',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.PollOptionResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updatePollOption(
-    request: UpdatePollOptionRequest & { poll_id: string },
-  ): Promise<StreamResponse<PollOptionResponse>> {
-    const pathParams = {
-      poll_id: request?.poll_id,
-    };
-    const body = {
-      id: request?.id,
-      text: request?.text,
-      custom: request?.custom,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<PollOptionResponse>
-    >(
-      'PUT',
-      '/api/v2/polls/{poll_id}/options',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.PollOptionResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deletePollOption(request: {
-    poll_id: string;
-    option_id: string;
-    user_id?: string;
-  }): Promise<StreamResponse<Response>> {
-    const queryParams = {
-      user_id: request?.user_id,
-    };
-    const pathParams = {
-      poll_id: request?.poll_id,
-      option_id: request?.option_id,
-    };
-
-    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
-      'DELETE',
-      '/api/v2/polls/{poll_id}/options/{option_id}',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.Response?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getPollOption(request: {
-    poll_id: string;
-    option_id: string;
-    user_id?: string;
-  }): Promise<StreamResponse<PollOptionResponse>> {
-    const queryParams = {
-      user_id: request?.user_id,
-    };
-    const pathParams = {
-      poll_id: request?.poll_id,
-      option_id: request?.option_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<PollOptionResponse>
-    >(
-      'GET',
-      '/api/v2/polls/{poll_id}/options/{option_id}',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.PollOptionResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryPollVotes(
-    request: QueryPollVotesRequest & { poll_id: string; user_id?: string },
-  ): Promise<StreamResponse<PollVotesResponse>> {
-    const queryParams = {
-      user_id: request?.user_id,
-    };
-    const pathParams = {
-      poll_id: request?.poll_id,
-    };
-    const body = {
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<PollVotesResponse>
-    >(
-      'POST',
-      '/api/v2/polls/{poll_id}/votes',
-      pathParams,
-      queryParams,
-      body,
-      'application/json',
-    );
-
-    decoders.PollVotesResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updatePushNotificationPreferences(
-    request: UpsertPushPreferencesRequest,
-  ): Promise<StreamResponse<UpsertPushPreferencesResponse>> {
-    const body = {
-      preferences: request?.preferences,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpsertPushPreferencesResponse>
-    >(
-      'POST',
-      '/api/v2/push_preferences',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpsertPushPreferencesResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteFile(request?: {
-    url?: string;
-  }): Promise<StreamResponse<Response>> {
-    const queryParams = {
-      url: request?.url,
-    };
-
-    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
-      'DELETE',
-      '/api/v2/uploads/file',
-      undefined,
-      queryParams,
-    );
-
-    decoders.Response?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async uploadFile(
-    request?: FileUploadRequest,
-  ): Promise<StreamResponse<FileUploadResponse>> {
-    const body = {
-      file: request?.file,
-      user: request?.user,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<FileUploadResponse>
-    >(
-      'POST',
-      '/api/v2/uploads/file',
-      undefined,
-      undefined,
-      body,
-      'multipart/form-data',
-    );
-
-    decoders.FileUploadResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteImage(request?: {
-    url?: string;
-  }): Promise<StreamResponse<Response>> {
-    const queryParams = {
-      url: request?.url,
-    };
-
-    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
-      'DELETE',
-      '/api/v2/uploads/image',
-      undefined,
-      queryParams,
-    );
-
-    decoders.Response?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async uploadImage(
-    request?: ImageUploadRequest,
-  ): Promise<StreamResponse<ImageUploadResponse>> {
-    const body = {
-      file: request?.file,
-      upload_sizes: request?.upload_sizes,
-      user: request?.user,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<ImageUploadResponse>
-    >(
-      'POST',
-      '/api/v2/uploads/image',
-      undefined,
-      undefined,
-      body,
-      'multipart/form-data',
-    );
-
-    decoders.ImageUploadResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async listUserGroups(request?: {
-    limit?: number;
-    id_gt?: string;
-    created_at_gt?: string;
-    team_id?: string;
-  }): Promise<StreamResponse<ListUserGroupsResponse>> {
-    const queryParams = {
-      limit: request?.limit,
-      id_gt: request?.id_gt,
-      created_at_gt: request?.created_at_gt,
-      team_id: request?.team_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<ListUserGroupsResponse>
-    >('GET', '/api/v2/usergroups', undefined, queryParams);
-
-    decoders.ListUserGroupsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async createUserGroup(
-    request: CreateUserGroupRequest,
-  ): Promise<StreamResponse<CreateUserGroupResponse>> {
-    const body = {
-      name: request?.name,
-      description: request?.description,
-      id: request?.id,
-      team_id: request?.team_id,
-      member_ids: request?.member_ids,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<CreateUserGroupResponse>
-    >(
-      'POST',
-      '/api/v2/usergroups',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.CreateUserGroupResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async searchUserGroups(request: {
-    query: string;
-    limit?: number;
-    name_gt?: string;
-    id_gt?: string;
-    team_id?: string;
-  }): Promise<StreamResponse<SearchUserGroupsResponse>> {
-    const queryParams = {
-      query: request?.query,
-      limit: request?.limit,
-      name_gt: request?.name_gt,
-      id_gt: request?.id_gt,
-      team_id: request?.team_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<SearchUserGroupsResponse>
-    >('GET', '/api/v2/usergroups/search', undefined, queryParams);
-
-    decoders.SearchUserGroupsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteUserGroup(request: {
-    id: string;
-    team_id?: string;
-  }): Promise<StreamResponse<Response>> {
-    const queryParams = {
-      team_id: request?.team_id,
-    };
-    const pathParams = {
-      id: request?.id,
-    };
-
-    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
-      'DELETE',
-      '/api/v2/usergroups/{id}',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.Response?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getUserGroup(request: {
-    id: string;
-    team_id?: string;
-  }): Promise<StreamResponse<GetUserGroupResponse>> {
-    const queryParams = {
-      team_id: request?.team_id,
-    };
-    const pathParams = {
-      id: request?.id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetUserGroupResponse>
-    >('GET', '/api/v2/usergroups/{id}', pathParams, queryParams);
-
-    decoders.GetUserGroupResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateUserGroup(
-    request: UpdateUserGroupRequest & { id: string },
-  ): Promise<StreamResponse<UpdateUserGroupResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-    const body = {
-      description: request?.description,
-      name: request?.name,
-      team_id: request?.team_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateUserGroupResponse>
-    >(
-      'PUT',
-      '/api/v2/usergroups/{id}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateUserGroupResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async addUserGroupMembers(
-    request: AddUserGroupMembersRequest & { id: string },
-  ): Promise<StreamResponse<AddUserGroupMembersResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-    const body = {
-      member_ids: request?.member_ids,
-      as_admin: request?.as_admin,
-      team_id: request?.team_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<AddUserGroupMembersResponse>
-    >(
-      'POST',
-      '/api/v2/usergroups/{id}/members',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.AddUserGroupMembersResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async removeUserGroupMembers(
-    request: RemoveUserGroupMembersRequest & { id: string },
-  ): Promise<StreamResponse<RemoveUserGroupMembersResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-    const body = {
-      member_ids: request?.member_ids,
-      team_id: request?.team_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<RemoveUserGroupMembersResponse>
-    >(
-      'POST',
-      '/api/v2/usergroups/{id}/members/delete',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.RemoveUserGroupMembersResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryUsers(request?: {
-    payload?: QueryUsersPayload;
-  }): Promise<StreamResponse<QueryUsersResponse>> {
-    const queryParams = {
-      payload: request?.payload,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryUsersResponse>
-    >('GET', '/api/v2/users', undefined, queryParams);
-
-    decoders.QueryUsersResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateUsersPartial(
-    request: UpdateUsersPartialRequest,
-  ): Promise<StreamResponse<UpdateUsersResponse>> {
-    const body = {
-      users: request?.users,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateUsersResponse>
-    >('PATCH', '/api/v2/users', undefined, undefined, body, 'application/json');
-
-    decoders.UpdateUsersResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateUsers(
-    request: UpdateUsersRequest,
-  ): Promise<StreamResponse<UpdateUsersResponse>> {
-    const body = {
-      users: request?.users,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateUsersResponse>
-    >('POST', '/api/v2/users', undefined, undefined, body, 'application/json');
-
-    decoders.UpdateUsersResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getBlockedUsers(): Promise<StreamResponse<GetBlockedUsersResponse>> {
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetBlockedUsersResponse>
-    >('GET', '/api/v2/users/block', undefined, undefined);
-
-    decoders.GetBlockedUsersResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async blockUsers(
-    request: BlockUsersRequest,
-  ): Promise<StreamResponse<BlockUsersResponse>> {
-    const body = {
-      blocked_user_id: request?.blocked_user_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<BlockUsersResponse>
-    >(
-      'POST',
-      '/api/v2/users/block',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.BlockUsersResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getUserLiveLocations(): Promise<
-    StreamResponse<SharedLocationsResponse>
-  > {
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<SharedLocationsResponse>
-    >('GET', '/api/v2/users/live_locations', undefined, undefined);
-
-    decoders.SharedLocationsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateLiveLocation(
-    request: UpdateLiveLocationRequest,
-  ): Promise<StreamResponse<SharedLocationResponse>> {
-    const body = {
-      message_id: request?.message_id,
-      end_at: request?.end_at,
-      latitude: request?.latitude,
-      longitude: request?.longitude,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<SharedLocationResponse>
-    >(
-      'PUT',
-      '/api/v2/users/live_locations',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.SharedLocationResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async unblockUsers(
-    request: UnblockUsersRequest,
-  ): Promise<StreamResponse<UnblockUsersResponse>> {
-    const body = {
-      blocked_user_id: request?.blocked_user_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UnblockUsersResponse>
-    >(
-      'POST',
-      '/api/v2/users/unblock',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UnblockUsersResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
+      return {...response.body, metadata: response.metadata};
 }
+    
+    async listBlockLists (request?: 
+    
+    
+    {team?: string,
+    }
+    ): Promise<StreamResponse<ListBlockListResponse>> {
+        
+        const queryParams = {
+          team: request?.team,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<ListBlockListResponse>>('GET', '/api/v2/blocklists',  undefined , queryParams  );
+
+       decoders["ListBlockListResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async createBlockList (request: CreateBlockListRequest 
+    
+    ): Promise<StreamResponse<CreateBlockListResponse>> {
+        const body = {
+          name: request?.name,words: request?.words,is_leet_check_enabled: request?.is_leet_check_enabled,is_plural_check_enabled: request?.is_plural_check_enabled,team: request?.team,type: request?.type,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<CreateBlockListResponse>>('POST', '/api/v2/blocklists',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["CreateBlockListResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteBlockList (request: 
+    
+    
+    {name: string,team?: string,
+    }
+    ): Promise<StreamResponse<Response>> {
+        
+        const queryParams = {
+          team: request?.team,
+        };
+        const pathParams = {
+          name: request?.name,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/blocklists/{name}', pathParams , queryParams  );
+
+       decoders["Response"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateBlockList (request: UpdateBlockListRequest 
+     & 
+    
+    {name: string,
+    }
+    ): Promise<StreamResponse<UpdateBlockListResponse>> {
+        const pathParams = {
+          name: request?.name,
+        };
+        const body = {
+          is_leet_check_enabled: request?.is_leet_check_enabled,is_plural_check_enabled: request?.is_plural_check_enabled,team: request?.team,words: request?.words,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateBlockListResponse>>('PUT', '/api/v2/blocklists/{name}', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["UpdateBlockListResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteDevice (request: 
+    
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<Response>> {
+        
+        const queryParams = {
+          id: request?.id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/devices',  undefined , queryParams  );
+
+       decoders["Response"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async listDevices (): Promise<StreamResponse<ListDevicesResponse>> {
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<ListDevicesResponse>>('GET', '/api/v2/devices',  undefined ,  undefined  );
+
+       decoders["ListDevicesResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async createDevice (request: CreateDeviceRequest 
+    
+    ): Promise<StreamResponse<Response>> {
+        const body = {
+          id: request?.id,push_provider: request?.push_provider,push_provider_name: request?.push_provider_name,voip_token: request?.voip_token,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('POST', '/api/v2/devices',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["Response"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async addActivity (request: AddActivityRequest 
+    
+    ): Promise<StreamResponse<AddActivityResponse>> {
+        const body = {
+          type: request?.type,feeds: request?.feeds,copy_custom_to_notification: request?.copy_custom_to_notification,create_notification_activity: request?.create_notification_activity,enrich_own_fields: request?.enrich_own_fields,expires_at: request?.expires_at,id: request?.id,parent_id: request?.parent_id,poll_id: request?.poll_id,restrict_replies: request?.restrict_replies,skip_enrich_url: request?.skip_enrich_url,skip_push: request?.skip_push,text: request?.text,visibility: request?.visibility,visibility_tag: request?.visibility_tag,attachments: request?.attachments,collection_refs: request?.collection_refs,filter_tags: request?.filter_tags,interest_tags: request?.interest_tags,mentioned_user_ids: request?.mentioned_user_ids,custom: request?.custom,location: request?.location,search_data: request?.search_data,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<AddActivityResponse>>('POST', '/api/v2/feeds/activities',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["AddActivityResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async upsertActivities (request: UpsertActivitiesRequest 
+    
+    ): Promise<StreamResponse<UpsertActivitiesResponse>> {
+        const body = {
+          activities: request?.activities,enrich_own_fields: request?.enrich_own_fields,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpsertActivitiesResponse>>('POST', '/api/v2/feeds/activities/batch',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["UpsertActivitiesResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteActivities (request: DeleteActivitiesRequest 
+    
+    ): Promise<StreamResponse<DeleteActivitiesResponse>> {
+        const body = {
+          ids: request?.ids,delete_notification_activity: request?.delete_notification_activity,hard_delete: request?.hard_delete,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<DeleteActivitiesResponse>>('POST', '/api/v2/feeds/activities/delete',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["DeleteActivitiesResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async trackActivityMetrics (request: TrackActivityMetricsRequest 
+    
+    ): Promise<StreamResponse<TrackActivityMetricsResponse>> {
+        const body = {
+          events: request?.events,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<TrackActivityMetricsResponse>>('POST', '/api/v2/feeds/activities/metrics/track',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["TrackActivityMetricsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryActivities (request?: QueryActivitiesRequest 
+    
+    ): Promise<StreamResponse<QueryActivitiesResponse>> {
+        const body = {
+          enrich_own_fields: request?.enrich_own_fields,include_soft_deleted_activities: request?.include_soft_deleted_activities,limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryActivitiesResponse>>('POST', '/api/v2/feeds/activities/query',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["QueryActivitiesResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteBookmark (request: 
+    
+    
+    {activity_id: string,folder_id?: string,
+    }
+    ): Promise<StreamResponse<DeleteBookmarkResponse>> {
+        
+        const queryParams = {
+          folder_id: request?.folder_id,
+        };
+        const pathParams = {
+          activity_id: request?.activity_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<DeleteBookmarkResponse>>('DELETE', '/api/v2/feeds/activities/{activity_id}/bookmarks', pathParams , queryParams  );
+
+       decoders["DeleteBookmarkResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateBookmark (request: UpdateBookmarkRequest 
+     & 
+    
+    {activity_id: string,
+    }
+    ): Promise<StreamResponse<UpdateBookmarkResponse>> {
+        const pathParams = {
+          activity_id: request?.activity_id,
+        };
+        const body = {
+          folder_id: request?.folder_id,new_folder_id: request?.new_folder_id,custom: request?.custom,new_folder: request?.new_folder,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateBookmarkResponse>>('PATCH', '/api/v2/feeds/activities/{activity_id}/bookmarks', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["UpdateBookmarkResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async addBookmark (request: AddBookmarkRequest 
+     & 
+    
+    {activity_id: string,
+    }
+    ): Promise<StreamResponse<AddBookmarkResponse>> {
+        const pathParams = {
+          activity_id: request?.activity_id,
+        };
+        const body = {
+          folder_id: request?.folder_id,custom: request?.custom,new_folder: request?.new_folder,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<AddBookmarkResponse>>('POST', '/api/v2/feeds/activities/{activity_id}/bookmarks', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["AddBookmarkResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async activityFeedback (request: ActivityFeedbackRequest 
+     & 
+    
+    {activity_id: string,
+    }
+    ): Promise<StreamResponse<ActivityFeedbackResponse>> {
+        const pathParams = {
+          activity_id: request?.activity_id,
+        };
+        const body = {
+          hide: request?.hide,show_less: request?.show_less,show_more: request?.show_more,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<ActivityFeedbackResponse>>('POST', '/api/v2/feeds/activities/{activity_id}/feedback', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["ActivityFeedbackResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async castPollVote (request: CastPollVoteRequest 
+     & 
+    
+    {activity_id: string,poll_id: string,
+    }
+    ): Promise<StreamResponse<PollVoteResponse>> {
+        const pathParams = {
+          activity_id: request?.activity_id, poll_id: request?.poll_id,
+        };
+        const body = {
+          vote: request?.vote,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<PollVoteResponse>>('POST', '/api/v2/feeds/activities/{activity_id}/polls/{poll_id}/vote', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["PollVoteResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deletePollVote (request: 
+    
+    
+    {activity_id: string,poll_id: string,vote_id: string,user_id?: string,
+    }
+    ): Promise<StreamResponse<PollVoteResponse>> {
+        
+        const queryParams = {
+          user_id: request?.user_id,
+        };
+        const pathParams = {
+          activity_id: request?.activity_id, poll_id: request?.poll_id, vote_id: request?.vote_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<PollVoteResponse>>('DELETE', '/api/v2/feeds/activities/{activity_id}/polls/{poll_id}/vote/{vote_id}', pathParams , queryParams  );
+
+       decoders["PollVoteResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async addActivityReaction (request: AddReactionRequest 
+     & 
+    
+    {activity_id: string,
+    }
+    ): Promise<StreamResponse<AddReactionResponse>> {
+        const pathParams = {
+          activity_id: request?.activity_id,
+        };
+        const body = {
+          type: request?.type,copy_custom_to_notification: request?.copy_custom_to_notification,create_notification_activity: request?.create_notification_activity,enforce_unique: request?.enforce_unique,skip_push: request?.skip_push,custom: request?.custom,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<AddReactionResponse>>('POST', '/api/v2/feeds/activities/{activity_id}/reactions', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["AddReactionResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryActivityReactions (request: QueryActivityReactionsRequest 
+     & 
+    
+    {activity_id: string,
+    }
+    ): Promise<StreamResponse<QueryActivityReactionsResponse>> {
+        const pathParams = {
+          activity_id: request?.activity_id,
+        };
+        const body = {
+          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryActivityReactionsResponse>>('POST', '/api/v2/feeds/activities/{activity_id}/reactions/query', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["QueryActivityReactionsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteActivityReaction (request: 
+    
+    
+    {activity_id: string,type: string,delete_notification_activity?: boolean,
+    }
+    ): Promise<StreamResponse<DeleteActivityReactionResponse>> {
+        
+        const queryParams = {
+          delete_notification_activity: request?.delete_notification_activity,
+        };
+        const pathParams = {
+          activity_id: request?.activity_id, type: request?.type,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<DeleteActivityReactionResponse>>('DELETE', '/api/v2/feeds/activities/{activity_id}/reactions/{type}', pathParams , queryParams  );
+
+       decoders["DeleteActivityReactionResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteActivity (request: 
+    
+    
+    {id: string,hard_delete?: boolean,delete_notification_activity?: boolean,
+    }
+    ): Promise<StreamResponse<DeleteActivityResponse>> {
+        
+        const queryParams = {
+          hard_delete: request?.hard_delete, delete_notification_activity: request?.delete_notification_activity,
+        };
+        const pathParams = {
+          id: request?.id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<DeleteActivityResponse>>('DELETE', '/api/v2/feeds/activities/{id}', pathParams , queryParams  );
+
+       decoders["DeleteActivityResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getActivity (request: 
+    
+    
+    {id: string,comment_sort?: string,comment_limit?: number,
+    }
+    ): Promise<StreamResponse<GetActivityResponse>> {
+        
+        const queryParams = {
+          comment_sort: request?.comment_sort, comment_limit: request?.comment_limit,
+        };
+        const pathParams = {
+          id: request?.id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<GetActivityResponse>>('GET', '/api/v2/feeds/activities/{id}', pathParams , queryParams  );
+
+       decoders["GetActivityResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateActivityPartial (request: UpdateActivityPartialRequest 
+     & 
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<UpdateActivityPartialResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        const body = {
+          copy_custom_to_notification: request?.copy_custom_to_notification,enrich_own_fields: request?.enrich_own_fields,handle_mention_notifications: request?.handle_mention_notifications,run_activity_processors: request?.run_activity_processors,unset: request?.unset,set: request?.set,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateActivityPartialResponse>>('PATCH', '/api/v2/feeds/activities/{id}', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["UpdateActivityPartialResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateActivity (request: UpdateActivityRequest 
+     & 
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<UpdateActivityResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        const body = {
+          copy_custom_to_notification: request?.copy_custom_to_notification,enrich_own_fields: request?.enrich_own_fields,expires_at: request?.expires_at,handle_mention_notifications: request?.handle_mention_notifications,poll_id: request?.poll_id,restrict_replies: request?.restrict_replies,run_activity_processors: request?.run_activity_processors,skip_enrich_url: request?.skip_enrich_url,text: request?.text,visibility: request?.visibility,visibility_tag: request?.visibility_tag,attachments: request?.attachments,collection_refs: request?.collection_refs,feeds: request?.feeds,filter_tags: request?.filter_tags,interest_tags: request?.interest_tags,mentioned_user_ids: request?.mentioned_user_ids,custom: request?.custom,location: request?.location,search_data: request?.search_data,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateActivityResponse>>('PUT', '/api/v2/feeds/activities/{id}', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["UpdateActivityResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async restoreActivity (request: RestoreActivityRequest 
+     & 
+    
+    {id: string,enrich_own_fields?: boolean,
+    }
+    ): Promise<StreamResponse<RestoreActivityResponse>> {
+        
+        const queryParams = {
+          enrich_own_fields: request?.enrich_own_fields,
+        };
+        const pathParams = {
+          id: request?.id,
+        };
+        const body = {
+          
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<RestoreActivityResponse>>('POST', '/api/v2/feeds/activities/{id}/restore', pathParams , queryParams  , body, 'application/json');
+
+       decoders["RestoreActivityResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryBookmarkFolders (request?: QueryBookmarkFoldersRequest 
+    
+    ): Promise<StreamResponse<QueryBookmarkFoldersResponse>> {
+        const body = {
+          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryBookmarkFoldersResponse>>('POST', '/api/v2/feeds/bookmark_folders/query',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["QueryBookmarkFoldersResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteBookmarkFolder (request: 
+    
+    
+    {folder_id: string,
+    }
+    ): Promise<StreamResponse<DeleteBookmarkFolderResponse>> {
+        const pathParams = {
+          folder_id: request?.folder_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<DeleteBookmarkFolderResponse>>('DELETE', '/api/v2/feeds/bookmark_folders/{folder_id}', pathParams ,  undefined  );
+
+       decoders["DeleteBookmarkFolderResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateBookmarkFolder (request: UpdateBookmarkFolderRequest 
+     & 
+    
+    {folder_id: string,
+    }
+    ): Promise<StreamResponse<UpdateBookmarkFolderResponse>> {
+        const pathParams = {
+          folder_id: request?.folder_id,
+        };
+        const body = {
+          name: request?.name,custom: request?.custom,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateBookmarkFolderResponse>>('PATCH', '/api/v2/feeds/bookmark_folders/{folder_id}', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["UpdateBookmarkFolderResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryBookmarks (request?: QueryBookmarksRequest 
+    
+    ): Promise<StreamResponse<QueryBookmarksResponse>> {
+        const body = {
+          enrich_own_fields: request?.enrich_own_fields,limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryBookmarksResponse>>('POST', '/api/v2/feeds/bookmarks/query',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["QueryBookmarksResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteCollections (request: 
+    
+    
+    {collection_refs: Array<string>,
+    }
+    ): Promise<StreamResponse<DeleteCollectionsResponse>> {
+        
+        const queryParams = {
+          collection_refs: request?.collection_refs,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<DeleteCollectionsResponse>>('DELETE', '/api/v2/feeds/collections',  undefined , queryParams  );
+
+       decoders["DeleteCollectionsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async readCollections (request?: 
+    
+    
+    {collection_refs?: Array<string>,
+    }
+    ): Promise<StreamResponse<ReadCollectionsResponse>> {
+        
+        const queryParams = {
+          collection_refs: request?.collection_refs,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<ReadCollectionsResponse>>('GET', '/api/v2/feeds/collections',  undefined , queryParams  );
+
+       decoders["ReadCollectionsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateCollections (request: UpdateCollectionsRequest 
+    
+    ): Promise<StreamResponse<UpdateCollectionsResponse>> {
+        const body = {
+          collections: request?.collections,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateCollectionsResponse>>('PATCH', '/api/v2/feeds/collections',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["UpdateCollectionsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async createCollections (request: CreateCollectionsRequest 
+    
+    ): Promise<StreamResponse<CreateCollectionsResponse>> {
+        const body = {
+          collections: request?.collections,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<CreateCollectionsResponse>>('POST', '/api/v2/feeds/collections',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["CreateCollectionsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryCollections (request?: QueryCollectionsRequest 
+    
+    ): Promise<StreamResponse<QueryCollectionsResponse>> {
+        const body = {
+          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryCollectionsResponse>>('POST', '/api/v2/feeds/collections/query',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["QueryCollectionsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getComments (request: 
+    
+    
+    {object_id: string,object_type: string,depth?: number,sort?: string,replies_limit?: number,id_around?: string,limit?: number,prev?: string,next?: string,
+    }
+    ): Promise<StreamResponse<GetCommentsResponse>> {
+        
+        const queryParams = {
+          object_id: request?.object_id, object_type: request?.object_type, depth: request?.depth, sort: request?.sort, replies_limit: request?.replies_limit, id_around: request?.id_around, limit: request?.limit, prev: request?.prev, next: request?.next,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<GetCommentsResponse>>('GET', '/api/v2/feeds/comments',  undefined , queryParams  );
+
+       decoders["GetCommentsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async addComment (request?: AddCommentRequest 
+    
+    ): Promise<StreamResponse<AddCommentResponse>> {
+        const body = {
+          comment: request?.comment,copy_custom_to_notification: request?.copy_custom_to_notification,create_notification_activity: request?.create_notification_activity,id: request?.id,object_id: request?.object_id,object_type: request?.object_type,parent_id: request?.parent_id,skip_enrich_url: request?.skip_enrich_url,skip_push: request?.skip_push,attachments: request?.attachments,mentioned_user_ids: request?.mentioned_user_ids,custom: request?.custom,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<AddCommentResponse>>('POST', '/api/v2/feeds/comments',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["AddCommentResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async addCommentsBatch (request: AddCommentsBatchRequest 
+    
+    ): Promise<StreamResponse<AddCommentsBatchResponse>> {
+        const body = {
+          comments: request?.comments,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<AddCommentsBatchResponse>>('POST', '/api/v2/feeds/comments/batch',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["AddCommentsBatchResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryComments (request: QueryCommentsRequest 
+    
+    ): Promise<StreamResponse<QueryCommentsResponse>> {
+        const body = {
+          filter: request?.filter,id_around: request?.id_around,limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryCommentsResponse>>('POST', '/api/v2/feeds/comments/query',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["QueryCommentsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteCommentBookmark (request: 
+    
+    
+    {comment_id: string,folder_id?: string,
+    }
+    ): Promise<StreamResponse<DeleteCommentBookmarkResponse>> {
+        
+        const queryParams = {
+          folder_id: request?.folder_id,
+        };
+        const pathParams = {
+          comment_id: request?.comment_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<DeleteCommentBookmarkResponse>>('DELETE', '/api/v2/feeds/comments/{comment_id}/bookmarks', pathParams , queryParams  );
+
+       decoders["DeleteCommentBookmarkResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateCommentBookmark (request: UpdateCommentBookmarkRequest 
+     & 
+    
+    {comment_id: string,
+    }
+    ): Promise<StreamResponse<UpdateCommentBookmarkResponse>> {
+        const pathParams = {
+          comment_id: request?.comment_id,
+        };
+        const body = {
+          folder_id: request?.folder_id,new_folder_id: request?.new_folder_id,custom: request?.custom,new_folder: request?.new_folder,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateCommentBookmarkResponse>>('PATCH', '/api/v2/feeds/comments/{comment_id}/bookmarks', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["UpdateCommentBookmarkResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async addCommentBookmark (request: AddCommentBookmarkRequest 
+     & 
+    
+    {comment_id: string,
+    }
+    ): Promise<StreamResponse<AddCommentBookmarkResponse>> {
+        const pathParams = {
+          comment_id: request?.comment_id,
+        };
+        const body = {
+          folder_id: request?.folder_id,custom: request?.custom,new_folder: request?.new_folder,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<AddCommentBookmarkResponse>>('POST', '/api/v2/feeds/comments/{comment_id}/bookmarks', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["AddCommentBookmarkResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteComment (request: 
+    
+    
+    {id: string,hard_delete?: boolean,delete_notification_activity?: boolean,
+    }
+    ): Promise<StreamResponse<DeleteCommentResponse>> {
+        
+        const queryParams = {
+          hard_delete: request?.hard_delete, delete_notification_activity: request?.delete_notification_activity,
+        };
+        const pathParams = {
+          id: request?.id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<DeleteCommentResponse>>('DELETE', '/api/v2/feeds/comments/{id}', pathParams , queryParams  );
+
+       decoders["DeleteCommentResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getComment (request: 
+    
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<GetCommentResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<GetCommentResponse>>('GET', '/api/v2/feeds/comments/{id}', pathParams ,  undefined  );
+
+       decoders["GetCommentResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateComment (request: UpdateCommentRequest 
+     & 
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<UpdateCommentResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        const body = {
+          comment: request?.comment,copy_custom_to_notification: request?.copy_custom_to_notification,handle_mention_notifications: request?.handle_mention_notifications,skip_enrich_url: request?.skip_enrich_url,skip_push: request?.skip_push,attachments: request?.attachments,mentioned_user_ids: request?.mentioned_user_ids,custom: request?.custom,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateCommentResponse>>('PATCH', '/api/v2/feeds/comments/{id}', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["UpdateCommentResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateCommentPartial (request: UpdateCommentPartialRequest 
+     & 
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<UpdateCommentPartialResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        const body = {
+          copy_custom_to_notification: request?.copy_custom_to_notification,handle_mention_notifications: request?.handle_mention_notifications,skip_enrich_url: request?.skip_enrich_url,skip_push: request?.skip_push,unset: request?.unset,set: request?.set,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateCommentPartialResponse>>('POST', '/api/v2/feeds/comments/{id}/partial', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["UpdateCommentPartialResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async addCommentReaction (request: AddCommentReactionRequest 
+     & 
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<AddCommentReactionResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        const body = {
+          type: request?.type,copy_custom_to_notification: request?.copy_custom_to_notification,create_notification_activity: request?.create_notification_activity,enforce_unique: request?.enforce_unique,skip_push: request?.skip_push,custom: request?.custom,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<AddCommentReactionResponse>>('POST', '/api/v2/feeds/comments/{id}/reactions', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["AddCommentReactionResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryCommentReactions (request: QueryCommentReactionsRequest 
+     & 
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<QueryCommentReactionsResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        const body = {
+          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryCommentReactionsResponse>>('POST', '/api/v2/feeds/comments/{id}/reactions/query', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["QueryCommentReactionsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteCommentReaction (request: 
+    
+    
+    {id: string,type: string,delete_notification_activity?: boolean,
+    }
+    ): Promise<StreamResponse<DeleteCommentReactionResponse>> {
+        
+        const queryParams = {
+          delete_notification_activity: request?.delete_notification_activity,
+        };
+        const pathParams = {
+          id: request?.id, type: request?.type,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<DeleteCommentReactionResponse>>('DELETE', '/api/v2/feeds/comments/{id}/reactions/{type}', pathParams , queryParams  );
+
+       decoders["DeleteCommentReactionResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getCommentReplies (request: 
+    
+    
+    {id: string,depth?: number,sort?: string,replies_limit?: number,id_around?: string,limit?: number,prev?: string,next?: string,
+    }
+    ): Promise<StreamResponse<GetCommentRepliesResponse>> {
+        
+        const queryParams = {
+          depth: request?.depth, sort: request?.sort, replies_limit: request?.replies_limit, id_around: request?.id_around, limit: request?.limit, prev: request?.prev, next: request?.next,
+        };
+        const pathParams = {
+          id: request?.id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<GetCommentRepliesResponse>>('GET', '/api/v2/feeds/comments/{id}/replies', pathParams , queryParams  );
+
+       decoders["GetCommentRepliesResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async restoreComment (request: RestoreCommentRequest 
+     & 
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<RestoreCommentResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        const body = {
+          
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<RestoreCommentResponse>>('POST', '/api/v2/feeds/comments/{id}/restore', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["RestoreCommentResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteFeed (request: 
+    
+    
+    {feed_group_id: string,feed_id: string,hard_delete?: boolean,
+    }
+    ): Promise<StreamResponse<DeleteFeedResponse>> {
+        
+        const queryParams = {
+          hard_delete: request?.hard_delete,
+        };
+        const pathParams = {
+          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<DeleteFeedResponse>>('DELETE', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}', pathParams , queryParams  );
+
+       decoders["DeleteFeedResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getOrCreateFeed (request: GetOrCreateFeedRequest 
+     & 
+    
+    {feed_group_id: string,feed_id: string,connection_id?: string,
+    }
+    ): Promise<StreamResponse<GetOrCreateFeedResponse>> {
+        
+        const queryParams = {
+          connection_id: request?.connection_id,
+        };
+        const pathParams = {
+          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
+        };
+        const body = {
+          id_around: request?.id_around,limit: request?.limit,next: request?.next,prev: request?.prev,view: request?.view,watch: request?.watch,data: request?.data,enrichment_options: request?.enrichment_options,external_ranking: request?.external_ranking,filter: request?.filter,followers_pagination: request?.followers_pagination,following_pagination: request?.following_pagination,friend_reactions_options: request?.friend_reactions_options,interest_weights: request?.interest_weights,member_pagination: request?.member_pagination,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<GetOrCreateFeedResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}', pathParams , queryParams  , body, 'application/json');
+
+       decoders["GetOrCreateFeedResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateFeed (request: UpdateFeedRequest 
+     & 
+    
+    {feed_group_id: string,feed_id: string,
+    }
+    ): Promise<StreamResponse<UpdateFeedResponse>> {
+        const pathParams = {
+          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
+        };
+        const body = {
+          clear_location: request?.clear_location,description: request?.description,enrich_own_fields: request?.enrich_own_fields,name: request?.name,filter_tags: request?.filter_tags,custom: request?.custom,location: request?.location,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateFeedResponse>>('PUT', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["UpdateFeedResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async markActivity (request: MarkActivityRequest 
+     & 
+    
+    {feed_group_id: string,feed_id: string,
+    }
+    ): Promise<StreamResponse<Response>> {
+        const pathParams = {
+          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
+        };
+        const body = {
+          mark_all_read: request?.mark_all_read,mark_all_seen: request?.mark_all_seen,mark_read: request?.mark_read,mark_seen: request?.mark_seen,mark_watched: request?.mark_watched,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/mark/batch', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["Response"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async unpinActivity (request: 
+    
+    
+    {feed_group_id: string,feed_id: string,activity_id: string,enrich_own_fields?: boolean,
+    }
+    ): Promise<StreamResponse<UnpinActivityResponse>> {
+        
+        const queryParams = {
+          enrich_own_fields: request?.enrich_own_fields,
+        };
+        const pathParams = {
+          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id, activity_id: request?.activity_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UnpinActivityResponse>>('DELETE', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/{activity_id}/pin', pathParams , queryParams  );
+
+       decoders["UnpinActivityResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async pinActivity (request: PinActivityRequest 
+     & 
+    
+    {feed_group_id: string,feed_id: string,activity_id: string,
+    }
+    ): Promise<StreamResponse<PinActivityResponse>> {
+        const pathParams = {
+          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id, activity_id: request?.activity_id,
+        };
+        const body = {
+          enrich_own_fields: request?.enrich_own_fields,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<PinActivityResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/{activity_id}/pin', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["PinActivityResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async changeFeedVisibility (request: ChangeFeedVisibilityRequest 
+     & 
+    
+    {feed_group_id: string,feed_id: string,
+    }
+    ): Promise<StreamResponse<ChangeFeedVisibilityResponse>> {
+        const pathParams = {
+          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
+        };
+        const body = {
+          visibility: request?.visibility,pending_follows_action: request?.pending_follows_action,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<ChangeFeedVisibilityResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/change_visibility', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["ChangeFeedVisibilityResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateFeedMembers (request: UpdateFeedMembersRequest 
+     & 
+    
+    {feed_group_id: string,feed_id: string,
+    }
+    ): Promise<StreamResponse<UpdateFeedMembersResponse>> {
+        const pathParams = {
+          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
+        };
+        const body = {
+          operation: request?.operation,limit: request?.limit,next: request?.next,prev: request?.prev,members: request?.members,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateFeedMembersResponse>>('PATCH', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["UpdateFeedMembersResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async acceptFeedMemberInvite (request: AcceptFeedMemberInviteRequest 
+     & 
+    
+    {feed_id: string,feed_group_id: string,
+    }
+    ): Promise<StreamResponse<AcceptFeedMemberInviteResponse>> {
+        const pathParams = {
+          feed_id: request?.feed_id, feed_group_id: request?.feed_group_id,
+        };
+        const body = {
+          
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<AcceptFeedMemberInviteResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/accept', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["AcceptFeedMemberInviteResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryFeedMembers (request: QueryFeedMembersRequest 
+     & 
+    
+    {feed_group_id: string,feed_id: string,
+    }
+    ): Promise<StreamResponse<QueryFeedMembersResponse>> {
+        const pathParams = {
+          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
+        };
+        const body = {
+          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryFeedMembersResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/query', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["QueryFeedMembersResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async rejectFeedMemberInvite (request: RejectFeedMemberInviteRequest 
+     & 
+    
+    {feed_group_id: string,feed_id: string,
+    }
+    ): Promise<StreamResponse<RejectFeedMemberInviteResponse>> {
+        const pathParams = {
+          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
+        };
+        const body = {
+          
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<RejectFeedMemberInviteResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/reject', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["RejectFeedMemberInviteResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryPinnedActivities (request: QueryPinnedActivitiesRequest 
+     & 
+    
+    {feed_group_id: string,feed_id: string,
+    }
+    ): Promise<StreamResponse<QueryPinnedActivitiesResponse>> {
+        const pathParams = {
+          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
+        };
+        const body = {
+          enrich_own_fields: request?.enrich_own_fields,limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryPinnedActivitiesResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/pinned_activities/query', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["QueryPinnedActivitiesResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async stopWatchingFeed (request: 
+    
+    
+    {feed_group_id: string,feed_id: string,connection_id?: string,
+    }
+    ): Promise<StreamResponse<Response>> {
+        
+        const queryParams = {
+          connection_id: request?.connection_id,
+        };
+        const pathParams = {
+          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/watch', pathParams , queryParams  );
+
+       decoders["Response"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getFollowSuggestions (request: 
+    
+    
+    {feed_group_id: string,limit?: number,
+    }
+    ): Promise<StreamResponse<GetFollowSuggestionsResponse>> {
+        
+        const queryParams = {
+          limit: request?.limit,
+        };
+        const pathParams = {
+          feed_group_id: request?.feed_group_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<GetFollowSuggestionsResponse>>('GET', '/api/v2/feeds/feed_groups/{feed_group_id}/follow_suggestions', pathParams , queryParams  );
+
+       decoders["GetFollowSuggestionsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async createFeedsBatch (request: CreateFeedsBatchRequest 
+    
+    ): Promise<StreamResponse<CreateFeedsBatchResponse>> {
+        const body = {
+          feeds: request?.feeds,enrich_own_fields: request?.enrich_own_fields,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<CreateFeedsBatchResponse>>('POST', '/api/v2/feeds/feeds/batch',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["CreateFeedsBatchResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async ownBatch (request: OwnBatchRequest 
+     & 
+    
+    {connection_id?: string,
+    }
+    ): Promise<StreamResponse<OwnBatchResponse>> {
+        
+        const queryParams = {
+          connection_id: request?.connection_id,
+        };
+        const body = {
+          feeds: request?.feeds,fields: request?.fields,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<OwnBatchResponse>>('POST', '/api/v2/feeds/feeds/own/batch',  undefined , queryParams  , body, 'application/json');
+
+       decoders["OwnBatchResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    protected async _queryFeeds (request?: QueryFeedsRequest 
+     & 
+    
+    {connection_id?: string,
+    }
+    ): Promise<StreamResponse<QueryFeedsResponse>> {
+        
+        const queryParams = {
+          connection_id: request?.connection_id,
+        };
+        const body = {
+          enrich_own_fields: request?.enrich_own_fields,limit: request?.limit,next: request?.next,prev: request?.prev,watch: request?.watch,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryFeedsResponse>>('POST', '/api/v2/feeds/feeds/query',  undefined , queryParams  , body, 'application/json');
+
+       decoders["QueryFeedsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateFollow (request: UpdateFollowRequest 
+    
+    ): Promise<StreamResponse<UpdateFollowResponse>> {
+        const body = {
+          source: request?.source,target: request?.target,activity_copy_limit: request?.activity_copy_limit,copy_custom_to_notification: request?.copy_custom_to_notification,create_notification_activity: request?.create_notification_activity,enrich_own_fields: request?.enrich_own_fields,follower_role: request?.follower_role,push_preference: request?.push_preference,skip_push: request?.skip_push,custom: request?.custom,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateFollowResponse>>('PATCH', '/api/v2/feeds/follows',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["UpdateFollowResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async follow (request: FollowRequest 
+    
+    ): Promise<StreamResponse<SingleFollowResponse>> {
+        const body = {
+          source: request?.source,target: request?.target,activity_copy_limit: request?.activity_copy_limit,copy_custom_to_notification: request?.copy_custom_to_notification,create_notification_activity: request?.create_notification_activity,enrich_own_fields: request?.enrich_own_fields,push_preference: request?.push_preference,skip_push: request?.skip_push,custom: request?.custom,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<SingleFollowResponse>>('POST', '/api/v2/feeds/follows',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["SingleFollowResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async acceptFollow (request: AcceptFollowRequest 
+    
+    ): Promise<StreamResponse<AcceptFollowResponse>> {
+        const body = {
+          source: request?.source,target: request?.target,follower_role: request?.follower_role,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<AcceptFollowResponse>>('POST', '/api/v2/feeds/follows/accept',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["AcceptFollowResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async followBatch (request: FollowBatchRequest 
+    
+    ): Promise<StreamResponse<FollowBatchResponse>> {
+        const body = {
+          follows: request?.follows,enrich_own_fields: request?.enrich_own_fields,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<FollowBatchResponse>>('POST', '/api/v2/feeds/follows/batch',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["FollowBatchResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getOrCreateFollows (request: FollowBatchRequest 
+    
+    ): Promise<StreamResponse<FollowBatchResponse>> {
+        const body = {
+          follows: request?.follows,enrich_own_fields: request?.enrich_own_fields,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<FollowBatchResponse>>('POST', '/api/v2/feeds/follows/batch/upsert',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["FollowBatchResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryFollows (request?: QueryFollowsRequest 
+    
+    ): Promise<StreamResponse<QueryFollowsResponse>> {
+        const body = {
+          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryFollowsResponse>>('POST', '/api/v2/feeds/follows/query',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["QueryFollowsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async rejectFollow (request: RejectFollowRequest 
+    
+    ): Promise<StreamResponse<RejectFollowResponse>> {
+        const body = {
+          source: request?.source,target: request?.target,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<RejectFollowResponse>>('POST', '/api/v2/feeds/follows/reject',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["RejectFollowResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async unfollow (request: 
+    
+    
+    {source: string,target: string,delete_notification_activity?: boolean,keep_history?: boolean,enrich_own_fields?: boolean,
+    }
+    ): Promise<StreamResponse<UnfollowResponse>> {
+        
+        const queryParams = {
+          delete_notification_activity: request?.delete_notification_activity, keep_history: request?.keep_history, enrich_own_fields: request?.enrich_own_fields,
+        };
+        const pathParams = {
+          source: request?.source, target: request?.target,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UnfollowResponse>>('DELETE', '/api/v2/feeds/follows/{source}/{target}', pathParams , queryParams  );
+
+       decoders["UnfollowResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getOrCreateUnfollows (request: UnfollowBatchRequest 
+    
+    ): Promise<StreamResponse<UnfollowBatchResponse>> {
+        const body = {
+          follows: request?.follows,delete_notification_activity: request?.delete_notification_activity,enrich_own_fields: request?.enrich_own_fields,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UnfollowBatchResponse>>('POST', '/api/v2/feeds/unfollow/batch/upsert',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["UnfollowBatchResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async createGuest (request: CreateGuestRequest 
+    
+    ): Promise<StreamResponse<CreateGuestResponse>> {
+        const body = {
+          user: request?.user,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<CreateGuestResponse>>('POST', '/api/v2/guest',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["CreateGuestResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async longPoll (request?: 
+    
+    
+    {connection_id?: string,json?: WSAuthMessage,
+    }
+    ): Promise<StreamResponse<{}>> {
+        
+        const queryParams = {
+          connection_id: request?.connection_id, json: request?.json,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<{}>>('GET', '/api/v2/longpoll',  undefined , queryParams  );
+
+       decoders["{}"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getOG (request: 
+    
+    
+    {url: string,
+    }
+    ): Promise<StreamResponse<GetOGResponse>> {
+        
+        const queryParams = {
+          url: request?.url,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<GetOGResponse>>('GET', '/api/v2/og',  undefined , queryParams  );
+
+       decoders["GetOGResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async createPoll (request: CreatePollRequest 
+    
+    ): Promise<StreamResponse<PollResponse>> {
+        const body = {
+          name: request?.name,allow_answers: request?.allow_answers,allow_user_suggested_options: request?.allow_user_suggested_options,description: request?.description,enforce_unique_vote: request?.enforce_unique_vote,id: request?.id,is_closed: request?.is_closed,max_votes_allowed: request?.max_votes_allowed,voting_visibility: request?.voting_visibility,options: request?.options,custom: request?.custom,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<PollResponse>>('POST', '/api/v2/polls',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["PollResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updatePoll (request: UpdatePollRequest 
+    
+    ): Promise<StreamResponse<PollResponse>> {
+        const body = {
+          id: request?.id,name: request?.name,allow_answers: request?.allow_answers,allow_user_suggested_options: request?.allow_user_suggested_options,description: request?.description,enforce_unique_vote: request?.enforce_unique_vote,is_closed: request?.is_closed,max_votes_allowed: request?.max_votes_allowed,voting_visibility: request?.voting_visibility,options: request?.options,custom: request?.custom,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<PollResponse>>('PUT', '/api/v2/polls',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["PollResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryPolls (request?: QueryPollsRequest 
+     & 
+    
+    {user_id?: string,
+    }
+    ): Promise<StreamResponse<QueryPollsResponse>> {
+        
+        const queryParams = {
+          user_id: request?.user_id,
+        };
+        const body = {
+          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryPollsResponse>>('POST', '/api/v2/polls/query',  undefined , queryParams  , body, 'application/json');
+
+       decoders["QueryPollsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deletePoll (request: 
+    
+    
+    {poll_id: string,user_id?: string,
+    }
+    ): Promise<StreamResponse<Response>> {
+        
+        const queryParams = {
+          user_id: request?.user_id,
+        };
+        const pathParams = {
+          poll_id: request?.poll_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/polls/{poll_id}', pathParams , queryParams  );
+
+       decoders["Response"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getPoll (request: 
+    
+    
+    {poll_id: string,user_id?: string,
+    }
+    ): Promise<StreamResponse<PollResponse>> {
+        
+        const queryParams = {
+          user_id: request?.user_id,
+        };
+        const pathParams = {
+          poll_id: request?.poll_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<PollResponse>>('GET', '/api/v2/polls/{poll_id}', pathParams , queryParams  );
+
+       decoders["PollResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updatePollPartial (request: UpdatePollPartialRequest 
+     & 
+    
+    {poll_id: string,
+    }
+    ): Promise<StreamResponse<PollResponse>> {
+        const pathParams = {
+          poll_id: request?.poll_id,
+        };
+        const body = {
+          unset: request?.unset,set: request?.set,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<PollResponse>>('PATCH', '/api/v2/polls/{poll_id}', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["PollResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async createPollOption (request: CreatePollOptionRequest 
+     & 
+    
+    {poll_id: string,
+    }
+    ): Promise<StreamResponse<PollOptionResponse>> {
+        const pathParams = {
+          poll_id: request?.poll_id,
+        };
+        const body = {
+          text: request?.text,custom: request?.custom,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<PollOptionResponse>>('POST', '/api/v2/polls/{poll_id}/options', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["PollOptionResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updatePollOption (request: UpdatePollOptionRequest 
+     & 
+    
+    {poll_id: string,
+    }
+    ): Promise<StreamResponse<PollOptionResponse>> {
+        const pathParams = {
+          poll_id: request?.poll_id,
+        };
+        const body = {
+          id: request?.id,text: request?.text,custom: request?.custom,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<PollOptionResponse>>('PUT', '/api/v2/polls/{poll_id}/options', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["PollOptionResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deletePollOption (request: 
+    
+    
+    {poll_id: string,option_id: string,user_id?: string,
+    }
+    ): Promise<StreamResponse<Response>> {
+        
+        const queryParams = {
+          user_id: request?.user_id,
+        };
+        const pathParams = {
+          poll_id: request?.poll_id, option_id: request?.option_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/polls/{poll_id}/options/{option_id}', pathParams , queryParams  );
+
+       decoders["Response"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getPollOption (request: 
+    
+    
+    {poll_id: string,option_id: string,user_id?: string,
+    }
+    ): Promise<StreamResponse<PollOptionResponse>> {
+        
+        const queryParams = {
+          user_id: request?.user_id,
+        };
+        const pathParams = {
+          poll_id: request?.poll_id, option_id: request?.option_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<PollOptionResponse>>('GET', '/api/v2/polls/{poll_id}/options/{option_id}', pathParams , queryParams  );
+
+       decoders["PollOptionResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryPollVotes (request: QueryPollVotesRequest 
+     & 
+    
+    {poll_id: string,user_id?: string,
+    }
+    ): Promise<StreamResponse<PollVotesResponse>> {
+        
+        const queryParams = {
+          user_id: request?.user_id,
+        };
+        const pathParams = {
+          poll_id: request?.poll_id,
+        };
+        const body = {
+          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<PollVotesResponse>>('POST', '/api/v2/polls/{poll_id}/votes', pathParams , queryParams  , body, 'application/json');
+
+       decoders["PollVotesResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updatePushNotificationPreferences (request: UpsertPushPreferencesRequest 
+    
+    ): Promise<StreamResponse<UpsertPushPreferencesResponse>> {
+        const body = {
+          preferences: request?.preferences,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpsertPushPreferencesResponse>>('POST', '/api/v2/push_preferences',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["UpsertPushPreferencesResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteFile (request?: 
+    
+    
+    {url?: string,
+    }
+    ): Promise<StreamResponse<Response>> {
+        
+        const queryParams = {
+          url: request?.url,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/uploads/file',  undefined , queryParams  );
+
+       decoders["Response"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async uploadFile (request?: FileUploadRequest 
+    
+    ): Promise<StreamResponse<FileUploadResponse>> {
+        const body = {
+          file: request?.file,user: request?.user,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<FileUploadResponse>>('POST', '/api/v2/uploads/file',  undefined ,  undefined  , body, 'multipart/form-data');
+
+       decoders["FileUploadResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteImage (request?: 
+    
+    
+    {url?: string,
+    }
+    ): Promise<StreamResponse<Response>> {
+        
+        const queryParams = {
+          url: request?.url,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/uploads/image',  undefined , queryParams  );
+
+       decoders["Response"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async uploadImage (request?: ImageUploadRequest 
+    
+    ): Promise<StreamResponse<ImageUploadResponse>> {
+        const body = {
+          file: request?.file,upload_sizes: request?.upload_sizes,user: request?.user,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<ImageUploadResponse>>('POST', '/api/v2/uploads/image',  undefined ,  undefined  , body, 'multipart/form-data');
+
+       decoders["ImageUploadResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async listUserGroups (request?: 
+    
+    
+    {limit?: number,id_gt?: string,created_at_gt?: string,team_id?: string,
+    }
+    ): Promise<StreamResponse<ListUserGroupsResponse>> {
+        
+        const queryParams = {
+          limit: request?.limit, id_gt: request?.id_gt, created_at_gt: request?.created_at_gt, team_id: request?.team_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<ListUserGroupsResponse>>('GET', '/api/v2/usergroups',  undefined , queryParams  );
+
+       decoders["ListUserGroupsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async createUserGroup (request: CreateUserGroupRequest 
+    
+    ): Promise<StreamResponse<CreateUserGroupResponse>> {
+        const body = {
+          name: request?.name,description: request?.description,id: request?.id,team_id: request?.team_id,member_ids: request?.member_ids,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<CreateUserGroupResponse>>('POST', '/api/v2/usergroups',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["CreateUserGroupResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async searchUserGroups (request: 
+    
+    
+    {query: string,limit?: number,name_gt?: string,id_gt?: string,team_id?: string,
+    }
+    ): Promise<StreamResponse<SearchUserGroupsResponse>> {
+        
+        const queryParams = {
+          query: request?.query, limit: request?.limit, name_gt: request?.name_gt, id_gt: request?.id_gt, team_id: request?.team_id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<SearchUserGroupsResponse>>('GET', '/api/v2/usergroups/search',  undefined , queryParams  );
+
+       decoders["SearchUserGroupsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteUserGroup (request: 
+    
+    
+    {id: string,team_id?: string,
+    }
+    ): Promise<StreamResponse<Response>> {
+        
+        const queryParams = {
+          team_id: request?.team_id,
+        };
+        const pathParams = {
+          id: request?.id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/usergroups/{id}', pathParams , queryParams  );
+
+       decoders["Response"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getUserGroup (request: 
+    
+    
+    {id: string,team_id?: string,
+    }
+    ): Promise<StreamResponse<GetUserGroupResponse>> {
+        
+        const queryParams = {
+          team_id: request?.team_id,
+        };
+        const pathParams = {
+          id: request?.id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<GetUserGroupResponse>>('GET', '/api/v2/usergroups/{id}', pathParams , queryParams  );
+
+       decoders["GetUserGroupResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateUserGroup (request: UpdateUserGroupRequest 
+     & 
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<UpdateUserGroupResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        const body = {
+          description: request?.description,name: request?.name,team_id: request?.team_id,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateUserGroupResponse>>('PUT', '/api/v2/usergroups/{id}', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["UpdateUserGroupResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async addUserGroupMembers (request: AddUserGroupMembersRequest 
+     & 
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<AddUserGroupMembersResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        const body = {
+          member_ids: request?.member_ids,as_admin: request?.as_admin,team_id: request?.team_id,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<AddUserGroupMembersResponse>>('POST', '/api/v2/usergroups/{id}/members', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["AddUserGroupMembersResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async removeUserGroupMembers (request: RemoveUserGroupMembersRequest 
+     & 
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<RemoveUserGroupMembersResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        const body = {
+          member_ids: request?.member_ids,team_id: request?.team_id,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<RemoveUserGroupMembersResponse>>('POST', '/api/v2/usergroups/{id}/members/delete', pathParams ,  undefined  , body, 'application/json');
+
+       decoders["RemoveUserGroupMembersResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryUsers (request?: 
+    
+    
+    {payload?: QueryUsersPayload,
+    }
+    ): Promise<StreamResponse<QueryUsersResponse>> {
+        
+        const queryParams = {
+          payload: request?.payload,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryUsersResponse>>('GET', '/api/v2/users',  undefined , queryParams  );
+
+       decoders["QueryUsersResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateUsersPartial (request: UpdateUsersPartialRequest 
+    
+    ): Promise<StreamResponse<UpdateUsersResponse>> {
+        const body = {
+          users: request?.users,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateUsersResponse>>('PATCH', '/api/v2/users',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["UpdateUsersResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateUsers (request: UpdateUsersRequest 
+    
+    ): Promise<StreamResponse<UpdateUsersResponse>> {
+        const body = {
+          users: request?.users,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpdateUsersResponse>>('POST', '/api/v2/users',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["UpdateUsersResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getBlockedUsers (): Promise<StreamResponse<GetBlockedUsersResponse>> {
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<GetBlockedUsersResponse>>('GET', '/api/v2/users/block',  undefined ,  undefined  );
+
+       decoders["GetBlockedUsersResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async blockUsers (request: BlockUsersRequest 
+    
+    ): Promise<StreamResponse<BlockUsersResponse>> {
+        const body = {
+          blocked_user_id: request?.blocked_user_id,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<BlockUsersResponse>>('POST', '/api/v2/users/block',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["BlockUsersResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getUserLiveLocations (): Promise<StreamResponse<SharedLocationsResponse>> {
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<SharedLocationsResponse>>('GET', '/api/v2/users/live_locations',  undefined ,  undefined  );
+
+       decoders["SharedLocationsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async updateLiveLocation (request: UpdateLiveLocationRequest 
+    
+    ): Promise<StreamResponse<SharedLocationResponse>> {
+        const body = {
+          message_id: request?.message_id,end_at: request?.end_at,latitude: request?.latitude,longitude: request?.longitude,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<SharedLocationResponse>>('PUT', '/api/v2/users/live_locations',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["SharedLocationResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async unblockUsers (request: UnblockUsersRequest 
+    
+    ): Promise<StreamResponse<UnblockUsersResponse>> {
+        const body = {
+          blocked_user_id: request?.blocked_user_id,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UnblockUsersResponse>>('POST', '/api/v2/users/unblock',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["UnblockUsersResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    }

--- a/packages/feeds-client/src/gen/feeds/FeedsApi.ts
+++ b/packages/feeds-client/src/gen/feeds/FeedsApi.ts
@@ -1,2128 +1,3100 @@
-import { ApiClient, StreamResponse } from '../../gen-imports';
-import {  AIImageConfig,  AIImageLabelDefinition,  AITextConfig,  AIVideoConfig,  APIError,  AWSRekognitionRule,  AcceptFeedMemberInviteRequest,  AcceptFeedMemberInviteResponse,  AcceptFollowRequest,  AcceptFollowResponse,  Action,  ActionLogResponse,  ActionSequence,  ActivityAddedEvent,  ActivityDeletedEvent,  ActivityFeedbackEvent,  ActivityFeedbackEventPayload,  ActivityFeedbackRequest,  ActivityFeedbackResponse,  ActivityFilterConfig,  ActivityMarkEvent,  ActivityPinResponse,  ActivityPinnedEvent,  ActivityProcessorConfig,  ActivityReactionAddedEvent,  ActivityReactionDeletedEvent,  ActivityReactionUpdatedEvent,  ActivityRemovedFromFeedEvent,  ActivityRequest,  ActivityResponse,  ActivityRestoredEvent,  ActivitySelectorConfig,  ActivityUnpinnedEvent,  ActivityUpdatedEvent,  AddActivityRequest,  AddActivityResponse,  AddBookmarkRequest,  AddBookmarkResponse,  AddCommentBookmarkRequest,  AddCommentBookmarkResponse,  AddCommentReactionRequest,  AddCommentReactionResponse,  AddCommentRequest,  AddCommentResponse,  AddCommentsBatchRequest,  AddCommentsBatchResponse,  AddFolderRequest,  AddReactionRequest,  AddReactionResponse,  AddUserGroupMembersRequest,  AddUserGroupMembersResponse,  AggregatedActivityResponse,  AggregationConfig,  AppEventResponse,  AppResponseFields,  AppUpdatedEvent,  AppealItemResponse,  AppealRequest,  AppealResponse,  Attachment,  AutomodPlatformCircumventionConfig,  AutomodRule,  AutomodSemanticFiltersConfig,  AutomodSemanticFiltersRule,  AutomodToxicityConfig,  BanActionRequestPayload,  BanInfoResponse,  BanOptions,  BanRequest,  BanResponse,  BlockActionRequestPayload,  BlockListConfig,  BlockListOptions,  BlockListResponse,  BlockListRule,  BlockUsersRequest,  BlockUsersResponse,  BlockedUserResponse,  BodyguardProfileSummary,  BodyguardRule,  BodyguardSeverityRule,  BookmarkAddedEvent,  BookmarkDeletedEvent,  BookmarkFolderDeletedEvent,  BookmarkFolderResponse,  BookmarkFolderUpdatedEvent,  BookmarkResponse,  BookmarkUpdatedEvent,  BulkDeleteActionConfigRequest,  BulkDeleteActionConfigResponse,  BulkUpsertActionConfigRequest,  BulkUpsertActionConfigResponse,  BypassActionRequest,  CallActionOptions,  CallCustomPropertyParameters,  CallResponse,  CallRuleActionSequence,  CallTypeRuleParameters,  CallViolationCountParameters,  CastPollVoteRequest,  ChangeFeedVisibilityRequest,  ChangeFeedVisibilityResponse,  ChannelConfigWithInfo,  ChannelMemberResponse,  ChannelMessageCountRuleParameters,  ChannelMute,  ChannelOwnCapability,  ChannelPushPreferencesResponse,  ChannelResponse,  ChatDraftPayloadResponse,  ChatDraftResponse,  ChatMessageResponse,  ChatModerationV2Response,  ChatPreferences,  ChatPreferencesInput,  ChatPreferencesResponse,  ChatReactionGroupResponse,  ChatReactionGroupUserResponse,  ChatReactionResponse,  ChatReminderResponseData,  ChatSharedLocationResponseData,  ClosedCaptionRuleParameters,  CollectionRequest,  CollectionResponse,  Command,  CommentAddedEvent,  CommentDeletedEvent,  CommentReactionAddedEvent,  CommentReactionDeletedEvent,  CommentReactionUpdatedEvent,  CommentResponse,  CommentRestoredEvent,  CommentUpdatedEvent,  ConfigResponse,  ConnectUserDetailsRequest,  ContentCountRuleParameters,  CreateBlockListRequest,  CreateBlockListResponse,  CreateCollectionsRequest,  CreateCollectionsResponse,  CreateDeviceRequest,  CreateFeedsBatchRequest,  CreateFeedsBatchResponse,  CreateGuestRequest,  CreateGuestResponse,  CreatePollOptionRequest,  CreatePollRequest,  CreateUserGroupRequest,  CreateUserGroupResponse,  CustomActionRequestPayload,  Data,  DecayFunctionConfig,  DeleteActionConfigResponse,  DeleteActivitiesRequest,  DeleteActivitiesResponse,  DeleteActivityReactionResponse,  DeleteActivityRequestPayload,  DeleteActivityResponse,  DeleteBookmarkFolderResponse,  DeleteBookmarkResponse,  DeleteCollectionsResponse,  DeleteCommentBookmarkResponse,  DeleteCommentReactionResponse,  DeleteCommentRequestPayload,  DeleteCommentResponse,  DeleteFeedResponse,  DeleteMessageRequestPayload,  DeleteModerationConfigResponse,  DeleteReactionRequestPayload,  DeleteUserRequestPayload,  DeliveryReceiptsResponse,  DeviceResponse,  DraftPayloadResponse,  DraftResponse,  EnrichedActivity,  EnrichedCollectionResponse,  EnrichedReaction,  EnrichmentOptions,  EntityCreatorResponse,  EscalatePayload,  EscalationMetadata,  FeedCreatedEvent,  FeedDeletedEvent,  FeedGroup,  FeedGroupChangedEvent,  FeedGroupDeletedEvent,  FeedGroupRestoredEvent,  FeedInput,  FeedMemberAddedEvent,  FeedMemberRemovedEvent,  FeedMemberRequest,  FeedMemberResponse,  FeedMemberUpdatedEvent,  FeedOwnCapability,  FeedOwnData,  FeedRequest,  FeedResponse,  FeedSuggestionResponse,  FeedUpdatedEvent,  FeedsActivityLocation,  FeedsBookmarkResponse,  FeedsEnrichedCollectionResponse,  FeedsFeedResponse,  FeedsNotificationComment,  FeedsNotificationContext,  FeedsNotificationParentActivity,  FeedsNotificationTarget,  FeedsNotificationTrigger,  FeedsPreferences,  FeedsPreferencesResponse,  FeedsReactionGroupResponse,  FeedsReactionResponse,  FeedsV3ActivityResponse,  FeedsV3CommentResponse,  Field,  FileUploadConfig,  FileUploadRequest,  FileUploadResponse,  FilterConfigResponse,  FlagCountRuleParameters,  FlagRequest,  FlagResponse,  FlagUserOptions,  FollowBatchRequest,  FollowBatchResponse,  FollowCreatedEvent,  FollowDeletedEvent,  FollowRequest,  FollowResponse,  FollowUpdatedEvent,  FriendReactionsOptions,  FullUserResponse,  GetActionConfigResponse,  GetActivityResponse,  GetAppealResponse,  GetApplicationResponse,  GetBlockedUsersResponse,  GetCommentRepliesResponse,  GetCommentResponse,  GetCommentsResponse,  GetConfigResponse,  GetFollowSuggestionsResponse,  GetOGResponse,  GetOrCreateFeedRequest,  GetOrCreateFeedResponse,  GetUserGroupResponse,  GoogleVisionConfig,  HarmConfig,  HealthCheckEvent,  ImageContentParameters,  ImageData,  ImageRuleParameters,  ImageSize,  ImageUploadRequest,  ImageUploadResponse,  Images,  KeyframeRuleParameters,  LLMConfig,  LLMRule,  LabelThresholds,  ListBlockListResponse,  ListDevicesResponse,  ListUserGroupsResponse,  Location,  MarkActivityRequest,  MarkReviewedRequestPayload,  MembershipLevelResponse,  MessageResponse,  ModerationActionConfigResponse,  ModerationCustomActionEvent,  ModerationFlagResponse,  ModerationFlaggedEvent,  ModerationMarkReviewedEvent,  ModerationPayload,  ModerationPayloadResponse,  ModerationV2Response,  MuteRequest,  MuteResponse,  NotificationComment,  NotificationConfig,  NotificationContext,  NotificationFeedUpdatedEvent,  NotificationParentActivity,  NotificationStatusResponse,  NotificationTarget,  NotificationTrigger,  OCRRule,  OnlyUserID,  OwnBatchRequest,  OwnBatchResponse,  OwnUserResponse,  PagerRequest,  PagerResponse,  PinActivityRequest,  PinActivityResponse,  PollClosedFeedEvent,  PollDeletedFeedEvent,  PollOptionInput,  PollOptionRequest,  PollOptionResponse,  PollOptionResponseData,  PollResponse,  PollResponseData,  PollUpdatedFeedEvent,  PollVoteCastedFeedEvent,  PollVoteChangedFeedEvent,  PollVoteRemovedFeedEvent,  PollVoteResponse,  PollVoteResponseData,  PollVotesResponse,  PrivacySettingsResponse,  PushNotificationConfig,  PushPreferenceInput,  PushPreferencesResponse,  QueryActivitiesRequest,  QueryActivitiesResponse,  QueryActivityReactionsRequest,  QueryActivityReactionsResponse,  QueryAppealsRequest,  QueryAppealsResponse,  QueryBookmarkFoldersRequest,  QueryBookmarkFoldersResponse,  QueryBookmarksRequest,  QueryBookmarksResponse,  QueryCollectionsRequest,  QueryCollectionsResponse,  QueryCommentReactionsRequest,  QueryCommentReactionsResponse,  QueryCommentsRequest,  QueryCommentsResponse,  QueryFeedMembersRequest,  QueryFeedMembersResponse,  QueryFeedsRequest,  QueryFeedsResponse,  QueryFollowsRequest,  QueryFollowsResponse,  QueryModerationConfigsRequest,  QueryModerationConfigsResponse,  QueryPinnedActivitiesRequest,  QueryPinnedActivitiesResponse,  QueryPollVotesRequest,  QueryPollsRequest,  QueryPollsResponse,  QueryReviewQueueRequest,  QueryReviewQueueResponse,  QueryUsersPayload,  QueryUsersResponse,  RankingConfig,  Reaction,  ReactionGroupResponse,  ReactionGroupUserResponse,  ReactionResponse,  ReadCollectionsResponse,  ReadReceiptsResponse,  RejectAppealRequestPayload,  RejectFeedMemberInviteRequest,  RejectFeedMemberInviteResponse,  RejectFollowRequest,  RejectFollowResponse,  ReminderResponseData,  RemoveUserGroupMembersRequest,  RemoveUserGroupMembersResponse,  RepliesMeta,  Response,  RestoreActionRequestPayload,  RestoreActivityRequest,  RestoreActivityResponse,  RestoreCommentRequest,  RestoreCommentResponse,  ReviewQueueItemResponse,  RuleBuilderAction,  RuleBuilderCondition,  RuleBuilderConditionGroup,  RuleBuilderConfig,  RuleBuilderRule,  SearchUserGroupsResponse,  ShadowBlockActionRequestPayload,  SharedLocationResponse,  SharedLocationResponseData,  SharedLocationsResponse,  SingleFollowResponse,  SortParam,  SortParamRequest,  StoriesConfig,  StoriesFeedUpdatedEvent,  SubmitActionRequest,  SubmitActionResponse,  TextContentParameters,  TextRuleParameters,  ThreadedCommentResponse,  Thresholds,  Time,  TrackActivityMetricsEvent,  TrackActivityMetricsEventResult,  TrackActivityMetricsRequest,  TrackActivityMetricsResponse,  TypingIndicatorsResponse,  UnbanActionRequestPayload,  UnblockActionRequestPayload,  UnblockUsersRequest,  UnblockUsersResponse,  UnfollowBatchRequest,  UnfollowBatchResponse,  UnfollowPair,  UnfollowResponse,  UnpinActivityResponse,  UpdateActivityPartialRequest,  UpdateActivityPartialResponse,  UpdateActivityRequest,  UpdateActivityResponse,  UpdateBlockListRequest,  UpdateBlockListResponse,  UpdateBookmarkFolderRequest,  UpdateBookmarkFolderResponse,  UpdateBookmarkRequest,  UpdateBookmarkResponse,  UpdateCollectionRequest,  UpdateCollectionsRequest,  UpdateCollectionsResponse,  UpdateCommentBookmarkRequest,  UpdateCommentBookmarkResponse,  UpdateCommentPartialRequest,  UpdateCommentPartialResponse,  UpdateCommentRequest,  UpdateCommentResponse,  UpdateFeedMembersRequest,  UpdateFeedMembersResponse,  UpdateFeedRequest,  UpdateFeedResponse,  UpdateFollowRequest,  UpdateFollowResponse,  UpdateLiveLocationRequest,  UpdatePollOptionRequest,  UpdatePollPartialRequest,  UpdatePollRequest,  UpdateUserGroupRequest,  UpdateUserGroupResponse,  UpdateUserPartialRequest,  UpdateUsersPartialRequest,  UpdateUsersRequest,  UpdateUsersResponse,  UpsertActionConfigItem,  UpsertActionConfigRequest,  UpsertActionConfigResponse,  UpsertActivitiesRequest,  UpsertActivitiesResponse,  UpsertConfigRequest,  UpsertConfigResponse,  UpsertPushPreferencesRequest,  UpsertPushPreferencesResponse,  User,  UserBannedEvent,  UserCreatedWithinParameters,  UserCustomPropertyParameters,  UserDeactivatedEvent,  UserGroupMember,  UserGroupResponse,  UserIdenticalContentCountParameters,  UserMuteResponse,  UserReactivatedEvent,  UserRequest,  UserResponse,  UserResponseCommonFields,  UserResponsePrivacyFields,  UserRoleParameters,  UserRuleParameters,  UserUnbannedEvent,  UserUpdatedEvent,  VelocityFilterConfig,  VelocityFilterConfigRule,  VideoCallRuleConfig,  VideoContentParameters,  VideoEndCallRequestPayload,  VideoKickUserRequestPayload,  VideoRuleParameters,  VoteData,  WSAuthMessage,  WSClientEvent,  WSEvent,  } from '../models';
-import { decoders } from '../model-decoders/decoders'
+import type { ApiClient, StreamResponse } from '../../gen-imports';
+import type {
+  AcceptFeedMemberInviteRequest,
+  AcceptFeedMemberInviteResponse,
+  AcceptFollowRequest,
+  AcceptFollowResponse,
+  ActivityFeedbackRequest,
+  ActivityFeedbackResponse,
+  AddActivityRequest,
+  AddActivityResponse,
+  AddBookmarkRequest,
+  AddBookmarkResponse,
+  AddCommentBookmarkRequest,
+  AddCommentBookmarkResponse,
+  AddCommentReactionRequest,
+  AddCommentReactionResponse,
+  AddCommentRequest,
+  AddCommentResponse,
+  AddCommentsBatchRequest,
+  AddCommentsBatchResponse,
+  AddReactionRequest,
+  AddReactionResponse,
+  AddUserGroupMembersRequest,
+  AddUserGroupMembersResponse,
+  BlockUsersRequest,
+  BlockUsersResponse,
+  CastPollVoteRequest,
+  ChangeFeedVisibilityRequest,
+  ChangeFeedVisibilityResponse,
+  CreateBlockListRequest,
+  CreateBlockListResponse,
+  CreateCollectionsRequest,
+  CreateCollectionsResponse,
+  CreateDeviceRequest,
+  CreateFeedsBatchRequest,
+  CreateFeedsBatchResponse,
+  CreateGuestRequest,
+  CreateGuestResponse,
+  CreatePollOptionRequest,
+  CreatePollRequest,
+  CreateUserGroupRequest,
+  CreateUserGroupResponse,
+  DeleteActivitiesRequest,
+  DeleteActivitiesResponse,
+  DeleteActivityReactionResponse,
+  DeleteActivityResponse,
+  DeleteBookmarkFolderResponse,
+  DeleteBookmarkResponse,
+  DeleteCollectionsResponse,
+  DeleteCommentBookmarkResponse,
+  DeleteCommentReactionResponse,
+  DeleteCommentResponse,
+  DeleteFeedResponse,
+  FileUploadRequest,
+  FileUploadResponse,
+  FollowBatchRequest,
+  FollowBatchResponse,
+  FollowRequest,
+  GetActivityResponse,
+  GetApplicationResponse,
+  GetBlockedUsersResponse,
+  GetCommentRepliesResponse,
+  GetCommentResponse,
+  GetCommentsResponse,
+  GetFollowSuggestionsResponse,
+  GetOGResponse,
+  GetOrCreateFeedRequest,
+  GetOrCreateFeedResponse,
+  GetUserGroupResponse,
+  ImageUploadRequest,
+  ImageUploadResponse,
+  ListBlockListResponse,
+  ListDevicesResponse,
+  ListUserGroupsResponse,
+  MarkActivityRequest,
+  OwnBatchRequest,
+  OwnBatchResponse,
+  PinActivityRequest,
+  PinActivityResponse,
+  PollOptionResponse,
+  PollResponse,
+  PollVoteResponse,
+  PollVotesResponse,
+  QueryActivitiesRequest,
+  QueryActivitiesResponse,
+  QueryActivityReactionsRequest,
+  QueryActivityReactionsResponse,
+  QueryBookmarkFoldersRequest,
+  QueryBookmarkFoldersResponse,
+  QueryBookmarksRequest,
+  QueryBookmarksResponse,
+  QueryCollectionsRequest,
+  QueryCollectionsResponse,
+  QueryCommentReactionsRequest,
+  QueryCommentReactionsResponse,
+  QueryCommentsRequest,
+  QueryCommentsResponse,
+  QueryFeedMembersRequest,
+  QueryFeedMembersResponse,
+  QueryFeedsRequest,
+  QueryFeedsResponse,
+  QueryFollowsRequest,
+  QueryFollowsResponse,
+  QueryPinnedActivitiesRequest,
+  QueryPinnedActivitiesResponse,
+  QueryPollVotesRequest,
+  QueryPollsRequest,
+  QueryPollsResponse,
+  QueryUsersPayload,
+  QueryUsersResponse,
+  ReadCollectionsResponse,
+  RejectFeedMemberInviteRequest,
+  RejectFeedMemberInviteResponse,
+  RejectFollowRequest,
+  RejectFollowResponse,
+  RemoveUserGroupMembersRequest,
+  RemoveUserGroupMembersResponse,
+  Response,
+  RestoreActivityRequest,
+  RestoreActivityResponse,
+  RestoreCommentRequest,
+  RestoreCommentResponse,
+  SearchUserGroupsResponse,
+  SharedLocationResponse,
+  SharedLocationsResponse,
+  SingleFollowResponse,
+  TrackActivityMetricsRequest,
+  TrackActivityMetricsResponse,
+  UnblockUsersRequest,
+  UnblockUsersResponse,
+  UnfollowBatchRequest,
+  UnfollowBatchResponse,
+  UnfollowResponse,
+  UnpinActivityResponse,
+  UpdateActivityPartialRequest,
+  UpdateActivityPartialResponse,
+  UpdateActivityRequest,
+  UpdateActivityResponse,
+  UpdateBlockListRequest,
+  UpdateBlockListResponse,
+  UpdateBookmarkFolderRequest,
+  UpdateBookmarkFolderResponse,
+  UpdateBookmarkRequest,
+  UpdateBookmarkResponse,
+  UpdateCollectionsRequest,
+  UpdateCollectionsResponse,
+  UpdateCommentBookmarkRequest,
+  UpdateCommentBookmarkResponse,
+  UpdateCommentPartialRequest,
+  UpdateCommentPartialResponse,
+  UpdateCommentRequest,
+  UpdateCommentResponse,
+  UpdateFeedMembersRequest,
+  UpdateFeedMembersResponse,
+  UpdateFeedRequest,
+  UpdateFeedResponse,
+  UpdateFollowRequest,
+  UpdateFollowResponse,
+  UpdateLiveLocationRequest,
+  UpdatePollOptionRequest,
+  UpdatePollPartialRequest,
+  UpdatePollRequest,
+  UpdateUserGroupRequest,
+  UpdateUserGroupResponse,
+  UpdateUsersPartialRequest,
+  UpdateUsersRequest,
+  UpdateUsersResponse,
+  UpsertActivitiesRequest,
+  UpsertActivitiesResponse,
+  UpsertPushPreferencesRequest,
+  UpsertPushPreferencesResponse,
+  WSAuthMessage,
+} from '../models';
+import { decoders } from '../model-decoders/decoders';
 
 export class FeedsApi {
-
-    constructor(public readonly apiClient: ApiClient) {}
-
-    
-    async getApp (): Promise<StreamResponse<GetApplicationResponse>> {
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<GetApplicationResponse>>('GET', '/api/v2/app',  undefined ,  undefined  );
-
-       decoders["GetApplicationResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async listBlockLists (request?: 
-    
-    
-    {team?: string,
-    }
-    ): Promise<StreamResponse<ListBlockListResponse>> {
-        
-        const queryParams = {
-          team: request?.team,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<ListBlockListResponse>>('GET', '/api/v2/blocklists',  undefined , queryParams  );
-
-       decoders["ListBlockListResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async createBlockList (request: CreateBlockListRequest 
-    
-    ): Promise<StreamResponse<CreateBlockListResponse>> {
-        const body = {
-          name: request?.name,words: request?.words,is_leet_check_enabled: request?.is_leet_check_enabled,is_plural_check_enabled: request?.is_plural_check_enabled,team: request?.team,type: request?.type,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<CreateBlockListResponse>>('POST', '/api/v2/blocklists',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["CreateBlockListResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteBlockList (request: 
-    
-    
-    {name: string,team?: string,
-    }
-    ): Promise<StreamResponse<Response>> {
-        
-        const queryParams = {
-          team: request?.team,
-        };
-        const pathParams = {
-          name: request?.name,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/blocklists/{name}', pathParams , queryParams  );
-
-       decoders["Response"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateBlockList (request: UpdateBlockListRequest 
-     & 
-    
-    {name: string,
-    }
-    ): Promise<StreamResponse<UpdateBlockListResponse>> {
-        const pathParams = {
-          name: request?.name,
-        };
-        const body = {
-          is_leet_check_enabled: request?.is_leet_check_enabled,is_plural_check_enabled: request?.is_plural_check_enabled,team: request?.team,words: request?.words,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateBlockListResponse>>('PUT', '/api/v2/blocklists/{name}', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["UpdateBlockListResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteDevice (request: 
-    
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<Response>> {
-        
-        const queryParams = {
-          id: request?.id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/devices',  undefined , queryParams  );
-
-       decoders["Response"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async listDevices (): Promise<StreamResponse<ListDevicesResponse>> {
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<ListDevicesResponse>>('GET', '/api/v2/devices',  undefined ,  undefined  );
-
-       decoders["ListDevicesResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async createDevice (request: CreateDeviceRequest 
-    
-    ): Promise<StreamResponse<Response>> {
-        const body = {
-          id: request?.id,push_provider: request?.push_provider,push_provider_name: request?.push_provider_name,voip_token: request?.voip_token,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('POST', '/api/v2/devices',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["Response"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async addActivity (request: AddActivityRequest 
-    
-    ): Promise<StreamResponse<AddActivityResponse>> {
-        const body = {
-          type: request?.type,feeds: request?.feeds,copy_custom_to_notification: request?.copy_custom_to_notification,create_notification_activity: request?.create_notification_activity,enrich_own_fields: request?.enrich_own_fields,expires_at: request?.expires_at,id: request?.id,parent_id: request?.parent_id,poll_id: request?.poll_id,restrict_replies: request?.restrict_replies,skip_enrich_url: request?.skip_enrich_url,skip_push: request?.skip_push,text: request?.text,visibility: request?.visibility,visibility_tag: request?.visibility_tag,attachments: request?.attachments,collection_refs: request?.collection_refs,filter_tags: request?.filter_tags,interest_tags: request?.interest_tags,mentioned_user_ids: request?.mentioned_user_ids,custom: request?.custom,location: request?.location,search_data: request?.search_data,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<AddActivityResponse>>('POST', '/api/v2/feeds/activities',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["AddActivityResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async upsertActivities (request: UpsertActivitiesRequest 
-    
-    ): Promise<StreamResponse<UpsertActivitiesResponse>> {
-        const body = {
-          activities: request?.activities,enrich_own_fields: request?.enrich_own_fields,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpsertActivitiesResponse>>('POST', '/api/v2/feeds/activities/batch',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["UpsertActivitiesResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteActivities (request: DeleteActivitiesRequest 
-    
-    ): Promise<StreamResponse<DeleteActivitiesResponse>> {
-        const body = {
-          ids: request?.ids,delete_notification_activity: request?.delete_notification_activity,hard_delete: request?.hard_delete,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<DeleteActivitiesResponse>>('POST', '/api/v2/feeds/activities/delete',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["DeleteActivitiesResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async trackActivityMetrics (request: TrackActivityMetricsRequest 
-    
-    ): Promise<StreamResponse<TrackActivityMetricsResponse>> {
-        const body = {
-          events: request?.events,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<TrackActivityMetricsResponse>>('POST', '/api/v2/feeds/activities/metrics/track',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["TrackActivityMetricsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryActivities (request?: QueryActivitiesRequest 
-    
-    ): Promise<StreamResponse<QueryActivitiesResponse>> {
-        const body = {
-          enrich_own_fields: request?.enrich_own_fields,include_soft_deleted_activities: request?.include_soft_deleted_activities,limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryActivitiesResponse>>('POST', '/api/v2/feeds/activities/query',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["QueryActivitiesResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteBookmark (request: 
-    
-    
-    {activity_id: string,folder_id?: string,
-    }
-    ): Promise<StreamResponse<DeleteBookmarkResponse>> {
-        
-        const queryParams = {
-          folder_id: request?.folder_id,
-        };
-        const pathParams = {
-          activity_id: request?.activity_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<DeleteBookmarkResponse>>('DELETE', '/api/v2/feeds/activities/{activity_id}/bookmarks', pathParams , queryParams  );
-
-       decoders["DeleteBookmarkResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateBookmark (request: UpdateBookmarkRequest 
-     & 
-    
-    {activity_id: string,
-    }
-    ): Promise<StreamResponse<UpdateBookmarkResponse>> {
-        const pathParams = {
-          activity_id: request?.activity_id,
-        };
-        const body = {
-          folder_id: request?.folder_id,new_folder_id: request?.new_folder_id,custom: request?.custom,new_folder: request?.new_folder,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateBookmarkResponse>>('PATCH', '/api/v2/feeds/activities/{activity_id}/bookmarks', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["UpdateBookmarkResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async addBookmark (request: AddBookmarkRequest 
-     & 
-    
-    {activity_id: string,
-    }
-    ): Promise<StreamResponse<AddBookmarkResponse>> {
-        const pathParams = {
-          activity_id: request?.activity_id,
-        };
-        const body = {
-          folder_id: request?.folder_id,custom: request?.custom,new_folder: request?.new_folder,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<AddBookmarkResponse>>('POST', '/api/v2/feeds/activities/{activity_id}/bookmarks', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["AddBookmarkResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async activityFeedback (request: ActivityFeedbackRequest 
-     & 
-    
-    {activity_id: string,
-    }
-    ): Promise<StreamResponse<ActivityFeedbackResponse>> {
-        const pathParams = {
-          activity_id: request?.activity_id,
-        };
-        const body = {
-          hide: request?.hide,show_less: request?.show_less,show_more: request?.show_more,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<ActivityFeedbackResponse>>('POST', '/api/v2/feeds/activities/{activity_id}/feedback', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["ActivityFeedbackResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async castPollVote (request: CastPollVoteRequest 
-     & 
-    
-    {activity_id: string,poll_id: string,
-    }
-    ): Promise<StreamResponse<PollVoteResponse>> {
-        const pathParams = {
-          activity_id: request?.activity_id, poll_id: request?.poll_id,
-        };
-        const body = {
-          vote: request?.vote,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<PollVoteResponse>>('POST', '/api/v2/feeds/activities/{activity_id}/polls/{poll_id}/vote', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["PollVoteResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deletePollVote (request: 
-    
-    
-    {activity_id: string,poll_id: string,vote_id: string,user_id?: string,
-    }
-    ): Promise<StreamResponse<PollVoteResponse>> {
-        
-        const queryParams = {
-          user_id: request?.user_id,
-        };
-        const pathParams = {
-          activity_id: request?.activity_id, poll_id: request?.poll_id, vote_id: request?.vote_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<PollVoteResponse>>('DELETE', '/api/v2/feeds/activities/{activity_id}/polls/{poll_id}/vote/{vote_id}', pathParams , queryParams  );
-
-       decoders["PollVoteResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async addActivityReaction (request: AddReactionRequest 
-     & 
-    
-    {activity_id: string,
-    }
-    ): Promise<StreamResponse<AddReactionResponse>> {
-        const pathParams = {
-          activity_id: request?.activity_id,
-        };
-        const body = {
-          type: request?.type,copy_custom_to_notification: request?.copy_custom_to_notification,create_notification_activity: request?.create_notification_activity,enforce_unique: request?.enforce_unique,skip_push: request?.skip_push,custom: request?.custom,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<AddReactionResponse>>('POST', '/api/v2/feeds/activities/{activity_id}/reactions', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["AddReactionResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryActivityReactions (request: QueryActivityReactionsRequest 
-     & 
-    
-    {activity_id: string,
-    }
-    ): Promise<StreamResponse<QueryActivityReactionsResponse>> {
-        const pathParams = {
-          activity_id: request?.activity_id,
-        };
-        const body = {
-          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryActivityReactionsResponse>>('POST', '/api/v2/feeds/activities/{activity_id}/reactions/query', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["QueryActivityReactionsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteActivityReaction (request: 
-    
-    
-    {activity_id: string,type: string,delete_notification_activity?: boolean,
-    }
-    ): Promise<StreamResponse<DeleteActivityReactionResponse>> {
-        
-        const queryParams = {
-          delete_notification_activity: request?.delete_notification_activity,
-        };
-        const pathParams = {
-          activity_id: request?.activity_id, type: request?.type,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<DeleteActivityReactionResponse>>('DELETE', '/api/v2/feeds/activities/{activity_id}/reactions/{type}', pathParams , queryParams  );
-
-       decoders["DeleteActivityReactionResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteActivity (request: 
-    
-    
-    {id: string,hard_delete?: boolean,delete_notification_activity?: boolean,
-    }
-    ): Promise<StreamResponse<DeleteActivityResponse>> {
-        
-        const queryParams = {
-          hard_delete: request?.hard_delete, delete_notification_activity: request?.delete_notification_activity,
-        };
-        const pathParams = {
-          id: request?.id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<DeleteActivityResponse>>('DELETE', '/api/v2/feeds/activities/{id}', pathParams , queryParams  );
-
-       decoders["DeleteActivityResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getActivity (request: 
-    
-    
-    {id: string,comment_sort?: string,comment_limit?: number,
-    }
-    ): Promise<StreamResponse<GetActivityResponse>> {
-        
-        const queryParams = {
-          comment_sort: request?.comment_sort, comment_limit: request?.comment_limit,
-        };
-        const pathParams = {
-          id: request?.id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<GetActivityResponse>>('GET', '/api/v2/feeds/activities/{id}', pathParams , queryParams  );
-
-       decoders["GetActivityResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateActivityPartial (request: UpdateActivityPartialRequest 
-     & 
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<UpdateActivityPartialResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        const body = {
-          copy_custom_to_notification: request?.copy_custom_to_notification,enrich_own_fields: request?.enrich_own_fields,handle_mention_notifications: request?.handle_mention_notifications,run_activity_processors: request?.run_activity_processors,unset: request?.unset,set: request?.set,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateActivityPartialResponse>>('PATCH', '/api/v2/feeds/activities/{id}', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["UpdateActivityPartialResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateActivity (request: UpdateActivityRequest 
-     & 
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<UpdateActivityResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        const body = {
-          copy_custom_to_notification: request?.copy_custom_to_notification,enrich_own_fields: request?.enrich_own_fields,expires_at: request?.expires_at,handle_mention_notifications: request?.handle_mention_notifications,poll_id: request?.poll_id,restrict_replies: request?.restrict_replies,run_activity_processors: request?.run_activity_processors,skip_enrich_url: request?.skip_enrich_url,text: request?.text,visibility: request?.visibility,visibility_tag: request?.visibility_tag,attachments: request?.attachments,collection_refs: request?.collection_refs,feeds: request?.feeds,filter_tags: request?.filter_tags,interest_tags: request?.interest_tags,mentioned_user_ids: request?.mentioned_user_ids,custom: request?.custom,location: request?.location,search_data: request?.search_data,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateActivityResponse>>('PUT', '/api/v2/feeds/activities/{id}', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["UpdateActivityResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async restoreActivity (request: RestoreActivityRequest 
-     & 
-    
-    {id: string,enrich_own_fields?: boolean,
-    }
-    ): Promise<StreamResponse<RestoreActivityResponse>> {
-        
-        const queryParams = {
-          enrich_own_fields: request?.enrich_own_fields,
-        };
-        const pathParams = {
-          id: request?.id,
-        };
-        const body = {
-          
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<RestoreActivityResponse>>('POST', '/api/v2/feeds/activities/{id}/restore', pathParams , queryParams  , body, 'application/json');
-
-       decoders["RestoreActivityResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryBookmarkFolders (request?: QueryBookmarkFoldersRequest 
-    
-    ): Promise<StreamResponse<QueryBookmarkFoldersResponse>> {
-        const body = {
-          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryBookmarkFoldersResponse>>('POST', '/api/v2/feeds/bookmark_folders/query',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["QueryBookmarkFoldersResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteBookmarkFolder (request: 
-    
-    
-    {folder_id: string,
-    }
-    ): Promise<StreamResponse<DeleteBookmarkFolderResponse>> {
-        const pathParams = {
-          folder_id: request?.folder_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<DeleteBookmarkFolderResponse>>('DELETE', '/api/v2/feeds/bookmark_folders/{folder_id}', pathParams ,  undefined  );
-
-       decoders["DeleteBookmarkFolderResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateBookmarkFolder (request: UpdateBookmarkFolderRequest 
-     & 
-    
-    {folder_id: string,
-    }
-    ): Promise<StreamResponse<UpdateBookmarkFolderResponse>> {
-        const pathParams = {
-          folder_id: request?.folder_id,
-        };
-        const body = {
-          name: request?.name,custom: request?.custom,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateBookmarkFolderResponse>>('PATCH', '/api/v2/feeds/bookmark_folders/{folder_id}', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["UpdateBookmarkFolderResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryBookmarks (request?: QueryBookmarksRequest 
-    
-    ): Promise<StreamResponse<QueryBookmarksResponse>> {
-        const body = {
-          enrich_own_fields: request?.enrich_own_fields,limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryBookmarksResponse>>('POST', '/api/v2/feeds/bookmarks/query',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["QueryBookmarksResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteCollections (request: 
-    
-    
-    {collection_refs: Array<string>,
-    }
-    ): Promise<StreamResponse<DeleteCollectionsResponse>> {
-        
-        const queryParams = {
-          collection_refs: request?.collection_refs,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<DeleteCollectionsResponse>>('DELETE', '/api/v2/feeds/collections',  undefined , queryParams  );
-
-       decoders["DeleteCollectionsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async readCollections (request?: 
-    
-    
-    {collection_refs?: Array<string>,
-    }
-    ): Promise<StreamResponse<ReadCollectionsResponse>> {
-        
-        const queryParams = {
-          collection_refs: request?.collection_refs,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<ReadCollectionsResponse>>('GET', '/api/v2/feeds/collections',  undefined , queryParams  );
-
-       decoders["ReadCollectionsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateCollections (request: UpdateCollectionsRequest 
-    
-    ): Promise<StreamResponse<UpdateCollectionsResponse>> {
-        const body = {
-          collections: request?.collections,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateCollectionsResponse>>('PATCH', '/api/v2/feeds/collections',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["UpdateCollectionsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async createCollections (request: CreateCollectionsRequest 
-    
-    ): Promise<StreamResponse<CreateCollectionsResponse>> {
-        const body = {
-          collections: request?.collections,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<CreateCollectionsResponse>>('POST', '/api/v2/feeds/collections',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["CreateCollectionsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryCollections (request?: QueryCollectionsRequest 
-    
-    ): Promise<StreamResponse<QueryCollectionsResponse>> {
-        const body = {
-          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryCollectionsResponse>>('POST', '/api/v2/feeds/collections/query',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["QueryCollectionsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getComments (request: 
-    
-    
-    {object_id: string,object_type: string,depth?: number,sort?: string,replies_limit?: number,id_around?: string,limit?: number,prev?: string,next?: string,
-    }
-    ): Promise<StreamResponse<GetCommentsResponse>> {
-        
-        const queryParams = {
-          object_id: request?.object_id, object_type: request?.object_type, depth: request?.depth, sort: request?.sort, replies_limit: request?.replies_limit, id_around: request?.id_around, limit: request?.limit, prev: request?.prev, next: request?.next,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<GetCommentsResponse>>('GET', '/api/v2/feeds/comments',  undefined , queryParams  );
-
-       decoders["GetCommentsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async addComment (request?: AddCommentRequest 
-    
-    ): Promise<StreamResponse<AddCommentResponse>> {
-        const body = {
-          comment: request?.comment,copy_custom_to_notification: request?.copy_custom_to_notification,create_notification_activity: request?.create_notification_activity,id: request?.id,object_id: request?.object_id,object_type: request?.object_type,parent_id: request?.parent_id,skip_enrich_url: request?.skip_enrich_url,skip_push: request?.skip_push,attachments: request?.attachments,mentioned_user_ids: request?.mentioned_user_ids,custom: request?.custom,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<AddCommentResponse>>('POST', '/api/v2/feeds/comments',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["AddCommentResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async addCommentsBatch (request: AddCommentsBatchRequest 
-    
-    ): Promise<StreamResponse<AddCommentsBatchResponse>> {
-        const body = {
-          comments: request?.comments,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<AddCommentsBatchResponse>>('POST', '/api/v2/feeds/comments/batch',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["AddCommentsBatchResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryComments (request: QueryCommentsRequest 
-    
-    ): Promise<StreamResponse<QueryCommentsResponse>> {
-        const body = {
-          filter: request?.filter,id_around: request?.id_around,limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryCommentsResponse>>('POST', '/api/v2/feeds/comments/query',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["QueryCommentsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteCommentBookmark (request: 
-    
-    
-    {comment_id: string,folder_id?: string,
-    }
-    ): Promise<StreamResponse<DeleteCommentBookmarkResponse>> {
-        
-        const queryParams = {
-          folder_id: request?.folder_id,
-        };
-        const pathParams = {
-          comment_id: request?.comment_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<DeleteCommentBookmarkResponse>>('DELETE', '/api/v2/feeds/comments/{comment_id}/bookmarks', pathParams , queryParams  );
-
-       decoders["DeleteCommentBookmarkResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateCommentBookmark (request: UpdateCommentBookmarkRequest 
-     & 
-    
-    {comment_id: string,
-    }
-    ): Promise<StreamResponse<UpdateCommentBookmarkResponse>> {
-        const pathParams = {
-          comment_id: request?.comment_id,
-        };
-        const body = {
-          folder_id: request?.folder_id,new_folder_id: request?.new_folder_id,custom: request?.custom,new_folder: request?.new_folder,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateCommentBookmarkResponse>>('PATCH', '/api/v2/feeds/comments/{comment_id}/bookmarks', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["UpdateCommentBookmarkResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async addCommentBookmark (request: AddCommentBookmarkRequest 
-     & 
-    
-    {comment_id: string,
-    }
-    ): Promise<StreamResponse<AddCommentBookmarkResponse>> {
-        const pathParams = {
-          comment_id: request?.comment_id,
-        };
-        const body = {
-          folder_id: request?.folder_id,custom: request?.custom,new_folder: request?.new_folder,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<AddCommentBookmarkResponse>>('POST', '/api/v2/feeds/comments/{comment_id}/bookmarks', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["AddCommentBookmarkResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteComment (request: 
-    
-    
-    {id: string,hard_delete?: boolean,delete_notification_activity?: boolean,
-    }
-    ): Promise<StreamResponse<DeleteCommentResponse>> {
-        
-        const queryParams = {
-          hard_delete: request?.hard_delete, delete_notification_activity: request?.delete_notification_activity,
-        };
-        const pathParams = {
-          id: request?.id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<DeleteCommentResponse>>('DELETE', '/api/v2/feeds/comments/{id}', pathParams , queryParams  );
-
-       decoders["DeleteCommentResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getComment (request: 
-    
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<GetCommentResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<GetCommentResponse>>('GET', '/api/v2/feeds/comments/{id}', pathParams ,  undefined  );
-
-       decoders["GetCommentResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateComment (request: UpdateCommentRequest 
-     & 
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<UpdateCommentResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        const body = {
-          comment: request?.comment,copy_custom_to_notification: request?.copy_custom_to_notification,handle_mention_notifications: request?.handle_mention_notifications,skip_enrich_url: request?.skip_enrich_url,skip_push: request?.skip_push,attachments: request?.attachments,mentioned_user_ids: request?.mentioned_user_ids,custom: request?.custom,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateCommentResponse>>('PATCH', '/api/v2/feeds/comments/{id}', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["UpdateCommentResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateCommentPartial (request: UpdateCommentPartialRequest 
-     & 
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<UpdateCommentPartialResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        const body = {
-          copy_custom_to_notification: request?.copy_custom_to_notification,handle_mention_notifications: request?.handle_mention_notifications,skip_enrich_url: request?.skip_enrich_url,skip_push: request?.skip_push,unset: request?.unset,set: request?.set,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateCommentPartialResponse>>('POST', '/api/v2/feeds/comments/{id}/partial', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["UpdateCommentPartialResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async addCommentReaction (request: AddCommentReactionRequest 
-     & 
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<AddCommentReactionResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        const body = {
-          type: request?.type,copy_custom_to_notification: request?.copy_custom_to_notification,create_notification_activity: request?.create_notification_activity,enforce_unique: request?.enforce_unique,skip_push: request?.skip_push,custom: request?.custom,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<AddCommentReactionResponse>>('POST', '/api/v2/feeds/comments/{id}/reactions', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["AddCommentReactionResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryCommentReactions (request: QueryCommentReactionsRequest 
-     & 
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<QueryCommentReactionsResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        const body = {
-          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryCommentReactionsResponse>>('POST', '/api/v2/feeds/comments/{id}/reactions/query', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["QueryCommentReactionsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteCommentReaction (request: 
-    
-    
-    {id: string,type: string,delete_notification_activity?: boolean,
-    }
-    ): Promise<StreamResponse<DeleteCommentReactionResponse>> {
-        
-        const queryParams = {
-          delete_notification_activity: request?.delete_notification_activity,
-        };
-        const pathParams = {
-          id: request?.id, type: request?.type,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<DeleteCommentReactionResponse>>('DELETE', '/api/v2/feeds/comments/{id}/reactions/{type}', pathParams , queryParams  );
-
-       decoders["DeleteCommentReactionResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getCommentReplies (request: 
-    
-    
-    {id: string,depth?: number,sort?: string,replies_limit?: number,id_around?: string,limit?: number,prev?: string,next?: string,
-    }
-    ): Promise<StreamResponse<GetCommentRepliesResponse>> {
-        
-        const queryParams = {
-          depth: request?.depth, sort: request?.sort, replies_limit: request?.replies_limit, id_around: request?.id_around, limit: request?.limit, prev: request?.prev, next: request?.next,
-        };
-        const pathParams = {
-          id: request?.id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<GetCommentRepliesResponse>>('GET', '/api/v2/feeds/comments/{id}/replies', pathParams , queryParams  );
-
-       decoders["GetCommentRepliesResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async restoreComment (request: RestoreCommentRequest 
-     & 
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<RestoreCommentResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        const body = {
-          
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<RestoreCommentResponse>>('POST', '/api/v2/feeds/comments/{id}/restore', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["RestoreCommentResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteFeed (request: 
-    
-    
-    {feed_group_id: string,feed_id: string,hard_delete?: boolean,
-    }
-    ): Promise<StreamResponse<DeleteFeedResponse>> {
-        
-        const queryParams = {
-          hard_delete: request?.hard_delete,
-        };
-        const pathParams = {
-          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<DeleteFeedResponse>>('DELETE', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}', pathParams , queryParams  );
-
-       decoders["DeleteFeedResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getOrCreateFeed (request: GetOrCreateFeedRequest 
-     & 
-    
-    {feed_group_id: string,feed_id: string,connection_id?: string,
-    }
-    ): Promise<StreamResponse<GetOrCreateFeedResponse>> {
-        
-        const queryParams = {
-          connection_id: request?.connection_id,
-        };
-        const pathParams = {
-          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
-        };
-        const body = {
-          id_around: request?.id_around,limit: request?.limit,next: request?.next,prev: request?.prev,view: request?.view,watch: request?.watch,data: request?.data,enrichment_options: request?.enrichment_options,external_ranking: request?.external_ranking,filter: request?.filter,followers_pagination: request?.followers_pagination,following_pagination: request?.following_pagination,friend_reactions_options: request?.friend_reactions_options,interest_weights: request?.interest_weights,member_pagination: request?.member_pagination,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<GetOrCreateFeedResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}', pathParams , queryParams  , body, 'application/json');
-
-       decoders["GetOrCreateFeedResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateFeed (request: UpdateFeedRequest 
-     & 
-    
-    {feed_group_id: string,feed_id: string,
-    }
-    ): Promise<StreamResponse<UpdateFeedResponse>> {
-        const pathParams = {
-          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
-        };
-        const body = {
-          clear_location: request?.clear_location,description: request?.description,enrich_own_fields: request?.enrich_own_fields,name: request?.name,filter_tags: request?.filter_tags,custom: request?.custom,location: request?.location,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateFeedResponse>>('PUT', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["UpdateFeedResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async markActivity (request: MarkActivityRequest 
-     & 
-    
-    {feed_group_id: string,feed_id: string,
-    }
-    ): Promise<StreamResponse<Response>> {
-        const pathParams = {
-          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
-        };
-        const body = {
-          mark_all_read: request?.mark_all_read,mark_all_seen: request?.mark_all_seen,mark_read: request?.mark_read,mark_seen: request?.mark_seen,mark_watched: request?.mark_watched,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/mark/batch', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["Response"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async unpinActivity (request: 
-    
-    
-    {feed_group_id: string,feed_id: string,activity_id: string,enrich_own_fields?: boolean,
-    }
-    ): Promise<StreamResponse<UnpinActivityResponse>> {
-        
-        const queryParams = {
-          enrich_own_fields: request?.enrich_own_fields,
-        };
-        const pathParams = {
-          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id, activity_id: request?.activity_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UnpinActivityResponse>>('DELETE', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/{activity_id}/pin', pathParams , queryParams  );
-
-       decoders["UnpinActivityResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async pinActivity (request: PinActivityRequest 
-     & 
-    
-    {feed_group_id: string,feed_id: string,activity_id: string,
-    }
-    ): Promise<StreamResponse<PinActivityResponse>> {
-        const pathParams = {
-          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id, activity_id: request?.activity_id,
-        };
-        const body = {
-          enrich_own_fields: request?.enrich_own_fields,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<PinActivityResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/{activity_id}/pin', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["PinActivityResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async changeFeedVisibility (request: ChangeFeedVisibilityRequest 
-     & 
-    
-    {feed_group_id: string,feed_id: string,
-    }
-    ): Promise<StreamResponse<ChangeFeedVisibilityResponse>> {
-        const pathParams = {
-          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
-        };
-        const body = {
-          visibility: request?.visibility,pending_follows_action: request?.pending_follows_action,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<ChangeFeedVisibilityResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/change_visibility', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["ChangeFeedVisibilityResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateFeedMembers (request: UpdateFeedMembersRequest 
-     & 
-    
-    {feed_group_id: string,feed_id: string,
-    }
-    ): Promise<StreamResponse<UpdateFeedMembersResponse>> {
-        const pathParams = {
-          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
-        };
-        const body = {
-          operation: request?.operation,limit: request?.limit,next: request?.next,prev: request?.prev,members: request?.members,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateFeedMembersResponse>>('PATCH', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["UpdateFeedMembersResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async acceptFeedMemberInvite (request: AcceptFeedMemberInviteRequest 
-     & 
-    
-    {feed_id: string,feed_group_id: string,
-    }
-    ): Promise<StreamResponse<AcceptFeedMemberInviteResponse>> {
-        const pathParams = {
-          feed_id: request?.feed_id, feed_group_id: request?.feed_group_id,
-        };
-        const body = {
-          
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<AcceptFeedMemberInviteResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/accept', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["AcceptFeedMemberInviteResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryFeedMembers (request: QueryFeedMembersRequest 
-     & 
-    
-    {feed_group_id: string,feed_id: string,
-    }
-    ): Promise<StreamResponse<QueryFeedMembersResponse>> {
-        const pathParams = {
-          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
-        };
-        const body = {
-          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryFeedMembersResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/query', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["QueryFeedMembersResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async rejectFeedMemberInvite (request: RejectFeedMemberInviteRequest 
-     & 
-    
-    {feed_group_id: string,feed_id: string,
-    }
-    ): Promise<StreamResponse<RejectFeedMemberInviteResponse>> {
-        const pathParams = {
-          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
-        };
-        const body = {
-          
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<RejectFeedMemberInviteResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/reject', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["RejectFeedMemberInviteResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryPinnedActivities (request: QueryPinnedActivitiesRequest 
-     & 
-    
-    {feed_group_id: string,feed_id: string,
-    }
-    ): Promise<StreamResponse<QueryPinnedActivitiesResponse>> {
-        const pathParams = {
-          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
-        };
-        const body = {
-          enrich_own_fields: request?.enrich_own_fields,limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryPinnedActivitiesResponse>>('POST', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/pinned_activities/query', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["QueryPinnedActivitiesResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async stopWatchingFeed (request: 
-    
-    
-    {feed_group_id: string,feed_id: string,connection_id?: string,
-    }
-    ): Promise<StreamResponse<Response>> {
-        
-        const queryParams = {
-          connection_id: request?.connection_id,
-        };
-        const pathParams = {
-          feed_group_id: request?.feed_group_id, feed_id: request?.feed_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/watch', pathParams , queryParams  );
-
-       decoders["Response"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getFollowSuggestions (request: 
-    
-    
-    {feed_group_id: string,limit?: number,
-    }
-    ): Promise<StreamResponse<GetFollowSuggestionsResponse>> {
-        
-        const queryParams = {
-          limit: request?.limit,
-        };
-        const pathParams = {
-          feed_group_id: request?.feed_group_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<GetFollowSuggestionsResponse>>('GET', '/api/v2/feeds/feed_groups/{feed_group_id}/follow_suggestions', pathParams , queryParams  );
-
-       decoders["GetFollowSuggestionsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async createFeedsBatch (request: CreateFeedsBatchRequest 
-    
-    ): Promise<StreamResponse<CreateFeedsBatchResponse>> {
-        const body = {
-          feeds: request?.feeds,enrich_own_fields: request?.enrich_own_fields,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<CreateFeedsBatchResponse>>('POST', '/api/v2/feeds/feeds/batch',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["CreateFeedsBatchResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async ownBatch (request: OwnBatchRequest 
-     & 
-    
-    {connection_id?: string,
-    }
-    ): Promise<StreamResponse<OwnBatchResponse>> {
-        
-        const queryParams = {
-          connection_id: request?.connection_id,
-        };
-        const body = {
-          feeds: request?.feeds,fields: request?.fields,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<OwnBatchResponse>>('POST', '/api/v2/feeds/feeds/own/batch',  undefined , queryParams  , body, 'application/json');
-
-       decoders["OwnBatchResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    protected async _queryFeeds (request?: QueryFeedsRequest 
-     & 
-    
-    {connection_id?: string,
-    }
-    ): Promise<StreamResponse<QueryFeedsResponse>> {
-        
-        const queryParams = {
-          connection_id: request?.connection_id,
-        };
-        const body = {
-          enrich_own_fields: request?.enrich_own_fields,limit: request?.limit,next: request?.next,prev: request?.prev,watch: request?.watch,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryFeedsResponse>>('POST', '/api/v2/feeds/feeds/query',  undefined , queryParams  , body, 'application/json');
-
-       decoders["QueryFeedsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateFollow (request: UpdateFollowRequest 
-    
-    ): Promise<StreamResponse<UpdateFollowResponse>> {
-        const body = {
-          source: request?.source,target: request?.target,activity_copy_limit: request?.activity_copy_limit,copy_custom_to_notification: request?.copy_custom_to_notification,create_notification_activity: request?.create_notification_activity,enrich_own_fields: request?.enrich_own_fields,follower_role: request?.follower_role,push_preference: request?.push_preference,skip_push: request?.skip_push,custom: request?.custom,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateFollowResponse>>('PATCH', '/api/v2/feeds/follows',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["UpdateFollowResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async follow (request: FollowRequest 
-    
-    ): Promise<StreamResponse<SingleFollowResponse>> {
-        const body = {
-          source: request?.source,target: request?.target,activity_copy_limit: request?.activity_copy_limit,copy_custom_to_notification: request?.copy_custom_to_notification,create_notification_activity: request?.create_notification_activity,enrich_own_fields: request?.enrich_own_fields,push_preference: request?.push_preference,skip_push: request?.skip_push,custom: request?.custom,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<SingleFollowResponse>>('POST', '/api/v2/feeds/follows',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["SingleFollowResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async acceptFollow (request: AcceptFollowRequest 
-    
-    ): Promise<StreamResponse<AcceptFollowResponse>> {
-        const body = {
-          source: request?.source,target: request?.target,follower_role: request?.follower_role,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<AcceptFollowResponse>>('POST', '/api/v2/feeds/follows/accept',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["AcceptFollowResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async followBatch (request: FollowBatchRequest 
-    
-    ): Promise<StreamResponse<FollowBatchResponse>> {
-        const body = {
-          follows: request?.follows,enrich_own_fields: request?.enrich_own_fields,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<FollowBatchResponse>>('POST', '/api/v2/feeds/follows/batch',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["FollowBatchResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getOrCreateFollows (request: FollowBatchRequest 
-    
-    ): Promise<StreamResponse<FollowBatchResponse>> {
-        const body = {
-          follows: request?.follows,enrich_own_fields: request?.enrich_own_fields,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<FollowBatchResponse>>('POST', '/api/v2/feeds/follows/batch/upsert',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["FollowBatchResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryFollows (request?: QueryFollowsRequest 
-    
-    ): Promise<StreamResponse<QueryFollowsResponse>> {
-        const body = {
-          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryFollowsResponse>>('POST', '/api/v2/feeds/follows/query',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["QueryFollowsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async rejectFollow (request: RejectFollowRequest 
-    
-    ): Promise<StreamResponse<RejectFollowResponse>> {
-        const body = {
-          source: request?.source,target: request?.target,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<RejectFollowResponse>>('POST', '/api/v2/feeds/follows/reject',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["RejectFollowResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async unfollow (request: 
-    
-    
-    {source: string,target: string,delete_notification_activity?: boolean,keep_history?: boolean,enrich_own_fields?: boolean,
-    }
-    ): Promise<StreamResponse<UnfollowResponse>> {
-        
-        const queryParams = {
-          delete_notification_activity: request?.delete_notification_activity, keep_history: request?.keep_history, enrich_own_fields: request?.enrich_own_fields,
-        };
-        const pathParams = {
-          source: request?.source, target: request?.target,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UnfollowResponse>>('DELETE', '/api/v2/feeds/follows/{source}/{target}', pathParams , queryParams  );
-
-       decoders["UnfollowResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getOrCreateUnfollows (request: UnfollowBatchRequest 
-    
-    ): Promise<StreamResponse<UnfollowBatchResponse>> {
-        const body = {
-          follows: request?.follows,delete_notification_activity: request?.delete_notification_activity,enrich_own_fields: request?.enrich_own_fields,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UnfollowBatchResponse>>('POST', '/api/v2/feeds/unfollow/batch/upsert',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["UnfollowBatchResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async createGuest (request: CreateGuestRequest 
-    
-    ): Promise<StreamResponse<CreateGuestResponse>> {
-        const body = {
-          user: request?.user,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<CreateGuestResponse>>('POST', '/api/v2/guest',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["CreateGuestResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async longPoll (request?: 
-    
-    
-    {connection_id?: string,json?: WSAuthMessage,
-    }
-    ): Promise<StreamResponse<{}>> {
-        
-        const queryParams = {
-          connection_id: request?.connection_id, json: request?.json,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<{}>>('GET', '/api/v2/longpoll',  undefined , queryParams  );
-
-       decoders["{}"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getOG (request: 
-    
-    
-    {url: string,
-    }
-    ): Promise<StreamResponse<GetOGResponse>> {
-        
-        const queryParams = {
-          url: request?.url,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<GetOGResponse>>('GET', '/api/v2/og',  undefined , queryParams  );
-
-       decoders["GetOGResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async createPoll (request: CreatePollRequest 
-    
-    ): Promise<StreamResponse<PollResponse>> {
-        const body = {
-          name: request?.name,allow_answers: request?.allow_answers,allow_user_suggested_options: request?.allow_user_suggested_options,description: request?.description,enforce_unique_vote: request?.enforce_unique_vote,id: request?.id,is_closed: request?.is_closed,max_votes_allowed: request?.max_votes_allowed,voting_visibility: request?.voting_visibility,options: request?.options,custom: request?.custom,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<PollResponse>>('POST', '/api/v2/polls',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["PollResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updatePoll (request: UpdatePollRequest 
-    
-    ): Promise<StreamResponse<PollResponse>> {
-        const body = {
-          id: request?.id,name: request?.name,allow_answers: request?.allow_answers,allow_user_suggested_options: request?.allow_user_suggested_options,description: request?.description,enforce_unique_vote: request?.enforce_unique_vote,is_closed: request?.is_closed,max_votes_allowed: request?.max_votes_allowed,voting_visibility: request?.voting_visibility,options: request?.options,custom: request?.custom,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<PollResponse>>('PUT', '/api/v2/polls',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["PollResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryPolls (request?: QueryPollsRequest 
-     & 
-    
-    {user_id?: string,
-    }
-    ): Promise<StreamResponse<QueryPollsResponse>> {
-        
-        const queryParams = {
-          user_id: request?.user_id,
-        };
-        const body = {
-          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryPollsResponse>>('POST', '/api/v2/polls/query',  undefined , queryParams  , body, 'application/json');
-
-       decoders["QueryPollsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deletePoll (request: 
-    
-    
-    {poll_id: string,user_id?: string,
-    }
-    ): Promise<StreamResponse<Response>> {
-        
-        const queryParams = {
-          user_id: request?.user_id,
-        };
-        const pathParams = {
-          poll_id: request?.poll_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/polls/{poll_id}', pathParams , queryParams  );
-
-       decoders["Response"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getPoll (request: 
-    
-    
-    {poll_id: string,user_id?: string,
-    }
-    ): Promise<StreamResponse<PollResponse>> {
-        
-        const queryParams = {
-          user_id: request?.user_id,
-        };
-        const pathParams = {
-          poll_id: request?.poll_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<PollResponse>>('GET', '/api/v2/polls/{poll_id}', pathParams , queryParams  );
-
-       decoders["PollResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updatePollPartial (request: UpdatePollPartialRequest 
-     & 
-    
-    {poll_id: string,
-    }
-    ): Promise<StreamResponse<PollResponse>> {
-        const pathParams = {
-          poll_id: request?.poll_id,
-        };
-        const body = {
-          unset: request?.unset,set: request?.set,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<PollResponse>>('PATCH', '/api/v2/polls/{poll_id}', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["PollResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async createPollOption (request: CreatePollOptionRequest 
-     & 
-    
-    {poll_id: string,
-    }
-    ): Promise<StreamResponse<PollOptionResponse>> {
-        const pathParams = {
-          poll_id: request?.poll_id,
-        };
-        const body = {
-          text: request?.text,custom: request?.custom,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<PollOptionResponse>>('POST', '/api/v2/polls/{poll_id}/options', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["PollOptionResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updatePollOption (request: UpdatePollOptionRequest 
-     & 
-    
-    {poll_id: string,
-    }
-    ): Promise<StreamResponse<PollOptionResponse>> {
-        const pathParams = {
-          poll_id: request?.poll_id,
-        };
-        const body = {
-          id: request?.id,text: request?.text,custom: request?.custom,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<PollOptionResponse>>('PUT', '/api/v2/polls/{poll_id}/options', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["PollOptionResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deletePollOption (request: 
-    
-    
-    {poll_id: string,option_id: string,user_id?: string,
-    }
-    ): Promise<StreamResponse<Response>> {
-        
-        const queryParams = {
-          user_id: request?.user_id,
-        };
-        const pathParams = {
-          poll_id: request?.poll_id, option_id: request?.option_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/polls/{poll_id}/options/{option_id}', pathParams , queryParams  );
-
-       decoders["Response"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getPollOption (request: 
-    
-    
-    {poll_id: string,option_id: string,user_id?: string,
-    }
-    ): Promise<StreamResponse<PollOptionResponse>> {
-        
-        const queryParams = {
-          user_id: request?.user_id,
-        };
-        const pathParams = {
-          poll_id: request?.poll_id, option_id: request?.option_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<PollOptionResponse>>('GET', '/api/v2/polls/{poll_id}/options/{option_id}', pathParams , queryParams  );
-
-       decoders["PollOptionResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryPollVotes (request: QueryPollVotesRequest 
-     & 
-    
-    {poll_id: string,user_id?: string,
-    }
-    ): Promise<StreamResponse<PollVotesResponse>> {
-        
-        const queryParams = {
-          user_id: request?.user_id,
-        };
-        const pathParams = {
-          poll_id: request?.poll_id,
-        };
-        const body = {
-          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<PollVotesResponse>>('POST', '/api/v2/polls/{poll_id}/votes', pathParams , queryParams  , body, 'application/json');
-
-       decoders["PollVotesResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updatePushNotificationPreferences (request: UpsertPushPreferencesRequest 
-    
-    ): Promise<StreamResponse<UpsertPushPreferencesResponse>> {
-        const body = {
-          preferences: request?.preferences,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpsertPushPreferencesResponse>>('POST', '/api/v2/push_preferences',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["UpsertPushPreferencesResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteFile (request?: 
-    
-    
-    {url?: string,
-    }
-    ): Promise<StreamResponse<Response>> {
-        
-        const queryParams = {
-          url: request?.url,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/uploads/file',  undefined , queryParams  );
-
-       decoders["Response"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async uploadFile (request?: FileUploadRequest 
-    
-    ): Promise<StreamResponse<FileUploadResponse>> {
-        const body = {
-          file: request?.file,user: request?.user,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<FileUploadResponse>>('POST', '/api/v2/uploads/file',  undefined ,  undefined  , body, 'multipart/form-data');
-
-       decoders["FileUploadResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteImage (request?: 
-    
-    
-    {url?: string,
-    }
-    ): Promise<StreamResponse<Response>> {
-        
-        const queryParams = {
-          url: request?.url,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/uploads/image',  undefined , queryParams  );
-
-       decoders["Response"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async uploadImage (request?: ImageUploadRequest 
-    
-    ): Promise<StreamResponse<ImageUploadResponse>> {
-        const body = {
-          file: request?.file,upload_sizes: request?.upload_sizes,user: request?.user,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<ImageUploadResponse>>('POST', '/api/v2/uploads/image',  undefined ,  undefined  , body, 'multipart/form-data');
-
-       decoders["ImageUploadResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async listUserGroups (request?: 
-    
-    
-    {limit?: number,id_gt?: string,created_at_gt?: string,team_id?: string,
-    }
-    ): Promise<StreamResponse<ListUserGroupsResponse>> {
-        
-        const queryParams = {
-          limit: request?.limit, id_gt: request?.id_gt, created_at_gt: request?.created_at_gt, team_id: request?.team_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<ListUserGroupsResponse>>('GET', '/api/v2/usergroups',  undefined , queryParams  );
-
-       decoders["ListUserGroupsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async createUserGroup (request: CreateUserGroupRequest 
-    
-    ): Promise<StreamResponse<CreateUserGroupResponse>> {
-        const body = {
-          name: request?.name,description: request?.description,id: request?.id,team_id: request?.team_id,member_ids: request?.member_ids,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<CreateUserGroupResponse>>('POST', '/api/v2/usergroups',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["CreateUserGroupResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async searchUserGroups (request: 
-    
-    
-    {query: string,limit?: number,name_gt?: string,id_gt?: string,team_id?: string,
-    }
-    ): Promise<StreamResponse<SearchUserGroupsResponse>> {
-        
-        const queryParams = {
-          query: request?.query, limit: request?.limit, name_gt: request?.name_gt, id_gt: request?.id_gt, team_id: request?.team_id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<SearchUserGroupsResponse>>('GET', '/api/v2/usergroups/search',  undefined , queryParams  );
-
-       decoders["SearchUserGroupsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteUserGroup (request: 
-    
-    
-    {id: string,team_id?: string,
-    }
-    ): Promise<StreamResponse<Response>> {
-        
-        const queryParams = {
-          team_id: request?.team_id,
-        };
-        const pathParams = {
-          id: request?.id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<Response>>('DELETE', '/api/v2/usergroups/{id}', pathParams , queryParams  );
-
-       decoders["Response"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getUserGroup (request: 
-    
-    
-    {id: string,team_id?: string,
-    }
-    ): Promise<StreamResponse<GetUserGroupResponse>> {
-        
-        const queryParams = {
-          team_id: request?.team_id,
-        };
-        const pathParams = {
-          id: request?.id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<GetUserGroupResponse>>('GET', '/api/v2/usergroups/{id}', pathParams , queryParams  );
-
-       decoders["GetUserGroupResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateUserGroup (request: UpdateUserGroupRequest 
-     & 
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<UpdateUserGroupResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        const body = {
-          description: request?.description,name: request?.name,team_id: request?.team_id,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateUserGroupResponse>>('PUT', '/api/v2/usergroups/{id}', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["UpdateUserGroupResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async addUserGroupMembers (request: AddUserGroupMembersRequest 
-     & 
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<AddUserGroupMembersResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        const body = {
-          member_ids: request?.member_ids,as_admin: request?.as_admin,team_id: request?.team_id,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<AddUserGroupMembersResponse>>('POST', '/api/v2/usergroups/{id}/members', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["AddUserGroupMembersResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async removeUserGroupMembers (request: RemoveUserGroupMembersRequest 
-     & 
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<RemoveUserGroupMembersResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        const body = {
-          member_ids: request?.member_ids,team_id: request?.team_id,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<RemoveUserGroupMembersResponse>>('POST', '/api/v2/usergroups/{id}/members/delete', pathParams ,  undefined  , body, 'application/json');
-
-       decoders["RemoveUserGroupMembersResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryUsers (request?: 
-    
-    
-    {payload?: QueryUsersPayload,
-    }
-    ): Promise<StreamResponse<QueryUsersResponse>> {
-        
-        const queryParams = {
-          payload: request?.payload,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryUsersResponse>>('GET', '/api/v2/users',  undefined , queryParams  );
-
-       decoders["QueryUsersResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateUsersPartial (request: UpdateUsersPartialRequest 
-    
-    ): Promise<StreamResponse<UpdateUsersResponse>> {
-        const body = {
-          users: request?.users,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateUsersResponse>>('PATCH', '/api/v2/users',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["UpdateUsersResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateUsers (request: UpdateUsersRequest 
-    
-    ): Promise<StreamResponse<UpdateUsersResponse>> {
-        const body = {
-          users: request?.users,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpdateUsersResponse>>('POST', '/api/v2/users',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["UpdateUsersResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getBlockedUsers (): Promise<StreamResponse<GetBlockedUsersResponse>> {
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<GetBlockedUsersResponse>>('GET', '/api/v2/users/block',  undefined ,  undefined  );
-
-       decoders["GetBlockedUsersResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async blockUsers (request: BlockUsersRequest 
-    
-    ): Promise<StreamResponse<BlockUsersResponse>> {
-        const body = {
-          blocked_user_id: request?.blocked_user_id,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<BlockUsersResponse>>('POST', '/api/v2/users/block',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["BlockUsersResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getUserLiveLocations (): Promise<StreamResponse<SharedLocationsResponse>> {
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<SharedLocationsResponse>>('GET', '/api/v2/users/live_locations',  undefined ,  undefined  );
-
-       decoders["SharedLocationsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async updateLiveLocation (request: UpdateLiveLocationRequest 
-    
-    ): Promise<StreamResponse<SharedLocationResponse>> {
-        const body = {
-          message_id: request?.message_id,end_at: request?.end_at,latitude: request?.latitude,longitude: request?.longitude,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<SharedLocationResponse>>('PUT', '/api/v2/users/live_locations',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["SharedLocationResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async unblockUsers (request: UnblockUsersRequest 
-    
-    ): Promise<StreamResponse<UnblockUsersResponse>> {
-        const body = {
-          blocked_user_id: request?.blocked_user_id,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UnblockUsersResponse>>('POST', '/api/v2/users/unblock',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["UnblockUsersResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
+  constructor(public readonly apiClient: ApiClient) {}
+
+  async getApp(): Promise<StreamResponse<GetApplicationResponse>> {
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetApplicationResponse>
+    >('GET', '/api/v2/app', undefined, undefined);
+
+    decoders.GetApplicationResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async listBlockLists(request?: {
+    team?: string;
+  }): Promise<StreamResponse<ListBlockListResponse>> {
+    const queryParams = {
+      team: request?.team,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<ListBlockListResponse>
+    >('GET', '/api/v2/blocklists', undefined, queryParams);
+
+    decoders.ListBlockListResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async createBlockList(
+    request: CreateBlockListRequest,
+  ): Promise<StreamResponse<CreateBlockListResponse>> {
+    const body = {
+      name: request?.name,
+      words: request?.words,
+      is_leet_check_enabled: request?.is_leet_check_enabled,
+      is_plural_check_enabled: request?.is_plural_check_enabled,
+      team: request?.team,
+      type: request?.type,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<CreateBlockListResponse>
+    >(
+      'POST',
+      '/api/v2/blocklists',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.CreateBlockListResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteBlockList(request: {
+    name: string;
+    team?: string;
+  }): Promise<StreamResponse<Response>> {
+    const queryParams = {
+      team: request?.team,
+    };
+    const pathParams = {
+      name: request?.name,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'DELETE',
+      '/api/v2/blocklists/{name}',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.Response?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateBlockList(
+    request: UpdateBlockListRequest & { name: string },
+  ): Promise<StreamResponse<UpdateBlockListResponse>> {
+    const pathParams = {
+      name: request?.name,
+    };
+    const body = {
+      is_leet_check_enabled: request?.is_leet_check_enabled,
+      is_plural_check_enabled: request?.is_plural_check_enabled,
+      team: request?.team,
+      words: request?.words,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateBlockListResponse>
+    >(
+      'PUT',
+      '/api/v2/blocklists/{name}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateBlockListResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteDevice(request: {
+    id: string;
+  }): Promise<StreamResponse<Response>> {
+    const queryParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'DELETE',
+      '/api/v2/devices',
+      undefined,
+      queryParams,
+    );
+
+    decoders.Response?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async listDevices(): Promise<StreamResponse<ListDevicesResponse>> {
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<ListDevicesResponse>
+    >('GET', '/api/v2/devices', undefined, undefined);
+
+    decoders.ListDevicesResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async createDevice(
+    request: CreateDeviceRequest,
+  ): Promise<StreamResponse<Response>> {
+    const body = {
+      id: request?.id,
+      push_provider: request?.push_provider,
+      push_provider_name: request?.push_provider_name,
+      voip_token: request?.voip_token,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'POST',
+      '/api/v2/devices',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.Response?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async addActivity(
+    request: AddActivityRequest,
+  ): Promise<StreamResponse<AddActivityResponse>> {
+    const body = {
+      type: request?.type,
+      feeds: request?.feeds,
+      copy_custom_to_notification: request?.copy_custom_to_notification,
+      create_notification_activity: request?.create_notification_activity,
+      enrich_own_fields: request?.enrich_own_fields,
+      expires_at: request?.expires_at,
+      id: request?.id,
+      parent_id: request?.parent_id,
+      poll_id: request?.poll_id,
+      restrict_replies: request?.restrict_replies,
+      skip_enrich_url: request?.skip_enrich_url,
+      skip_push: request?.skip_push,
+      text: request?.text,
+      visibility: request?.visibility,
+      visibility_tag: request?.visibility_tag,
+      attachments: request?.attachments,
+      collection_refs: request?.collection_refs,
+      filter_tags: request?.filter_tags,
+      interest_tags: request?.interest_tags,
+      mentioned_user_ids: request?.mentioned_user_ids,
+      custom: request?.custom,
+      location: request?.location,
+      search_data: request?.search_data,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<AddActivityResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/activities',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.AddActivityResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async upsertActivities(
+    request: UpsertActivitiesRequest,
+  ): Promise<StreamResponse<UpsertActivitiesResponse>> {
+    const body = {
+      activities: request?.activities,
+      enrich_own_fields: request?.enrich_own_fields,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpsertActivitiesResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/activities/batch',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpsertActivitiesResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteActivities(
+    request: DeleteActivitiesRequest,
+  ): Promise<StreamResponse<DeleteActivitiesResponse>> {
+    const body = {
+      ids: request?.ids,
+      delete_notification_activity: request?.delete_notification_activity,
+      hard_delete: request?.hard_delete,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteActivitiesResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/activities/delete',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.DeleteActivitiesResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async trackActivityMetrics(
+    request: TrackActivityMetricsRequest,
+  ): Promise<StreamResponse<TrackActivityMetricsResponse>> {
+    const body = {
+      events: request?.events,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<TrackActivityMetricsResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/activities/metrics/track',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.TrackActivityMetricsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryActivities(
+    request?: QueryActivitiesRequest,
+  ): Promise<StreamResponse<QueryActivitiesResponse>> {
+    const body = {
+      enrich_own_fields: request?.enrich_own_fields,
+      include_soft_deleted_activities: request?.include_soft_deleted_activities,
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryActivitiesResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/activities/query',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryActivitiesResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteBookmark(request: {
+    activity_id: string;
+    folder_id?: string;
+  }): Promise<StreamResponse<DeleteBookmarkResponse>> {
+    const queryParams = {
+      folder_id: request?.folder_id,
+    };
+    const pathParams = {
+      activity_id: request?.activity_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteBookmarkResponse>
+    >(
+      'DELETE',
+      '/api/v2/feeds/activities/{activity_id}/bookmarks',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.DeleteBookmarkResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateBookmark(
+    request: UpdateBookmarkRequest & { activity_id: string },
+  ): Promise<StreamResponse<UpdateBookmarkResponse>> {
+    const pathParams = {
+      activity_id: request?.activity_id,
+    };
+    const body = {
+      folder_id: request?.folder_id,
+      new_folder_id: request?.new_folder_id,
+      custom: request?.custom,
+      new_folder: request?.new_folder,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateBookmarkResponse>
+    >(
+      'PATCH',
+      '/api/v2/feeds/activities/{activity_id}/bookmarks',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateBookmarkResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async addBookmark(
+    request: AddBookmarkRequest & { activity_id: string },
+  ): Promise<StreamResponse<AddBookmarkResponse>> {
+    const pathParams = {
+      activity_id: request?.activity_id,
+    };
+    const body = {
+      folder_id: request?.folder_id,
+      custom: request?.custom,
+      new_folder: request?.new_folder,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<AddBookmarkResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/activities/{activity_id}/bookmarks',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.AddBookmarkResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async activityFeedback(
+    request: ActivityFeedbackRequest & { activity_id: string },
+  ): Promise<StreamResponse<ActivityFeedbackResponse>> {
+    const pathParams = {
+      activity_id: request?.activity_id,
+    };
+    const body = {
+      hide: request?.hide,
+      show_less: request?.show_less,
+      show_more: request?.show_more,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<ActivityFeedbackResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/activities/{activity_id}/feedback',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.ActivityFeedbackResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async castPollVote(
+    request: CastPollVoteRequest & { activity_id: string; poll_id: string },
+  ): Promise<StreamResponse<PollVoteResponse>> {
+    const pathParams = {
+      activity_id: request?.activity_id,
+      poll_id: request?.poll_id,
+    };
+    const body = {
+      vote: request?.vote,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<PollVoteResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/activities/{activity_id}/polls/{poll_id}/vote',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.PollVoteResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deletePollVote(request: {
+    activity_id: string;
+    poll_id: string;
+    vote_id: string;
+    user_id?: string;
+  }): Promise<StreamResponse<PollVoteResponse>> {
+    const queryParams = {
+      user_id: request?.user_id,
+    };
+    const pathParams = {
+      activity_id: request?.activity_id,
+      poll_id: request?.poll_id,
+      vote_id: request?.vote_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<PollVoteResponse>
+    >(
+      'DELETE',
+      '/api/v2/feeds/activities/{activity_id}/polls/{poll_id}/vote/{vote_id}',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.PollVoteResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async addActivityReaction(
+    request: AddReactionRequest & { activity_id: string },
+  ): Promise<StreamResponse<AddReactionResponse>> {
+    const pathParams = {
+      activity_id: request?.activity_id,
+    };
+    const body = {
+      type: request?.type,
+      copy_custom_to_notification: request?.copy_custom_to_notification,
+      create_notification_activity: request?.create_notification_activity,
+      enforce_unique: request?.enforce_unique,
+      skip_push: request?.skip_push,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<AddReactionResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/activities/{activity_id}/reactions',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.AddReactionResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryActivityReactions(
+    request: QueryActivityReactionsRequest & { activity_id: string },
+  ): Promise<StreamResponse<QueryActivityReactionsResponse>> {
+    const pathParams = {
+      activity_id: request?.activity_id,
+    };
+    const body = {
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryActivityReactionsResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/activities/{activity_id}/reactions/query',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryActivityReactionsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteActivityReaction(request: {
+    activity_id: string;
+    type: string;
+    delete_notification_activity?: boolean;
+  }): Promise<StreamResponse<DeleteActivityReactionResponse>> {
+    const queryParams = {
+      delete_notification_activity: request?.delete_notification_activity,
+    };
+    const pathParams = {
+      activity_id: request?.activity_id,
+      type: request?.type,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteActivityReactionResponse>
+    >(
+      'DELETE',
+      '/api/v2/feeds/activities/{activity_id}/reactions/{type}',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.DeleteActivityReactionResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteActivity(request: {
+    id: string;
+    hard_delete?: boolean;
+    delete_notification_activity?: boolean;
+  }): Promise<StreamResponse<DeleteActivityResponse>> {
+    const queryParams = {
+      hard_delete: request?.hard_delete,
+      delete_notification_activity: request?.delete_notification_activity,
+    };
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteActivityResponse>
+    >('DELETE', '/api/v2/feeds/activities/{id}', pathParams, queryParams);
+
+    decoders.DeleteActivityResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getActivity(request: {
+    id: string;
+    comment_sort?: string;
+    comment_limit?: number;
+  }): Promise<StreamResponse<GetActivityResponse>> {
+    const queryParams = {
+      comment_sort: request?.comment_sort,
+      comment_limit: request?.comment_limit,
+    };
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetActivityResponse>
+    >('GET', '/api/v2/feeds/activities/{id}', pathParams, queryParams);
+
+    decoders.GetActivityResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateActivityPartial(
+    request: UpdateActivityPartialRequest & { id: string },
+  ): Promise<StreamResponse<UpdateActivityPartialResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      copy_custom_to_notification: request?.copy_custom_to_notification,
+      enrich_own_fields: request?.enrich_own_fields,
+      handle_mention_notifications: request?.handle_mention_notifications,
+      run_activity_processors: request?.run_activity_processors,
+      unset: request?.unset,
+      set: request?.set,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateActivityPartialResponse>
+    >(
+      'PATCH',
+      '/api/v2/feeds/activities/{id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateActivityPartialResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateActivity(
+    request: UpdateActivityRequest & { id: string },
+  ): Promise<StreamResponse<UpdateActivityResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      copy_custom_to_notification: request?.copy_custom_to_notification,
+      enrich_own_fields: request?.enrich_own_fields,
+      expires_at: request?.expires_at,
+      handle_mention_notifications: request?.handle_mention_notifications,
+      poll_id: request?.poll_id,
+      restrict_replies: request?.restrict_replies,
+      run_activity_processors: request?.run_activity_processors,
+      skip_enrich_url: request?.skip_enrich_url,
+      text: request?.text,
+      visibility: request?.visibility,
+      visibility_tag: request?.visibility_tag,
+      attachments: request?.attachments,
+      collection_refs: request?.collection_refs,
+      feeds: request?.feeds,
+      filter_tags: request?.filter_tags,
+      interest_tags: request?.interest_tags,
+      mentioned_user_ids: request?.mentioned_user_ids,
+      custom: request?.custom,
+      location: request?.location,
+      search_data: request?.search_data,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateActivityResponse>
+    >(
+      'PUT',
+      '/api/v2/feeds/activities/{id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateActivityResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async restoreActivity(
+    request: RestoreActivityRequest & {
+      id: string;
+      enrich_own_fields?: boolean;
+    },
+  ): Promise<StreamResponse<RestoreActivityResponse>> {
+    const queryParams = {
+      enrich_own_fields: request?.enrich_own_fields,
+    };
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {};
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<RestoreActivityResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/activities/{id}/restore',
+      pathParams,
+      queryParams,
+      body,
+      'application/json',
+    );
+
+    decoders.RestoreActivityResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryBookmarkFolders(
+    request?: QueryBookmarkFoldersRequest,
+  ): Promise<StreamResponse<QueryBookmarkFoldersResponse>> {
+    const body = {
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryBookmarkFoldersResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/bookmark_folders/query',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryBookmarkFoldersResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteBookmarkFolder(request: {
+    folder_id: string;
+  }): Promise<StreamResponse<DeleteBookmarkFolderResponse>> {
+    const pathParams = {
+      folder_id: request?.folder_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteBookmarkFolderResponse>
+    >(
+      'DELETE',
+      '/api/v2/feeds/bookmark_folders/{folder_id}',
+      pathParams,
+      undefined,
+    );
+
+    decoders.DeleteBookmarkFolderResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateBookmarkFolder(
+    request: UpdateBookmarkFolderRequest & { folder_id: string },
+  ): Promise<StreamResponse<UpdateBookmarkFolderResponse>> {
+    const pathParams = {
+      folder_id: request?.folder_id,
+    };
+    const body = {
+      name: request?.name,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateBookmarkFolderResponse>
+    >(
+      'PATCH',
+      '/api/v2/feeds/bookmark_folders/{folder_id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateBookmarkFolderResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryBookmarks(
+    request?: QueryBookmarksRequest,
+  ): Promise<StreamResponse<QueryBookmarksResponse>> {
+    const body = {
+      enrich_own_fields: request?.enrich_own_fields,
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryBookmarksResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/bookmarks/query',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryBookmarksResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteCollections(request: {
+    collection_refs: string[];
+  }): Promise<StreamResponse<DeleteCollectionsResponse>> {
+    const queryParams = {
+      collection_refs: request?.collection_refs,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteCollectionsResponse>
+    >('DELETE', '/api/v2/feeds/collections', undefined, queryParams);
+
+    decoders.DeleteCollectionsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async readCollections(request?: {
+    collection_refs?: string[];
+  }): Promise<StreamResponse<ReadCollectionsResponse>> {
+    const queryParams = {
+      collection_refs: request?.collection_refs,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<ReadCollectionsResponse>
+    >('GET', '/api/v2/feeds/collections', undefined, queryParams);
+
+    decoders.ReadCollectionsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateCollections(
+    request: UpdateCollectionsRequest,
+  ): Promise<StreamResponse<UpdateCollectionsResponse>> {
+    const body = {
+      collections: request?.collections,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateCollectionsResponse>
+    >(
+      'PATCH',
+      '/api/v2/feeds/collections',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateCollectionsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async createCollections(
+    request: CreateCollectionsRequest,
+  ): Promise<StreamResponse<CreateCollectionsResponse>> {
+    const body = {
+      collections: request?.collections,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<CreateCollectionsResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/collections',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.CreateCollectionsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryCollections(
+    request?: QueryCollectionsRequest,
+  ): Promise<StreamResponse<QueryCollectionsResponse>> {
+    const body = {
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryCollectionsResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/collections/query',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryCollectionsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getComments(request: {
+    object_id: string;
+    object_type: string;
+    depth?: number;
+    sort?: string;
+    replies_limit?: number;
+    id_around?: string;
+    limit?: number;
+    prev?: string;
+    next?: string;
+  }): Promise<StreamResponse<GetCommentsResponse>> {
+    const queryParams = {
+      object_id: request?.object_id,
+      object_type: request?.object_type,
+      depth: request?.depth,
+      sort: request?.sort,
+      replies_limit: request?.replies_limit,
+      id_around: request?.id_around,
+      limit: request?.limit,
+      prev: request?.prev,
+      next: request?.next,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetCommentsResponse>
+    >('GET', '/api/v2/feeds/comments', undefined, queryParams);
+
+    decoders.GetCommentsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async addComment(
+    request?: AddCommentRequest,
+  ): Promise<StreamResponse<AddCommentResponse>> {
+    const body = {
+      comment: request?.comment,
+      copy_custom_to_notification: request?.copy_custom_to_notification,
+      create_notification_activity: request?.create_notification_activity,
+      id: request?.id,
+      object_id: request?.object_id,
+      object_type: request?.object_type,
+      parent_id: request?.parent_id,
+      skip_enrich_url: request?.skip_enrich_url,
+      skip_push: request?.skip_push,
+      attachments: request?.attachments,
+      mentioned_user_ids: request?.mentioned_user_ids,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<AddCommentResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/comments',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.AddCommentResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async addCommentsBatch(
+    request: AddCommentsBatchRequest,
+  ): Promise<StreamResponse<AddCommentsBatchResponse>> {
+    const body = {
+      comments: request?.comments,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<AddCommentsBatchResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/comments/batch',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.AddCommentsBatchResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryComments(
+    request: QueryCommentsRequest,
+  ): Promise<StreamResponse<QueryCommentsResponse>> {
+    const body = {
+      filter: request?.filter,
+      id_around: request?.id_around,
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryCommentsResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/comments/query',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryCommentsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteCommentBookmark(request: {
+    comment_id: string;
+    folder_id?: string;
+  }): Promise<StreamResponse<DeleteCommentBookmarkResponse>> {
+    const queryParams = {
+      folder_id: request?.folder_id,
+    };
+    const pathParams = {
+      comment_id: request?.comment_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteCommentBookmarkResponse>
+    >(
+      'DELETE',
+      '/api/v2/feeds/comments/{comment_id}/bookmarks',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.DeleteCommentBookmarkResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateCommentBookmark(
+    request: UpdateCommentBookmarkRequest & { comment_id: string },
+  ): Promise<StreamResponse<UpdateCommentBookmarkResponse>> {
+    const pathParams = {
+      comment_id: request?.comment_id,
+    };
+    const body = {
+      folder_id: request?.folder_id,
+      new_folder_id: request?.new_folder_id,
+      custom: request?.custom,
+      new_folder: request?.new_folder,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateCommentBookmarkResponse>
+    >(
+      'PATCH',
+      '/api/v2/feeds/comments/{comment_id}/bookmarks',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateCommentBookmarkResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async addCommentBookmark(
+    request: AddCommentBookmarkRequest & { comment_id: string },
+  ): Promise<StreamResponse<AddCommentBookmarkResponse>> {
+    const pathParams = {
+      comment_id: request?.comment_id,
+    };
+    const body = {
+      folder_id: request?.folder_id,
+      custom: request?.custom,
+      new_folder: request?.new_folder,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<AddCommentBookmarkResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/comments/{comment_id}/bookmarks',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.AddCommentBookmarkResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteComment(request: {
+    id: string;
+    hard_delete?: boolean;
+    delete_notification_activity?: boolean;
+  }): Promise<StreamResponse<DeleteCommentResponse>> {
+    const queryParams = {
+      hard_delete: request?.hard_delete,
+      delete_notification_activity: request?.delete_notification_activity,
+    };
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteCommentResponse>
+    >('DELETE', '/api/v2/feeds/comments/{id}', pathParams, queryParams);
+
+    decoders.DeleteCommentResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getComment(request: {
+    id: string;
+  }): Promise<StreamResponse<GetCommentResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetCommentResponse>
+    >('GET', '/api/v2/feeds/comments/{id}', pathParams, undefined);
+
+    decoders.GetCommentResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateComment(
+    request: UpdateCommentRequest & { id: string },
+  ): Promise<StreamResponse<UpdateCommentResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      comment: request?.comment,
+      copy_custom_to_notification: request?.copy_custom_to_notification,
+      handle_mention_notifications: request?.handle_mention_notifications,
+      skip_enrich_url: request?.skip_enrich_url,
+      skip_push: request?.skip_push,
+      attachments: request?.attachments,
+      mentioned_user_ids: request?.mentioned_user_ids,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateCommentResponse>
+    >(
+      'PATCH',
+      '/api/v2/feeds/comments/{id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateCommentResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateCommentPartial(
+    request: UpdateCommentPartialRequest & { id: string },
+  ): Promise<StreamResponse<UpdateCommentPartialResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      copy_custom_to_notification: request?.copy_custom_to_notification,
+      handle_mention_notifications: request?.handle_mention_notifications,
+      skip_enrich_url: request?.skip_enrich_url,
+      skip_push: request?.skip_push,
+      unset: request?.unset,
+      set: request?.set,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateCommentPartialResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/comments/{id}/partial',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateCommentPartialResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async addCommentReaction(
+    request: AddCommentReactionRequest & { id: string },
+  ): Promise<StreamResponse<AddCommentReactionResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      type: request?.type,
+      copy_custom_to_notification: request?.copy_custom_to_notification,
+      create_notification_activity: request?.create_notification_activity,
+      enforce_unique: request?.enforce_unique,
+      skip_push: request?.skip_push,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<AddCommentReactionResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/comments/{id}/reactions',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.AddCommentReactionResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryCommentReactions(
+    request: QueryCommentReactionsRequest & { id: string },
+  ): Promise<StreamResponse<QueryCommentReactionsResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryCommentReactionsResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/comments/{id}/reactions/query',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryCommentReactionsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteCommentReaction(request: {
+    id: string;
+    type: string;
+    delete_notification_activity?: boolean;
+  }): Promise<StreamResponse<DeleteCommentReactionResponse>> {
+    const queryParams = {
+      delete_notification_activity: request?.delete_notification_activity,
+    };
+    const pathParams = {
+      id: request?.id,
+      type: request?.type,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteCommentReactionResponse>
+    >(
+      'DELETE',
+      '/api/v2/feeds/comments/{id}/reactions/{type}',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.DeleteCommentReactionResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getCommentReplies(request: {
+    id: string;
+    depth?: number;
+    sort?: string;
+    replies_limit?: number;
+    id_around?: string;
+    limit?: number;
+    prev?: string;
+    next?: string;
+  }): Promise<StreamResponse<GetCommentRepliesResponse>> {
+    const queryParams = {
+      depth: request?.depth,
+      sort: request?.sort,
+      replies_limit: request?.replies_limit,
+      id_around: request?.id_around,
+      limit: request?.limit,
+      prev: request?.prev,
+      next: request?.next,
+    };
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetCommentRepliesResponse>
+    >('GET', '/api/v2/feeds/comments/{id}/replies', pathParams, queryParams);
+
+    decoders.GetCommentRepliesResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async restoreComment(
+    request: RestoreCommentRequest & { id: string },
+  ): Promise<StreamResponse<RestoreCommentResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {};
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<RestoreCommentResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/comments/{id}/restore',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.RestoreCommentResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteFeed(request: {
+    feed_group_id: string;
+    feed_id: string;
+    hard_delete?: boolean;
+  }): Promise<StreamResponse<DeleteFeedResponse>> {
+    const queryParams = {
+      hard_delete: request?.hard_delete,
+    };
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteFeedResponse>
+    >(
+      'DELETE',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.DeleteFeedResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getOrCreateFeed(
+    request: GetOrCreateFeedRequest & {
+      feed_group_id: string;
+      feed_id: string;
+      connection_id?: string;
+    },
+  ): Promise<StreamResponse<GetOrCreateFeedResponse>> {
+    const queryParams = {
+      connection_id: request?.connection_id,
+    };
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+    };
+    const body = {
+      id_around: request?.id_around,
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      view: request?.view,
+      watch: request?.watch,
+      data: request?.data,
+      enrichment_options: request?.enrichment_options,
+      external_ranking: request?.external_ranking,
+      filter: request?.filter,
+      followers_pagination: request?.followers_pagination,
+      following_pagination: request?.following_pagination,
+      friend_reactions_options: request?.friend_reactions_options,
+      interest_weights: request?.interest_weights,
+      member_pagination: request?.member_pagination,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetOrCreateFeedResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}',
+      pathParams,
+      queryParams,
+      body,
+      'application/json',
+    );
+
+    decoders.GetOrCreateFeedResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateFeed(
+    request: UpdateFeedRequest & { feed_group_id: string; feed_id: string },
+  ): Promise<StreamResponse<UpdateFeedResponse>> {
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+    };
+    const body = {
+      clear_location: request?.clear_location,
+      description: request?.description,
+      enrich_own_fields: request?.enrich_own_fields,
+      name: request?.name,
+      filter_tags: request?.filter_tags,
+      custom: request?.custom,
+      location: request?.location,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateFeedResponse>
+    >(
+      'PUT',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateFeedResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async markActivity(
+    request: MarkActivityRequest & { feed_group_id: string; feed_id: string },
+  ): Promise<StreamResponse<Response>> {
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+    };
+    const body = {
+      mark_all_read: request?.mark_all_read,
+      mark_all_seen: request?.mark_all_seen,
+      mark_read: request?.mark_read,
+      mark_seen: request?.mark_seen,
+      mark_watched: request?.mark_watched,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'POST',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/mark/batch',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.Response?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async unpinActivity(request: {
+    feed_group_id: string;
+    feed_id: string;
+    activity_id: string;
+    enrich_own_fields?: boolean;
+  }): Promise<StreamResponse<UnpinActivityResponse>> {
+    const queryParams = {
+      enrich_own_fields: request?.enrich_own_fields,
+    };
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+      activity_id: request?.activity_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UnpinActivityResponse>
+    >(
+      'DELETE',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/{activity_id}/pin',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.UnpinActivityResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async pinActivity(
+    request: PinActivityRequest & {
+      feed_group_id: string;
+      feed_id: string;
+      activity_id: string;
+    },
+  ): Promise<StreamResponse<PinActivityResponse>> {
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+      activity_id: request?.activity_id,
+    };
+    const body = {
+      enrich_own_fields: request?.enrich_own_fields,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<PinActivityResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/{activity_id}/pin',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.PinActivityResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async changeFeedVisibility(
+    request: ChangeFeedVisibilityRequest & {
+      feed_group_id: string;
+      feed_id: string;
+    },
+  ): Promise<StreamResponse<ChangeFeedVisibilityResponse>> {
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+    };
+    const body = {
+      visibility: request?.visibility,
+      pending_follows_action: request?.pending_follows_action,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<ChangeFeedVisibilityResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/change_visibility',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.ChangeFeedVisibilityResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateFeedMembers(
+    request: UpdateFeedMembersRequest & {
+      feed_group_id: string;
+      feed_id: string;
+    },
+  ): Promise<StreamResponse<UpdateFeedMembersResponse>> {
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+    };
+    const body = {
+      operation: request?.operation,
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      members: request?.members,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateFeedMembersResponse>
+    >(
+      'PATCH',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateFeedMembersResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async acceptFeedMemberInvite(
+    request: AcceptFeedMemberInviteRequest & {
+      feed_id: string;
+      feed_group_id: string;
+    },
+  ): Promise<StreamResponse<AcceptFeedMemberInviteResponse>> {
+    const pathParams = {
+      feed_id: request?.feed_id,
+      feed_group_id: request?.feed_group_id,
+    };
+    const body = {};
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<AcceptFeedMemberInviteResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/accept',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.AcceptFeedMemberInviteResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryFeedMembers(
+    request: QueryFeedMembersRequest & {
+      feed_group_id: string;
+      feed_id: string;
+    },
+  ): Promise<StreamResponse<QueryFeedMembersResponse>> {
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+    };
+    const body = {
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryFeedMembersResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/query',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryFeedMembersResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async rejectFeedMemberInvite(
+    request: RejectFeedMemberInviteRequest & {
+      feed_group_id: string;
+      feed_id: string;
+    },
+  ): Promise<StreamResponse<RejectFeedMemberInviteResponse>> {
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+    };
+    const body = {};
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<RejectFeedMemberInviteResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/reject',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.RejectFeedMemberInviteResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryPinnedActivities(
+    request: QueryPinnedActivitiesRequest & {
+      feed_group_id: string;
+      feed_id: string;
+    },
+  ): Promise<StreamResponse<QueryPinnedActivitiesResponse>> {
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+    };
+    const body = {
+      enrich_own_fields: request?.enrich_own_fields,
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryPinnedActivitiesResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/pinned_activities/query',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryPinnedActivitiesResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async stopWatchingFeed(request: {
+    feed_group_id: string;
+    feed_id: string;
+    connection_id?: string;
+  }): Promise<StreamResponse<Response>> {
+    const queryParams = {
+      connection_id: request?.connection_id,
+    };
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'DELETE',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/watch',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.Response?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getFollowSuggestions(request: {
+    feed_group_id: string;
+    limit?: number;
+  }): Promise<StreamResponse<GetFollowSuggestionsResponse>> {
+    const queryParams = {
+      limit: request?.limit,
+    };
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetFollowSuggestionsResponse>
+    >(
+      'GET',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/follow_suggestions',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.GetFollowSuggestionsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async createFeedsBatch(
+    request: CreateFeedsBatchRequest,
+  ): Promise<StreamResponse<CreateFeedsBatchResponse>> {
+    const body = {
+      feeds: request?.feeds,
+      enrich_own_fields: request?.enrich_own_fields,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<CreateFeedsBatchResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feeds/batch',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.CreateFeedsBatchResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async ownBatch(
+    request: OwnBatchRequest & { connection_id?: string },
+  ): Promise<StreamResponse<OwnBatchResponse>> {
+    const queryParams = {
+      connection_id: request?.connection_id,
+    };
+    const body = {
+      feeds: request?.feeds,
+      fields: request?.fields,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<OwnBatchResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feeds/own/batch',
+      undefined,
+      queryParams,
+      body,
+      'application/json',
+    );
+
+    decoders.OwnBatchResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  protected async _queryFeeds(
+    request?: QueryFeedsRequest & { connection_id?: string },
+  ): Promise<StreamResponse<QueryFeedsResponse>> {
+    const queryParams = {
+      connection_id: request?.connection_id,
+    };
+    const body = {
+      enrich_own_fields: request?.enrich_own_fields,
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      watch: request?.watch,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryFeedsResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feeds/query',
+      undefined,
+      queryParams,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryFeedsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateFollow(
+    request: UpdateFollowRequest,
+  ): Promise<StreamResponse<UpdateFollowResponse>> {
+    const body = {
+      source: request?.source,
+      target: request?.target,
+      activity_copy_limit: request?.activity_copy_limit,
+      copy_custom_to_notification: request?.copy_custom_to_notification,
+      create_notification_activity: request?.create_notification_activity,
+      enrich_own_fields: request?.enrich_own_fields,
+      follower_role: request?.follower_role,
+      push_preference: request?.push_preference,
+      skip_push: request?.skip_push,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateFollowResponse>
+    >(
+      'PATCH',
+      '/api/v2/feeds/follows',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateFollowResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async follow(
+    request: FollowRequest,
+  ): Promise<StreamResponse<SingleFollowResponse>> {
+    const body = {
+      source: request?.source,
+      target: request?.target,
+      activity_copy_limit: request?.activity_copy_limit,
+      copy_custom_to_notification: request?.copy_custom_to_notification,
+      create_notification_activity: request?.create_notification_activity,
+      enrich_own_fields: request?.enrich_own_fields,
+      push_preference: request?.push_preference,
+      skip_push: request?.skip_push,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<SingleFollowResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/follows',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.SingleFollowResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async acceptFollow(
+    request: AcceptFollowRequest,
+  ): Promise<StreamResponse<AcceptFollowResponse>> {
+    const body = {
+      source: request?.source,
+      target: request?.target,
+      follower_role: request?.follower_role,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<AcceptFollowResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/follows/accept',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.AcceptFollowResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async followBatch(
+    request: FollowBatchRequest,
+  ): Promise<StreamResponse<FollowBatchResponse>> {
+    const body = {
+      follows: request?.follows,
+      enrich_own_fields: request?.enrich_own_fields,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<FollowBatchResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/follows/batch',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.FollowBatchResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getOrCreateFollows(
+    request: FollowBatchRequest,
+  ): Promise<StreamResponse<FollowBatchResponse>> {
+    const body = {
+      follows: request?.follows,
+      enrich_own_fields: request?.enrich_own_fields,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<FollowBatchResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/follows/batch/upsert',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.FollowBatchResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryFollows(
+    request?: QueryFollowsRequest,
+  ): Promise<StreamResponse<QueryFollowsResponse>> {
+    const body = {
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryFollowsResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/follows/query',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryFollowsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async rejectFollow(
+    request: RejectFollowRequest,
+  ): Promise<StreamResponse<RejectFollowResponse>> {
+    const body = {
+      source: request?.source,
+      target: request?.target,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<RejectFollowResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/follows/reject',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.RejectFollowResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async unfollow(request: {
+    source: string;
+    target: string;
+    delete_notification_activity?: boolean;
+    keep_history?: boolean;
+    enrich_own_fields?: boolean;
+  }): Promise<StreamResponse<UnfollowResponse>> {
+    const queryParams = {
+      delete_notification_activity: request?.delete_notification_activity,
+      keep_history: request?.keep_history,
+      enrich_own_fields: request?.enrich_own_fields,
+    };
+    const pathParams = {
+      source: request?.source,
+      target: request?.target,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UnfollowResponse>
+    >(
+      'DELETE',
+      '/api/v2/feeds/follows/{source}/{target}',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.UnfollowResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getOrCreateUnfollows(
+    request: UnfollowBatchRequest,
+  ): Promise<StreamResponse<UnfollowBatchResponse>> {
+    const body = {
+      follows: request?.follows,
+      delete_notification_activity: request?.delete_notification_activity,
+      enrich_own_fields: request?.enrich_own_fields,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UnfollowBatchResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/unfollow/batch/upsert',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UnfollowBatchResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async createGuest(
+    request: CreateGuestRequest,
+  ): Promise<StreamResponse<CreateGuestResponse>> {
+    const body = {
+      user: request?.user,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<CreateGuestResponse>
+    >('POST', '/api/v2/guest', undefined, undefined, body, 'application/json');
+
+    decoders.CreateGuestResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async longPoll(request?: {
+    connection_id?: string;
+    json?: WSAuthMessage;
+  }): Promise<StreamResponse<{}>> {
+    const queryParams = {
+      connection_id: request?.connection_id,
+      json: request?.json,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<{}>>(
+      'GET',
+      '/api/v2/longpoll',
+      undefined,
+      queryParams,
+    );
+
+    decoders['{}']?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getOG(request: {
+    url: string;
+  }): Promise<StreamResponse<GetOGResponse>> {
+    const queryParams = {
+      url: request?.url,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetOGResponse>
+    >('GET', '/api/v2/og', undefined, queryParams);
+
+    decoders.GetOGResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async createPoll(
+    request: CreatePollRequest,
+  ): Promise<StreamResponse<PollResponse>> {
+    const body = {
+      name: request?.name,
+      allow_answers: request?.allow_answers,
+      allow_user_suggested_options: request?.allow_user_suggested_options,
+      description: request?.description,
+      enforce_unique_vote: request?.enforce_unique_vote,
+      id: request?.id,
+      is_closed: request?.is_closed,
+      max_votes_allowed: request?.max_votes_allowed,
+      voting_visibility: request?.voting_visibility,
+      options: request?.options,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<PollResponse>
+    >('POST', '/api/v2/polls', undefined, undefined, body, 'application/json');
+
+    decoders.PollResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updatePoll(
+    request: UpdatePollRequest,
+  ): Promise<StreamResponse<PollResponse>> {
+    const body = {
+      id: request?.id,
+      name: request?.name,
+      allow_answers: request?.allow_answers,
+      allow_user_suggested_options: request?.allow_user_suggested_options,
+      description: request?.description,
+      enforce_unique_vote: request?.enforce_unique_vote,
+      is_closed: request?.is_closed,
+      max_votes_allowed: request?.max_votes_allowed,
+      voting_visibility: request?.voting_visibility,
+      options: request?.options,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<PollResponse>
+    >('PUT', '/api/v2/polls', undefined, undefined, body, 'application/json');
+
+    decoders.PollResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryPolls(
+    request?: QueryPollsRequest & { user_id?: string },
+  ): Promise<StreamResponse<QueryPollsResponse>> {
+    const queryParams = {
+      user_id: request?.user_id,
+    };
+    const body = {
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryPollsResponse>
+    >(
+      'POST',
+      '/api/v2/polls/query',
+      undefined,
+      queryParams,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryPollsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deletePoll(request: {
+    poll_id: string;
+    user_id?: string;
+  }): Promise<StreamResponse<Response>> {
+    const queryParams = {
+      user_id: request?.user_id,
+    };
+    const pathParams = {
+      poll_id: request?.poll_id,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'DELETE',
+      '/api/v2/polls/{poll_id}',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.Response?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getPoll(request: {
+    poll_id: string;
+    user_id?: string;
+  }): Promise<StreamResponse<PollResponse>> {
+    const queryParams = {
+      user_id: request?.user_id,
+    };
+    const pathParams = {
+      poll_id: request?.poll_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<PollResponse>
+    >('GET', '/api/v2/polls/{poll_id}', pathParams, queryParams);
+
+    decoders.PollResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updatePollPartial(
+    request: UpdatePollPartialRequest & { poll_id: string },
+  ): Promise<StreamResponse<PollResponse>> {
+    const pathParams = {
+      poll_id: request?.poll_id,
+    };
+    const body = {
+      unset: request?.unset,
+      set: request?.set,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<PollResponse>
+    >(
+      'PATCH',
+      '/api/v2/polls/{poll_id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.PollResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async createPollOption(
+    request: CreatePollOptionRequest & { poll_id: string },
+  ): Promise<StreamResponse<PollOptionResponse>> {
+    const pathParams = {
+      poll_id: request?.poll_id,
+    };
+    const body = {
+      text: request?.text,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<PollOptionResponse>
+    >(
+      'POST',
+      '/api/v2/polls/{poll_id}/options',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.PollOptionResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updatePollOption(
+    request: UpdatePollOptionRequest & { poll_id: string },
+  ): Promise<StreamResponse<PollOptionResponse>> {
+    const pathParams = {
+      poll_id: request?.poll_id,
+    };
+    const body = {
+      id: request?.id,
+      text: request?.text,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<PollOptionResponse>
+    >(
+      'PUT',
+      '/api/v2/polls/{poll_id}/options',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.PollOptionResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deletePollOption(request: {
+    poll_id: string;
+    option_id: string;
+    user_id?: string;
+  }): Promise<StreamResponse<Response>> {
+    const queryParams = {
+      user_id: request?.user_id,
+    };
+    const pathParams = {
+      poll_id: request?.poll_id,
+      option_id: request?.option_id,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'DELETE',
+      '/api/v2/polls/{poll_id}/options/{option_id}',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.Response?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getPollOption(request: {
+    poll_id: string;
+    option_id: string;
+    user_id?: string;
+  }): Promise<StreamResponse<PollOptionResponse>> {
+    const queryParams = {
+      user_id: request?.user_id,
+    };
+    const pathParams = {
+      poll_id: request?.poll_id,
+      option_id: request?.option_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<PollOptionResponse>
+    >(
+      'GET',
+      '/api/v2/polls/{poll_id}/options/{option_id}',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.PollOptionResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryPollVotes(
+    request: QueryPollVotesRequest & { poll_id: string; user_id?: string },
+  ): Promise<StreamResponse<PollVotesResponse>> {
+    const queryParams = {
+      user_id: request?.user_id,
+    };
+    const pathParams = {
+      poll_id: request?.poll_id,
+    };
+    const body = {
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<PollVotesResponse>
+    >(
+      'POST',
+      '/api/v2/polls/{poll_id}/votes',
+      pathParams,
+      queryParams,
+      body,
+      'application/json',
+    );
+
+    decoders.PollVotesResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updatePushNotificationPreferences(
+    request: UpsertPushPreferencesRequest,
+  ): Promise<StreamResponse<UpsertPushPreferencesResponse>> {
+    const body = {
+      preferences: request?.preferences,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpsertPushPreferencesResponse>
+    >(
+      'POST',
+      '/api/v2/push_preferences',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpsertPushPreferencesResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteFile(request?: {
+    url?: string;
+  }): Promise<StreamResponse<Response>> {
+    const queryParams = {
+      url: request?.url,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'DELETE',
+      '/api/v2/uploads/file',
+      undefined,
+      queryParams,
+    );
+
+    decoders.Response?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async uploadFile(
+    request?: FileUploadRequest,
+  ): Promise<StreamResponse<FileUploadResponse>> {
+    const body = {
+      file: request?.file,
+      user: request?.user,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<FileUploadResponse>
+    >(
+      'POST',
+      '/api/v2/uploads/file',
+      undefined,
+      undefined,
+      body,
+      'multipart/form-data',
+    );
+
+    decoders.FileUploadResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteImage(request?: {
+    url?: string;
+  }): Promise<StreamResponse<Response>> {
+    const queryParams = {
+      url: request?.url,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'DELETE',
+      '/api/v2/uploads/image',
+      undefined,
+      queryParams,
+    );
+
+    decoders.Response?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async uploadImage(
+    request?: ImageUploadRequest,
+  ): Promise<StreamResponse<ImageUploadResponse>> {
+    const body = {
+      file: request?.file,
+      upload_sizes: request?.upload_sizes,
+      user: request?.user,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<ImageUploadResponse>
+    >(
+      'POST',
+      '/api/v2/uploads/image',
+      undefined,
+      undefined,
+      body,
+      'multipart/form-data',
+    );
+
+    decoders.ImageUploadResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async listUserGroups(request?: {
+    limit?: number;
+    id_gt?: string;
+    created_at_gt?: string;
+    team_id?: string;
+  }): Promise<StreamResponse<ListUserGroupsResponse>> {
+    const queryParams = {
+      limit: request?.limit,
+      id_gt: request?.id_gt,
+      created_at_gt: request?.created_at_gt,
+      team_id: request?.team_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<ListUserGroupsResponse>
+    >('GET', '/api/v2/usergroups', undefined, queryParams);
+
+    decoders.ListUserGroupsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async createUserGroup(
+    request: CreateUserGroupRequest,
+  ): Promise<StreamResponse<CreateUserGroupResponse>> {
+    const body = {
+      name: request?.name,
+      description: request?.description,
+      id: request?.id,
+      team_id: request?.team_id,
+      member_ids: request?.member_ids,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<CreateUserGroupResponse>
+    >(
+      'POST',
+      '/api/v2/usergroups',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.CreateUserGroupResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async searchUserGroups(request: {
+    query: string;
+    limit?: number;
+    name_gt?: string;
+    id_gt?: string;
+    team_id?: string;
+  }): Promise<StreamResponse<SearchUserGroupsResponse>> {
+    const queryParams = {
+      query: request?.query,
+      limit: request?.limit,
+      name_gt: request?.name_gt,
+      id_gt: request?.id_gt,
+      team_id: request?.team_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<SearchUserGroupsResponse>
+    >('GET', '/api/v2/usergroups/search', undefined, queryParams);
+
+    decoders.SearchUserGroupsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteUserGroup(request: {
+    id: string;
+    team_id?: string;
+  }): Promise<StreamResponse<Response>> {
+    const queryParams = {
+      team_id: request?.team_id,
+    };
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'DELETE',
+      '/api/v2/usergroups/{id}',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.Response?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getUserGroup(request: {
+    id: string;
+    team_id?: string;
+  }): Promise<StreamResponse<GetUserGroupResponse>> {
+    const queryParams = {
+      team_id: request?.team_id,
+    };
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetUserGroupResponse>
+    >('GET', '/api/v2/usergroups/{id}', pathParams, queryParams);
+
+    decoders.GetUserGroupResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateUserGroup(
+    request: UpdateUserGroupRequest & { id: string },
+  ): Promise<StreamResponse<UpdateUserGroupResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      description: request?.description,
+      name: request?.name,
+      team_id: request?.team_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateUserGroupResponse>
+    >(
+      'PUT',
+      '/api/v2/usergroups/{id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateUserGroupResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async addUserGroupMembers(
+    request: AddUserGroupMembersRequest & { id: string },
+  ): Promise<StreamResponse<AddUserGroupMembersResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      member_ids: request?.member_ids,
+      as_admin: request?.as_admin,
+      team_id: request?.team_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<AddUserGroupMembersResponse>
+    >(
+      'POST',
+      '/api/v2/usergroups/{id}/members',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.AddUserGroupMembersResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async removeUserGroupMembers(
+    request: RemoveUserGroupMembersRequest & { id: string },
+  ): Promise<StreamResponse<RemoveUserGroupMembersResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      member_ids: request?.member_ids,
+      team_id: request?.team_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<RemoveUserGroupMembersResponse>
+    >(
+      'POST',
+      '/api/v2/usergroups/{id}/members/delete',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.RemoveUserGroupMembersResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryUsers(request?: {
+    payload?: QueryUsersPayload;
+  }): Promise<StreamResponse<QueryUsersResponse>> {
+    const queryParams = {
+      payload: request?.payload,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryUsersResponse>
+    >('GET', '/api/v2/users', undefined, queryParams);
+
+    decoders.QueryUsersResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateUsersPartial(
+    request: UpdateUsersPartialRequest,
+  ): Promise<StreamResponse<UpdateUsersResponse>> {
+    const body = {
+      users: request?.users,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateUsersResponse>
+    >('PATCH', '/api/v2/users', undefined, undefined, body, 'application/json');
+
+    decoders.UpdateUsersResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateUsers(
+    request: UpdateUsersRequest,
+  ): Promise<StreamResponse<UpdateUsersResponse>> {
+    const body = {
+      users: request?.users,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateUsersResponse>
+    >('POST', '/api/v2/users', undefined, undefined, body, 'application/json');
+
+    decoders.UpdateUsersResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getBlockedUsers(): Promise<StreamResponse<GetBlockedUsersResponse>> {
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetBlockedUsersResponse>
+    >('GET', '/api/v2/users/block', undefined, undefined);
+
+    decoders.GetBlockedUsersResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async blockUsers(
+    request: BlockUsersRequest,
+  ): Promise<StreamResponse<BlockUsersResponse>> {
+    const body = {
+      blocked_user_id: request?.blocked_user_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<BlockUsersResponse>
+    >(
+      'POST',
+      '/api/v2/users/block',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.BlockUsersResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getUserLiveLocations(): Promise<
+    StreamResponse<SharedLocationsResponse>
+  > {
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<SharedLocationsResponse>
+    >('GET', '/api/v2/users/live_locations', undefined, undefined);
+
+    decoders.SharedLocationsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateLiveLocation(
+    request: UpdateLiveLocationRequest,
+  ): Promise<StreamResponse<SharedLocationResponse>> {
+    const body = {
+      message_id: request?.message_id,
+      end_at: request?.end_at,
+      latitude: request?.latitude,
+      longitude: request?.longitude,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<SharedLocationResponse>
+    >(
+      'PUT',
+      '/api/v2/users/live_locations',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.SharedLocationResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async unblockUsers(
+    request: UnblockUsersRequest,
+  ): Promise<StreamResponse<UnblockUsersResponse>> {
+    const body = {
+      blocked_user_id: request?.blocked_user_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UnblockUsersResponse>
+    >(
+      'POST',
+      '/api/v2/users/unblock',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UnblockUsersResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
 }
-    }

--- a/packages/feeds-client/src/gen/model-decoders/decoders.ts
+++ b/packages/feeds-client/src/gen/model-decoders/decoders.ts
@@ -1,10 +1,13 @@
 type Decoder = (i: any) => any;
 
-type TypeMapping = Record<string, {type: string, isSingle: boolean}>
+type TypeMapping = Record<string, { type: string; isSingle: boolean }>;
 
 export const decoders: Record<string, Decoder> = {};
 
-const decodeDatetimeType = (input: number | string) => typeof input === 'number' ? new Date(Math.floor(input / 1000000)) : new Date(input);
+const decodeDatetimeType = (input: number | string) =>
+  typeof input === 'number'
+    ? new Date(Math.floor(input / 1000000))
+    : new Date(input);
 
 decoders.DatetimeType = decodeDatetimeType;
 
@@ -16,13 +19,13 @@ const decode = (typeMappings: TypeMapping, input?: Record<string, any>) => {
       if (typeMappings[key]) {
         const decoder = decoders[typeMappings[key].type];
         if (decoder) {
-            if (typeMappings[key].isSingle) {
-              input[key] = decoder(input[key]);
-            } else {
-                Object.keys(input[key]).forEach(k => {
-                    input[key][k] = decoder(input[key][k])
-                })
-            }
+          if (typeMappings[key].isSingle) {
+            input[key] = decoder(input[key]);
+          } else {
+            Object.keys(input[key]).forEach((k) => {
+              input[key][k] = decoder(input[key][k]);
+            });
+          }
         }
       }
     }
@@ -31,3944 +34,2297 @@ const decode = (typeMappings: TypeMapping, input?: Record<string, any>) => {
   return input;
 };
 
+decoders.AcceptFeedMemberInviteResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    member: { type: 'FeedMemberResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
 
+decoders.AcceptFollowResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    follow: { type: 'FollowResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
 
-  decoders['AcceptFeedMemberInviteResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "member": {type: "FeedMemberResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['AcceptFollowResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "follow": {type: "FollowResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActionLogResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "review_queue_item": {type: "ReviewQueueItemResponse", isSingle: true},
-            
-        
-                "target_user": {type: "UserResponse", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityAddedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityDeletedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityFeedbackEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityMarkEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityPinResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityPinnedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "pinned_activity": {type: "PinActivityResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityReactionAddedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-        
-                "reaction": {type: "FeedsReactionResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityReactionDeletedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-        
-                "reaction": {type: "FeedsReactionResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityReactionUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-        
-                "reaction": {type: "FeedsReactionResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityRemovedFromFeedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-              "comments": {type: "CommentResponse", isSingle: false},
-            
-        
-        
-        
-        
-              "latest_reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-              "mentioned_users": {type: "UserResponse", isSingle: false},
-            
-        
-              "own_bookmarks": {type: "BookmarkResponse", isSingle: false},
-            
-        
-              "own_reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-              "collections": {type: "EnrichedCollectionResponse", isSingle: false},
-            
-        
-        
-              "reaction_groups": {type: "FeedsReactionGroupResponse", isSingle: false},
-            
-        
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "edited_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "expires_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-              "friend_reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-                "current_feed": {type: "FeedResponse", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "parent": {type: "ActivityResponse", isSingle: true},
-            
-        
-                "poll": {type: "PollResponseData", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityRestoredEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityUnpinnedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "pinned_activity": {type: "PinActivityResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ActivityUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['AddActivityResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['AddBookmarkResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "bookmark": {type: "BookmarkResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['AddCommentBookmarkResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "bookmark": {type: "BookmarkResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['AddCommentReactionResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        
-                "reaction": {type: "FeedsReactionResponse", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['AddCommentResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['AddCommentsBatchResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "comments": {type: "CommentResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['AddReactionResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-                "reaction": {type: "FeedsReactionResponse", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['AddUserGroupMembersResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "user_group": {type: "UserGroupResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['AggregatedActivityResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-              "activities": {type: "ActivityResponse", isSingle: false},
-            
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['AppUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['AppealItemResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['BanInfoResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "expires": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "created_by": {type: "UserResponse", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['BlockListResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-        
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['BlockUsersResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['BlockedUserResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "blocked_user": {type: "UserResponse", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['BookmarkAddedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "bookmark": {type: "BookmarkResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['BookmarkDeletedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "bookmark": {type: "BookmarkResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['BookmarkFolderDeletedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "bookmark_folder": {type: "BookmarkFolderResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['BookmarkFolderResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['BookmarkFolderUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "bookmark_folder": {type: "BookmarkFolderResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['BookmarkResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        
-        
-                "folder": {type: "BookmarkFolderResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['BookmarkUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "bookmark": {type: "BookmarkResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CallResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "ended_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "starts_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "created_by": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChangeFeedVisibilityResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "feed": {type: "FeedResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChannelConfigWithInfo'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-              "commands": {type: "Command", isSingle: false},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChannelMemberResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "archived_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "ban_expires": {type: "DatetimeType", isSingle: true},
-            
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "invite_accepted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "invite_rejected_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "pinned_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChannelMute'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "expires": {type: "DatetimeType", isSingle: true},
-            
-        
-                "channel": {type: "ChannelResponse", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChannelResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "hide_messages_before": {type: "DatetimeType", isSingle: true},
-            
-        
-                "last_message_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "mute_expires_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "truncated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-              "members": {type: "ChannelMemberResponse", isSingle: false},
-            
-        
-        
-                "config": {type: "ChannelConfigWithInfo", isSingle: true},
-            
-        
-                "created_by": {type: "UserResponse", isSingle: true},
-            
-        
-                "truncated_by": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChatDraftPayloadResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-              "mentioned_users": {type: "UserResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChatDraftResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "message": {type: "ChatDraftPayloadResponse", isSingle: true},
-            
-        
-        
-                "parent_message": {type: "ChatMessageResponse", isSingle: true},
-            
-        
-                "quoted_message": {type: "ChatMessageResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChatMessageResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-              "latest_reactions": {type: "ChatReactionResponse", isSingle: false},
-            
-        
-              "mentioned_users": {type: "UserResponse", isSingle: false},
-            
-        
-              "own_reactions": {type: "ChatReactionResponse", isSingle: false},
-            
-        
-        
-        
-        
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "message_text_updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "pin_expires": {type: "DatetimeType", isSingle: true},
-            
-        
-                "pinned_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-              "thread_participants": {type: "UserResponse", isSingle: false},
-            
-        
-                "draft": {type: "ChatDraftResponse", isSingle: true},
-            
-        
-        
-        
-                "member": {type: "ChannelMemberResponse", isSingle: true},
-            
-        
-        
-                "pinned_by": {type: "UserResponse", isSingle: true},
-            
-        
-                "poll": {type: "PollResponseData", isSingle: true},
-            
-        
-                "quoted_message": {type: "ChatMessageResponse", isSingle: true},
-            
-        
-              "reaction_groups": {type: "ChatReactionGroupResponse", isSingle: false},
-            
-        
-                "reminder": {type: "ChatReminderResponseData", isSingle: true},
-            
-        
-                "shared_location": {type: "ChatSharedLocationResponseData", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChatReactionGroupResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "first_reaction_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "last_reaction_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-              "latest_reactions_by": {type: "ChatReactionGroupUserResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChatReactionGroupUserResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChatReactionResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChatReminderResponseData'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "remind_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "message": {type: "ChatMessageResponse", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ChatSharedLocationResponseData'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "end_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "message": {type: "ChatMessageResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CollectionResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['Command'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CommentAddedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CommentDeletedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CommentReactionAddedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        
-        
-                "reaction": {type: "FeedsReactionResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CommentReactionDeletedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        
-        
-                "reaction": {type: "FeedsReactionResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CommentReactionUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        
-        
-                "reaction": {type: "FeedsReactionResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CommentResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-              "mentioned_users": {type: "UserResponse", isSingle: false},
-            
-        
-              "own_reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "edited_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-              "latest_reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-        
-        
-              "reaction_groups": {type: "FeedsReactionGroupResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CommentRestoredEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CommentUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ConfigResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CreateBlockListResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "blocklist": {type: "BlockListResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CreateCollectionsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "collections": {type: "CollectionResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CreateFeedsBatchResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "feeds": {type: "FeedResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CreateGuestResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['CreateUserGroupResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "user_group": {type: "UserGroupResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['DeleteActivityReactionResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-                "reaction": {type: "FeedsReactionResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['DeleteBookmarkResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "bookmark": {type: "BookmarkResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['DeleteCommentBookmarkResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "bookmark": {type: "BookmarkResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['DeleteCommentReactionResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        
-                "reaction": {type: "FeedsReactionResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['DeleteCommentResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['DeviceResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['DraftPayloadResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-              "mentioned_users": {type: "UserResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['DraftResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "message": {type: "DraftPayloadResponse", isSingle: true},
-            
-        
-        
-                "channel": {type: "ChannelResponse", isSingle: true},
-            
-        
-                "parent_message": {type: "MessageResponse", isSingle: true},
-            
-        
-                "quoted_message": {type: "MessageResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['EnrichedCollectionResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['EntityCreatorResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "deactivated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "last_active": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "revoke_tokens_issued_before": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedCreatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-              "members": {type: "FeedMemberResponse", isSingle: false},
-            
-        
-        
-                "feed": {type: "FeedResponse", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedDeletedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedGroupChangedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedGroupDeletedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedGroupRestoredEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedMemberAddedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "member": {type: "FeedMemberResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedMemberRemovedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedMemberResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        
-                "invite_accepted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "invite_rejected_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "membership_level": {type: "MembershipLevelResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedMemberUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "member": {type: "FeedMemberResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedOwnData'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "own_followings": {type: "FollowResponse", isSingle: false},
-            
-        
-              "own_follows": {type: "FollowResponse", isSingle: false},
-            
-        
-                "own_membership": {type: "FeedMemberResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "created_by": {type: "UserResponse", isSingle: true},
-            
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-              "own_followings": {type: "FollowResponse", isSingle: false},
-            
-        
-              "own_follows": {type: "FollowResponse", isSingle: false},
-            
-        
-        
-        
-                "own_membership": {type: "FeedMemberResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedSuggestionResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "created_by": {type: "UserResponse", isSingle: true},
-            
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-              "own_followings": {type: "FollowResponse", isSingle: false},
-            
-        
-              "own_follows": {type: "FollowResponse", isSingle: false},
-            
-        
-        
-        
-        
-                "own_membership": {type: "FeedMemberResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "feed": {type: "FeedResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedsBookmarkResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedsEnrichedCollectionResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedsFeedResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "created_by": {type: "UserResponse", isSingle: true},
-            
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedsReactionGroupResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "first_reaction_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "last_reaction_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedsReactionResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedsV3ActivityResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-              "comments": {type: "FeedsV3CommentResponse", isSingle: false},
-            
-        
-        
-        
-        
-              "latest_reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-              "mentioned_users": {type: "UserResponse", isSingle: false},
-            
-        
-              "own_bookmarks": {type: "FeedsBookmarkResponse", isSingle: false},
-            
-        
-              "own_reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-              "collections": {type: "FeedsEnrichedCollectionResponse", isSingle: false},
-            
-        
-        
-              "reaction_groups": {type: "FeedsReactionGroupResponse", isSingle: false},
-            
-        
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "edited_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "expires_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-              "friend_reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-                "current_feed": {type: "FeedsFeedResponse", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "parent": {type: "FeedsV3ActivityResponse", isSingle: true},
-            
-        
-                "poll": {type: "PollResponseData", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FeedsV3CommentResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-              "mentioned_users": {type: "UserResponse", isSingle: false},
-            
-        
-              "own_reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "edited_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-              "latest_reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-        
-        
-              "reaction_groups": {type: "FeedsReactionGroupResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FollowBatchResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "created": {type: "FollowResponse", isSingle: false},
-            
-        
-              "follows": {type: "FollowResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FollowCreatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "follow": {type: "FollowResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FollowDeletedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "follow": {type: "FollowResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FollowResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "source_feed": {type: "FeedResponse", isSingle: true},
-            
-        
-                "target_feed": {type: "FeedResponse", isSingle: true},
-            
-        
-                "request_accepted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "request_rejected_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FollowUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "follow": {type: "FollowResponse", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['FullUserResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-              "channel_mutes": {type: "ChannelMute", isSingle: false},
-            
-        
-              "devices": {type: "DeviceResponse", isSingle: false},
-            
-        
-              "mutes": {type: "UserMuteResponse", isSingle: false},
-            
-        
-        
-        
-        
-                "ban_expires": {type: "DatetimeType", isSingle: true},
-            
-        
-                "deactivated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "last_active": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "revoke_tokens_issued_before": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['GetActivityResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['GetAppealResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "item": {type: "AppealItemResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['GetBlockedUsersResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "blocks": {type: "BlockedUserResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['GetCommentRepliesResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-              "comments": {type: "ThreadedCommentResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['GetCommentResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['GetCommentsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-              "comments": {type: "ThreadedCommentResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['GetConfigResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "config": {type: "ConfigResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['GetFollowSuggestionsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "suggestions": {type: "FeedSuggestionResponse", isSingle: false},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['GetOrCreateFeedResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-              "activities": {type: "ActivityResponse", isSingle: false},
-            
-        
-              "aggregated_activities": {type: "AggregatedActivityResponse", isSingle: false},
-            
-        
-              "followers": {type: "FollowResponse", isSingle: false},
-            
-        
-              "following": {type: "FollowResponse", isSingle: false},
-            
-        
-              "members": {type: "FeedMemberResponse", isSingle: false},
-            
-        
-              "pinned_activities": {type: "ActivityPinResponse", isSingle: false},
-            
-        
-                "feed": {type: "FeedResponse", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-                "notification_status": {type: "NotificationStatusResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['GetUserGroupResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "user_group": {type: "UserGroupResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['HealthCheckEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "me": {type: "OwnUserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ListBlockListResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "blocklists": {type: "BlockListResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ListDevicesResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "devices": {type: "DeviceResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ListUserGroupsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "user_groups": {type: "UserGroupResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['MembershipLevelResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['MessageResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-              "latest_reactions": {type: "ReactionResponse", isSingle: false},
-            
-        
-              "mentioned_users": {type: "UserResponse", isSingle: false},
-            
-        
-              "own_reactions": {type: "ReactionResponse", isSingle: false},
-            
-        
-        
-        
-        
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "message_text_updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "pin_expires": {type: "DatetimeType", isSingle: true},
-            
-        
-                "pinned_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-              "thread_participants": {type: "UserResponse", isSingle: false},
-            
-        
-                "draft": {type: "DraftResponse", isSingle: true},
-            
-        
-        
-        
-                "member": {type: "ChannelMemberResponse", isSingle: true},
-            
-        
-        
-                "pinned_by": {type: "UserResponse", isSingle: true},
-            
-        
-                "poll": {type: "PollResponseData", isSingle: true},
-            
-        
-                "quoted_message": {type: "MessageResponse", isSingle: true},
-            
-        
-              "reaction_groups": {type: "ReactionGroupResponse", isSingle: false},
-            
-        
-                "reminder": {type: "ReminderResponseData", isSingle: true},
-            
-        
-                "shared_location": {type: "SharedLocationResponseData", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ModerationCustomActionEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "review_queue_item": {type: "ReviewQueueItemResponse", isSingle: true},
-            
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "message": {type: "MessageResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ModerationFlagResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "review_queue_item": {type: "ReviewQueueItemResponse", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ModerationFlaggedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ModerationMarkReviewedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "item": {type: "ReviewQueueItemResponse", isSingle: true},
-            
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "message": {type: "MessageResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['MuteResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "mutes": {type: "UserMuteResponse", isSingle: false},
-            
-        
-        
-                "own_user": {type: "OwnUserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['NotificationFeedUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-              "aggregated_activities": {type: "AggregatedActivityResponse", isSingle: false},
-            
-        
-                "notification_status": {type: "NotificationStatusResponse", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['NotificationStatusResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-                "last_read_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "last_seen_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['OwnBatchResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "data": {type: "FeedOwnData", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['OwnUserResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-              "channel_mutes": {type: "ChannelMute", isSingle: false},
-            
-        
-              "devices": {type: "DeviceResponse", isSingle: false},
-            
-        
-              "mutes": {type: "UserMuteResponse", isSingle: false},
-            
-        
-        
-        
-        
-                "deactivated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "last_active": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "revoke_tokens_issued_before": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "push_preferences": {type: "PushPreferencesResponse", isSingle: true},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PinActivityResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PollClosedFeedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "poll": {type: "PollResponseData", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PollDeletedFeedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "poll": {type: "PollResponseData", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PollResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "poll": {type: "PollResponseData", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PollResponseData'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-              "latest_answers": {type: "PollVoteResponseData", isSingle: false},
-            
-        
-        
-              "own_votes": {type: "PollVoteResponseData", isSingle: false},
-            
-        
-        
-        
-        
-        
-        
-                "created_by": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PollUpdatedFeedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "poll": {type: "PollResponseData", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PollVoteCastedFeedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "poll": {type: "PollResponseData", isSingle: true},
-            
-        
-                "poll_vote": {type: "PollVoteResponseData", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PollVoteChangedFeedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "poll": {type: "PollResponseData", isSingle: true},
-            
-        
-                "poll_vote": {type: "PollVoteResponseData", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PollVoteRemovedFeedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "poll": {type: "PollResponseData", isSingle: true},
-            
-        
-                "poll_vote": {type: "PollVoteResponseData", isSingle: true},
-            
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PollVoteResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "poll": {type: "PollResponseData", isSingle: true},
-            
-        
-                "vote": {type: "PollVoteResponseData", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PollVoteResponseData'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PollVotesResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "votes": {type: "PollVoteResponseData", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['PushPreferencesResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-                "disabled_until": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryActivitiesResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "activities": {type: "ActivityResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryActivityReactionsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryAppealsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "items": {type: "AppealItemResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryBookmarkFoldersResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "bookmark_folders": {type: "BookmarkFolderResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryBookmarksResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "bookmarks": {type: "BookmarkResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryCollectionsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "collections": {type: "CollectionResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryCommentReactionsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryCommentsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "comments": {type: "CommentResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryFeedMembersResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "members": {type: "FeedMemberResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryFeedsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "feeds": {type: "FeedResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryFollowsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "follows": {type: "FollowResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryModerationConfigsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "configs": {type: "ConfigResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryPinnedActivitiesResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "pinned_activities": {type: "ActivityPinResponse", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryPollsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "polls": {type: "PollResponseData", isSingle: false},
-            
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryReviewQueueResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "items": {type: "ReviewQueueItemResponse", isSingle: false},
-            
-        
-        
-        
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['QueryUsersResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "users": {type: "FullUserResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['Reaction'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ReactionGroupResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "first_reaction_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "last_reaction_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-              "latest_reactions_by": {type: "ReactionGroupUserResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ReactionGroupUserResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ReactionResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ReadCollectionsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "collections": {type: "CollectionResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['RejectFeedMemberInviteResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "member": {type: "FeedMemberResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['RejectFollowResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "follow": {type: "FollowResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ReminderResponseData'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "remind_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "channel": {type: "ChannelResponse", isSingle: true},
-            
-        
-                "message": {type: "MessageResponse", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['RemoveUserGroupMembersResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "user_group": {type: "UserGroupResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['RestoreActivityResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['RestoreCommentResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ReviewQueueItemResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-              "actions": {type: "ActionLogResponse", isSingle: false},
-            
-        
-              "bans": {type: "BanInfoResponse", isSingle: false},
-            
-        
-              "flags": {type: "ModerationFlagResponse", isSingle: false},
-            
-        
-        
-                "completed_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "escalated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "reviewed_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "appeal": {type: "AppealItemResponse", isSingle: true},
-            
-        
-                "assigned_to": {type: "UserResponse", isSingle: true},
-            
-        
-                "call": {type: "CallResponse", isSingle: true},
-            
-        
-                "entity_creator": {type: "EntityCreatorResponse", isSingle: true},
-            
-        
-        
-        
-                "feeds_v2_reaction": {type: "Reaction", isSingle: true},
-            
-        
-                "feeds_v3_activity": {type: "FeedsV3ActivityResponse", isSingle: true},
-            
-        
-                "feeds_v3_comment": {type: "FeedsV3CommentResponse", isSingle: true},
-            
-        
-                "message": {type: "ChatMessageResponse", isSingle: true},
-            
-        
-        
-                "reaction": {type: "Reaction", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['SearchUserGroupsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "user_groups": {type: "UserGroupResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['SharedLocationResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "end_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "channel": {type: "ChannelResponse", isSingle: true},
-            
-        
-                "message": {type: "MessageResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['SharedLocationResponseData'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "end_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "channel": {type: "ChannelResponse", isSingle: true},
-            
-        
-                "message": {type: "MessageResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['SharedLocationsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "active_live_locations": {type: "SharedLocationResponseData", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['SingleFollowResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "follow": {type: "FollowResponse", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['StoriesFeedUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-              "activities": {type: "ActivityResponse", isSingle: false},
-            
-        
-              "aggregated_activities": {type: "AggregatedActivityResponse", isSingle: false},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['SubmitActionResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "appeal_item": {type: "AppealItemResponse", isSingle: true},
-            
-        
-                "item": {type: "ReviewQueueItemResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['ThreadedCommentResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-              "mentioned_users": {type: "UserResponse", isSingle: false},
-            
-        
-              "own_reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "edited_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-              "latest_reactions": {type: "FeedsReactionResponse", isSingle: false},
-            
-        
-              "replies": {type: "ThreadedCommentResponse", isSingle: false},
-            
-        
-        
-        
-        
-              "reaction_groups": {type: "FeedsReactionGroupResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UnfollowBatchResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "follows": {type: "FollowResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UnfollowResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "follow": {type: "FollowResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UnpinActivityResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateActivityPartialResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateActivityResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "activity": {type: "ActivityResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateBlockListResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "blocklist": {type: "BlockListResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateBookmarkFolderResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "bookmark_folder": {type: "BookmarkFolderResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateBookmarkResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "bookmark": {type: "BookmarkResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateCollectionsResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "collections": {type: "CollectionResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateCommentBookmarkResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "bookmark": {type: "BookmarkResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateCommentPartialResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateCommentResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "comment": {type: "CommentResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateFeedMembersResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "added": {type: "FeedMemberResponse", isSingle: false},
-            
-        
-        
-              "updated": {type: "FeedMemberResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateFeedResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "feed": {type: "FeedResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateFollowResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "follow": {type: "FollowResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateUserGroupResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "user_group": {type: "UserGroupResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpdateUsersResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-              "users": {type: "FullUserResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpsertActivitiesResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-              "activities": {type: "ActivityResponse", isSingle: false},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpsertConfigResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "config": {type: "ConfigResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UpsertPushPreferencesResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-        
-              "user_preferences": {type: "PushPreferencesResponse", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UserBannedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "expiration": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UserDeactivatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UserGroupMember'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UserGroupResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-              "members": {type: "UserGroupMember", isSingle: false},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UserMuteResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "expires": {type: "DatetimeType", isSingle: true},
-            
-        
-                "target": {type: "UserResponse", isSingle: true},
-            
-        
-                "user": {type: "UserResponse", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UserReactivatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UserResponse'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-        
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "updated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-                "deactivated_at": {type: "DatetimeType", isSingle: true},
-            
-        
-                "deleted_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "last_active": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-                "revoke_tokens_issued_before": {type: "DatetimeType", isSingle: true},
-            
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UserUnbannedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-        }
-    return decode(typeMappings, input)
-  }
-
-  decoders['UserUpdatedEvent'] = (input?: {[key: string]: any}) => {
-    const typeMappings: TypeMapping = {
-                "created_at": {type: "DatetimeType", isSingle: true},
-            
-        
-        
-        
-        
-                "received_at": {type: "DatetimeType", isSingle: true},
-            
-        }
-    return decode(typeMappings, input)
-  }
+decoders.ActionLogResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    review_queue_item: { type: 'ReviewQueueItemResponse', isSingle: true },
+
+    target_user: { type: 'UserResponse', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityAddedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityDeletedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityFeedbackEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityMarkEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityPinResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityPinnedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    pinned_activity: { type: 'PinActivityResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityReactionAddedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    reaction: { type: 'FeedsReactionResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityReactionDeletedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    reaction: { type: 'FeedsReactionResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityReactionUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    reaction: { type: 'FeedsReactionResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityRemovedFromFeedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    comments: { type: 'CommentResponse', isSingle: false },
+
+    latest_reactions: { type: 'FeedsReactionResponse', isSingle: false },
+
+    mentioned_users: { type: 'UserResponse', isSingle: false },
+
+    own_bookmarks: { type: 'BookmarkResponse', isSingle: false },
+
+    own_reactions: { type: 'FeedsReactionResponse', isSingle: false },
+
+    collections: { type: 'EnrichedCollectionResponse', isSingle: false },
+
+    reaction_groups: { type: 'FeedsReactionGroupResponse', isSingle: false },
+
+    user: { type: 'UserResponse', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    edited_at: { type: 'DatetimeType', isSingle: true },
+
+    expires_at: { type: 'DatetimeType', isSingle: true },
+
+    friend_reactions: { type: 'FeedsReactionResponse', isSingle: false },
+
+    current_feed: { type: 'FeedResponse', isSingle: true },
+
+    parent: { type: 'ActivityResponse', isSingle: true },
+
+    poll: { type: 'PollResponseData', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityRestoredEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityUnpinnedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    pinned_activity: { type: 'PinActivityResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivityUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.AddActivityResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activity: { type: 'ActivityResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.AddBookmarkResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    bookmark: { type: 'BookmarkResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.AddCommentBookmarkResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    bookmark: { type: 'BookmarkResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.AddCommentReactionResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    comment: { type: 'CommentResponse', isSingle: true },
+
+    reaction: { type: 'FeedsReactionResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.AddCommentResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    comment: { type: 'CommentResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.AddCommentsBatchResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    comments: { type: 'CommentResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.AddReactionResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    reaction: { type: 'FeedsReactionResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.AddUserGroupMembersResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    user_group: { type: 'UserGroupResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.AggregatedActivityResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    activities: { type: 'ActivityResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.AppUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.AppealItemResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.BanInfoResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    expires: { type: 'DatetimeType', isSingle: true },
+
+    created_by: { type: 'UserResponse', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.BlockListResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.BlockUsersResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.BlockedUserResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    blocked_user: { type: 'UserResponse', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.BookmarkAddedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    bookmark: { type: 'BookmarkResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.BookmarkDeletedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    bookmark: { type: 'BookmarkResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.BookmarkFolderDeletedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    bookmark_folder: { type: 'BookmarkFolderResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.BookmarkFolderResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.BookmarkFolderUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    bookmark_folder: { type: 'BookmarkFolderResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.BookmarkResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+
+    comment: { type: 'CommentResponse', isSingle: true },
+
+    folder: { type: 'BookmarkFolderResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.BookmarkUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    bookmark: { type: 'BookmarkResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CallResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    ended_at: { type: 'DatetimeType', isSingle: true },
+
+    starts_at: { type: 'DatetimeType', isSingle: true },
+
+    created_by: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChangeFeedVisibilityResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    feed: { type: 'FeedResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChannelConfigWithInfo = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    commands: { type: 'Command', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChannelMemberResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    archived_at: { type: 'DatetimeType', isSingle: true },
+
+    ban_expires: { type: 'DatetimeType', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    invite_accepted_at: { type: 'DatetimeType', isSingle: true },
+
+    invite_rejected_at: { type: 'DatetimeType', isSingle: true },
+
+    pinned_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChannelMute = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    expires: { type: 'DatetimeType', isSingle: true },
+
+    channel: { type: 'ChannelResponse', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChannelResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    hide_messages_before: { type: 'DatetimeType', isSingle: true },
+
+    last_message_at: { type: 'DatetimeType', isSingle: true },
+
+    mute_expires_at: { type: 'DatetimeType', isSingle: true },
+
+    truncated_at: { type: 'DatetimeType', isSingle: true },
+
+    members: { type: 'ChannelMemberResponse', isSingle: false },
+
+    config: { type: 'ChannelConfigWithInfo', isSingle: true },
+
+    created_by: { type: 'UserResponse', isSingle: true },
+
+    truncated_by: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChatDraftPayloadResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    mentioned_users: { type: 'UserResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChatDraftResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    message: { type: 'ChatDraftPayloadResponse', isSingle: true },
+
+    parent_message: { type: 'ChatMessageResponse', isSingle: true },
+
+    quoted_message: { type: 'ChatMessageResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChatMessageResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    latest_reactions: { type: 'ChatReactionResponse', isSingle: false },
+
+    mentioned_users: { type: 'UserResponse', isSingle: false },
+
+    own_reactions: { type: 'ChatReactionResponse', isSingle: false },
+
+    user: { type: 'UserResponse', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    message_text_updated_at: { type: 'DatetimeType', isSingle: true },
+
+    pin_expires: { type: 'DatetimeType', isSingle: true },
+
+    pinned_at: { type: 'DatetimeType', isSingle: true },
+
+    thread_participants: { type: 'UserResponse', isSingle: false },
+
+    draft: { type: 'ChatDraftResponse', isSingle: true },
+
+    member: { type: 'ChannelMemberResponse', isSingle: true },
+
+    pinned_by: { type: 'UserResponse', isSingle: true },
+
+    poll: { type: 'PollResponseData', isSingle: true },
+
+    quoted_message: { type: 'ChatMessageResponse', isSingle: true },
+
+    reaction_groups: { type: 'ChatReactionGroupResponse', isSingle: false },
+
+    reminder: { type: 'ChatReminderResponseData', isSingle: true },
+
+    shared_location: { type: 'ChatSharedLocationResponseData', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChatReactionGroupResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    first_reaction_at: { type: 'DatetimeType', isSingle: true },
+
+    last_reaction_at: { type: 'DatetimeType', isSingle: true },
+
+    latest_reactions_by: {
+      type: 'ChatReactionGroupUserResponse',
+      isSingle: false,
+    },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChatReactionGroupUserResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChatReactionResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChatReminderResponseData = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    remind_at: { type: 'DatetimeType', isSingle: true },
+
+    message: { type: 'ChatMessageResponse', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ChatSharedLocationResponseData = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    end_at: { type: 'DatetimeType', isSingle: true },
+
+    message: { type: 'ChatMessageResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CollectionResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.Command = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CommentAddedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    comment: { type: 'CommentResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CommentDeletedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    comment: { type: 'CommentResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CommentReactionAddedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    comment: { type: 'CommentResponse', isSingle: true },
+
+    reaction: { type: 'FeedsReactionResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CommentReactionDeletedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    comment: { type: 'CommentResponse', isSingle: true },
+
+    reaction: { type: 'FeedsReactionResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CommentReactionUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    comment: { type: 'CommentResponse', isSingle: true },
+
+    reaction: { type: 'FeedsReactionResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CommentResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    mentioned_users: { type: 'UserResponse', isSingle: false },
+
+    own_reactions: { type: 'FeedsReactionResponse', isSingle: false },
+
+    user: { type: 'UserResponse', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    edited_at: { type: 'DatetimeType', isSingle: true },
+
+    latest_reactions: { type: 'FeedsReactionResponse', isSingle: false },
+
+    reaction_groups: { type: 'FeedsReactionGroupResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CommentRestoredEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    comment: { type: 'CommentResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CommentUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    comment: { type: 'CommentResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ConfigResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CreateBlockListResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    blocklist: { type: 'BlockListResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CreateCollectionsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    collections: { type: 'CollectionResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CreateFeedsBatchResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    feeds: { type: 'FeedResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CreateGuestResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.CreateUserGroupResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    user_group: { type: 'UserGroupResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.DeleteActivityReactionResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    reaction: { type: 'FeedsReactionResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.DeleteBookmarkResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    bookmark: { type: 'BookmarkResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.DeleteCommentBookmarkResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    bookmark: { type: 'BookmarkResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.DeleteCommentReactionResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    comment: { type: 'CommentResponse', isSingle: true },
+
+    reaction: { type: 'FeedsReactionResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.DeleteCommentResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    comment: { type: 'CommentResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.DeviceResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.DraftPayloadResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    mentioned_users: { type: 'UserResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.DraftResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    message: { type: 'DraftPayloadResponse', isSingle: true },
+
+    channel: { type: 'ChannelResponse', isSingle: true },
+
+    parent_message: { type: 'MessageResponse', isSingle: true },
+
+    quoted_message: { type: 'MessageResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.EnrichedCollectionResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.EntityCreatorResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    deactivated_at: { type: 'DatetimeType', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    last_active: { type: 'DatetimeType', isSingle: true },
+
+    revoke_tokens_issued_before: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedCreatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    members: { type: 'FeedMemberResponse', isSingle: false },
+
+    feed: { type: 'FeedResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedDeletedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedGroupChangedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedGroupDeletedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedGroupRestoredEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedMemberAddedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    member: { type: 'FeedMemberResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedMemberRemovedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedMemberResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+
+    invite_accepted_at: { type: 'DatetimeType', isSingle: true },
+
+    invite_rejected_at: { type: 'DatetimeType', isSingle: true },
+
+    membership_level: { type: 'MembershipLevelResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedMemberUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    member: { type: 'FeedMemberResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedOwnData = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    own_followings: { type: 'FollowResponse', isSingle: false },
+
+    own_follows: { type: 'FollowResponse', isSingle: false },
+
+    own_membership: { type: 'FeedMemberResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    created_by: { type: 'UserResponse', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    own_followings: { type: 'FollowResponse', isSingle: false },
+
+    own_follows: { type: 'FollowResponse', isSingle: false },
+
+    own_membership: { type: 'FeedMemberResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedSuggestionResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    created_by: { type: 'UserResponse', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    own_followings: { type: 'FollowResponse', isSingle: false },
+
+    own_follows: { type: 'FollowResponse', isSingle: false },
+
+    own_membership: { type: 'FeedMemberResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    feed: { type: 'FeedResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedsBookmarkResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedsEnrichedCollectionResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedsFeedResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    created_by: { type: 'UserResponse', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedsReactionGroupResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    first_reaction_at: { type: 'DatetimeType', isSingle: true },
+
+    last_reaction_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedsReactionResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedsV3ActivityResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    comments: { type: 'FeedsV3CommentResponse', isSingle: false },
+
+    latest_reactions: { type: 'FeedsReactionResponse', isSingle: false },
+
+    mentioned_users: { type: 'UserResponse', isSingle: false },
+
+    own_bookmarks: { type: 'FeedsBookmarkResponse', isSingle: false },
+
+    own_reactions: { type: 'FeedsReactionResponse', isSingle: false },
+
+    collections: { type: 'FeedsEnrichedCollectionResponse', isSingle: false },
+
+    reaction_groups: { type: 'FeedsReactionGroupResponse', isSingle: false },
+
+    user: { type: 'UserResponse', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    edited_at: { type: 'DatetimeType', isSingle: true },
+
+    expires_at: { type: 'DatetimeType', isSingle: true },
+
+    friend_reactions: { type: 'FeedsReactionResponse', isSingle: false },
+
+    current_feed: { type: 'FeedsFeedResponse', isSingle: true },
+
+    parent: { type: 'FeedsV3ActivityResponse', isSingle: true },
+
+    poll: { type: 'PollResponseData', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FeedsV3CommentResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    mentioned_users: { type: 'UserResponse', isSingle: false },
+
+    own_reactions: { type: 'FeedsReactionResponse', isSingle: false },
+
+    user: { type: 'UserResponse', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    edited_at: { type: 'DatetimeType', isSingle: true },
+
+    latest_reactions: { type: 'FeedsReactionResponse', isSingle: false },
+
+    reaction_groups: { type: 'FeedsReactionGroupResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FollowBatchResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created: { type: 'FollowResponse', isSingle: false },
+
+    follows: { type: 'FollowResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FollowCreatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    follow: { type: 'FollowResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FollowDeletedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    follow: { type: 'FollowResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FollowResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    source_feed: { type: 'FeedResponse', isSingle: true },
+
+    target_feed: { type: 'FeedResponse', isSingle: true },
+
+    request_accepted_at: { type: 'DatetimeType', isSingle: true },
+
+    request_rejected_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FollowUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    follow: { type: 'FollowResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.FullUserResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    channel_mutes: { type: 'ChannelMute', isSingle: false },
+
+    devices: { type: 'DeviceResponse', isSingle: false },
+
+    mutes: { type: 'UserMuteResponse', isSingle: false },
+
+    ban_expires: { type: 'DatetimeType', isSingle: true },
+
+    deactivated_at: { type: 'DatetimeType', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    last_active: { type: 'DatetimeType', isSingle: true },
+
+    revoke_tokens_issued_before: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.GetActivityResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activity: { type: 'ActivityResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.GetAppealResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    item: { type: 'AppealItemResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.GetBlockedUsersResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    blocks: { type: 'BlockedUserResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.GetCommentRepliesResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    comments: { type: 'ThreadedCommentResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.GetCommentResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    comment: { type: 'CommentResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.GetCommentsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    comments: { type: 'ThreadedCommentResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.GetConfigResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    config: { type: 'ConfigResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.GetFollowSuggestionsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    suggestions: { type: 'FeedSuggestionResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.GetOrCreateFeedResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activities: { type: 'ActivityResponse', isSingle: false },
+
+    aggregated_activities: {
+      type: 'AggregatedActivityResponse',
+      isSingle: false,
+    },
+
+    followers: { type: 'FollowResponse', isSingle: false },
+
+    following: { type: 'FollowResponse', isSingle: false },
+
+    members: { type: 'FeedMemberResponse', isSingle: false },
+
+    pinned_activities: { type: 'ActivityPinResponse', isSingle: false },
+
+    feed: { type: 'FeedResponse', isSingle: true },
+
+    notification_status: { type: 'NotificationStatusResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.GetUserGroupResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    user_group: { type: 'UserGroupResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.HealthCheckEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    me: { type: 'OwnUserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ListBlockListResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    blocklists: { type: 'BlockListResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ListDevicesResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    devices: { type: 'DeviceResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ListUserGroupsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    user_groups: { type: 'UserGroupResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.MembershipLevelResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.MessageResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    latest_reactions: { type: 'ReactionResponse', isSingle: false },
+
+    mentioned_users: { type: 'UserResponse', isSingle: false },
+
+    own_reactions: { type: 'ReactionResponse', isSingle: false },
+
+    user: { type: 'UserResponse', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    message_text_updated_at: { type: 'DatetimeType', isSingle: true },
+
+    pin_expires: { type: 'DatetimeType', isSingle: true },
+
+    pinned_at: { type: 'DatetimeType', isSingle: true },
+
+    thread_participants: { type: 'UserResponse', isSingle: false },
+
+    draft: { type: 'DraftResponse', isSingle: true },
+
+    member: { type: 'ChannelMemberResponse', isSingle: true },
+
+    pinned_by: { type: 'UserResponse', isSingle: true },
+
+    poll: { type: 'PollResponseData', isSingle: true },
+
+    quoted_message: { type: 'MessageResponse', isSingle: true },
+
+    reaction_groups: { type: 'ReactionGroupResponse', isSingle: false },
+
+    reminder: { type: 'ReminderResponseData', isSingle: true },
+
+    shared_location: { type: 'SharedLocationResponseData', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ModerationCustomActionEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    review_queue_item: { type: 'ReviewQueueItemResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    message: { type: 'MessageResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ModerationFlagResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    review_queue_item: { type: 'ReviewQueueItemResponse', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ModerationFlaggedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ModerationMarkReviewedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    item: { type: 'ReviewQueueItemResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    message: { type: 'MessageResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.MuteResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    mutes: { type: 'UserMuteResponse', isSingle: false },
+
+    own_user: { type: 'OwnUserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.NotificationFeedUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    aggregated_activities: {
+      type: 'AggregatedActivityResponse',
+      isSingle: false,
+    },
+
+    notification_status: { type: 'NotificationStatusResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.NotificationStatusResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    last_read_at: { type: 'DatetimeType', isSingle: true },
+
+    last_seen_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.OwnBatchResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    data: { type: 'FeedOwnData', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.OwnUserResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    channel_mutes: { type: 'ChannelMute', isSingle: false },
+
+    devices: { type: 'DeviceResponse', isSingle: false },
+
+    mutes: { type: 'UserMuteResponse', isSingle: false },
+
+    deactivated_at: { type: 'DatetimeType', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    last_active: { type: 'DatetimeType', isSingle: true },
+
+    revoke_tokens_issued_before: { type: 'DatetimeType', isSingle: true },
+
+    push_preferences: { type: 'PushPreferencesResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PinActivityResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PollClosedFeedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    poll: { type: 'PollResponseData', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PollDeletedFeedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    poll: { type: 'PollResponseData', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PollResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    poll: { type: 'PollResponseData', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PollResponseData = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    latest_answers: { type: 'PollVoteResponseData', isSingle: false },
+
+    own_votes: { type: 'PollVoteResponseData', isSingle: false },
+
+    created_by: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PollUpdatedFeedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    poll: { type: 'PollResponseData', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PollVoteCastedFeedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    poll: { type: 'PollResponseData', isSingle: true },
+
+    poll_vote: { type: 'PollVoteResponseData', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PollVoteChangedFeedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    poll: { type: 'PollResponseData', isSingle: true },
+
+    poll_vote: { type: 'PollVoteResponseData', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PollVoteRemovedFeedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    poll: { type: 'PollResponseData', isSingle: true },
+
+    poll_vote: { type: 'PollVoteResponseData', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PollVoteResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    poll: { type: 'PollResponseData', isSingle: true },
+
+    vote: { type: 'PollVoteResponseData', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PollVoteResponseData = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PollVotesResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    votes: { type: 'PollVoteResponseData', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.PushPreferencesResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    disabled_until: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryActivitiesResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activities: { type: 'ActivityResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryActivityReactionsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    reactions: { type: 'FeedsReactionResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryAppealsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    items: { type: 'AppealItemResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryBookmarkFoldersResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    bookmark_folders: { type: 'BookmarkFolderResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryBookmarksResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    bookmarks: { type: 'BookmarkResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryCollectionsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    collections: { type: 'CollectionResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryCommentReactionsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    reactions: { type: 'FeedsReactionResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryCommentsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    comments: { type: 'CommentResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryFeedMembersResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    members: { type: 'FeedMemberResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryFeedsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    feeds: { type: 'FeedResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryFollowsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    follows: { type: 'FollowResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryModerationConfigsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    configs: { type: 'ConfigResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryPinnedActivitiesResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    pinned_activities: { type: 'ActivityPinResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryPollsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    polls: { type: 'PollResponseData', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryReviewQueueResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    items: { type: 'ReviewQueueItemResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryUsersResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    users: { type: 'FullUserResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.Reaction = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ReactionGroupResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    first_reaction_at: { type: 'DatetimeType', isSingle: true },
+
+    last_reaction_at: { type: 'DatetimeType', isSingle: true },
+
+    latest_reactions_by: { type: 'ReactionGroupUserResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ReactionGroupUserResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ReactionResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ReadCollectionsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    collections: { type: 'CollectionResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.RejectFeedMemberInviteResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    member: { type: 'FeedMemberResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.RejectFollowResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    follow: { type: 'FollowResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ReminderResponseData = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    remind_at: { type: 'DatetimeType', isSingle: true },
+
+    channel: { type: 'ChannelResponse', isSingle: true },
+
+    message: { type: 'MessageResponse', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.RemoveUserGroupMembersResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    user_group: { type: 'UserGroupResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.RestoreActivityResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activity: { type: 'ActivityResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.RestoreCommentResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    comment: { type: 'CommentResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ReviewQueueItemResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    actions: { type: 'ActionLogResponse', isSingle: false },
+
+    bans: { type: 'BanInfoResponse', isSingle: false },
+
+    flags: { type: 'ModerationFlagResponse', isSingle: false },
+
+    completed_at: { type: 'DatetimeType', isSingle: true },
+
+    escalated_at: { type: 'DatetimeType', isSingle: true },
+
+    reviewed_at: { type: 'DatetimeType', isSingle: true },
+
+    appeal: { type: 'AppealItemResponse', isSingle: true },
+
+    assigned_to: { type: 'UserResponse', isSingle: true },
+
+    call: { type: 'CallResponse', isSingle: true },
+
+    entity_creator: { type: 'EntityCreatorResponse', isSingle: true },
+
+    feeds_v2_reaction: { type: 'Reaction', isSingle: true },
+
+    feeds_v3_activity: { type: 'FeedsV3ActivityResponse', isSingle: true },
+
+    feeds_v3_comment: { type: 'FeedsV3CommentResponse', isSingle: true },
+
+    message: { type: 'ChatMessageResponse', isSingle: true },
+
+    reaction: { type: 'Reaction', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.SearchUserGroupsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    user_groups: { type: 'UserGroupResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.SharedLocationResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    end_at: { type: 'DatetimeType', isSingle: true },
+
+    channel: { type: 'ChannelResponse', isSingle: true },
+
+    message: { type: 'MessageResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.SharedLocationResponseData = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    end_at: { type: 'DatetimeType', isSingle: true },
+
+    channel: { type: 'ChannelResponse', isSingle: true },
+
+    message: { type: 'MessageResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.SharedLocationsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    active_live_locations: {
+      type: 'SharedLocationResponseData',
+      isSingle: false,
+    },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.SingleFollowResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    follow: { type: 'FollowResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.StoriesFeedUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    activities: { type: 'ActivityResponse', isSingle: false },
+
+    aggregated_activities: {
+      type: 'AggregatedActivityResponse',
+      isSingle: false,
+    },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.SubmitActionResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    appeal_item: { type: 'AppealItemResponse', isSingle: true },
+
+    item: { type: 'ReviewQueueItemResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ThreadedCommentResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    mentioned_users: { type: 'UserResponse', isSingle: false },
+
+    own_reactions: { type: 'FeedsReactionResponse', isSingle: false },
+
+    user: { type: 'UserResponse', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    edited_at: { type: 'DatetimeType', isSingle: true },
+
+    latest_reactions: { type: 'FeedsReactionResponse', isSingle: false },
+
+    replies: { type: 'ThreadedCommentResponse', isSingle: false },
+
+    reaction_groups: { type: 'FeedsReactionGroupResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UnfollowBatchResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    follows: { type: 'FollowResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UnfollowResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    follow: { type: 'FollowResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UnpinActivityResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activity: { type: 'ActivityResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateActivityPartialResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activity: { type: 'ActivityResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateActivityResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activity: { type: 'ActivityResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateBlockListResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    blocklist: { type: 'BlockListResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateBookmarkFolderResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    bookmark_folder: { type: 'BookmarkFolderResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateBookmarkResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    bookmark: { type: 'BookmarkResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateCollectionsResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    collections: { type: 'CollectionResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateCommentBookmarkResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    bookmark: { type: 'BookmarkResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateCommentPartialResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    comment: { type: 'CommentResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateCommentResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    comment: { type: 'CommentResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateFeedMembersResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    added: { type: 'FeedMemberResponse', isSingle: false },
+
+    updated: { type: 'FeedMemberResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateFeedResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    feed: { type: 'FeedResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateFollowResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    follow: { type: 'FollowResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateUserGroupResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    user_group: { type: 'UserGroupResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpdateUsersResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    users: { type: 'FullUserResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpsertActivitiesResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    activities: { type: 'ActivityResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpsertConfigResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    config: { type: 'ConfigResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UpsertPushPreferencesResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    user_preferences: { type: 'PushPreferencesResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UserBannedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    expiration: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UserDeactivatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UserGroupMember = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UserGroupResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    members: { type: 'UserGroupMember', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UserMuteResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    expires: { type: 'DatetimeType', isSingle: true },
+
+    target: { type: 'UserResponse', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UserReactivatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UserResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    deactivated_at: { type: 'DatetimeType', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    last_active: { type: 'DatetimeType', isSingle: true },
+
+    revoke_tokens_issued_before: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UserUnbannedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UserUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};

--- a/packages/feeds-client/src/gen/model-decoders/decoders.ts
+++ b/packages/feeds-client/src/gen/model-decoders/decoders.ts
@@ -1,13 +1,10 @@
 type Decoder = (i: any) => any;
 
-type TypeMapping = Record<string, { type: string; isSingle: boolean }>;
+type TypeMapping = Record<string, {type: string, isSingle: boolean}>
 
 export const decoders: Record<string, Decoder> = {};
 
-const decodeDatetimeType = (input: number | string) =>
-  typeof input === 'number'
-    ? new Date(Math.floor(input / 1000000))
-    : new Date(input);
+const decodeDatetimeType = (input: number | string) => typeof input === 'number' ? new Date(Math.floor(input / 1000000)) : new Date(input);
 
 decoders.DatetimeType = decodeDatetimeType;
 
@@ -19,13 +16,13 @@ const decode = (typeMappings: TypeMapping, input?: Record<string, any>) => {
       if (typeMappings[key]) {
         const decoder = decoders[typeMappings[key].type];
         if (decoder) {
-          if (typeMappings[key].isSingle) {
-            input[key] = decoder(input[key]);
-          } else {
-            Object.keys(input[key]).forEach((k) => {
-              input[key][k] = decoder(input[key][k]);
-            });
-          }
+            if (typeMappings[key].isSingle) {
+              input[key] = decoder(input[key]);
+            } else {
+                Object.keys(input[key]).forEach(k => {
+                    input[key][k] = decoder(input[key][k])
+                })
+            }
         }
       }
     }
@@ -34,2187 +31,3944 @@ const decode = (typeMappings: TypeMapping, input?: Record<string, any>) => {
   return input;
 };
 
-decoders.AcceptFeedMemberInviteResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    member: { type: 'FeedMemberResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
 
-decoders.AcceptFollowResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    follow: { type: 'FollowResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
 
-decoders.ActionLogResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    review_queue_item: { type: 'ReviewQueueItemResponse', isSingle: true },
-
-    target_user: { type: 'UserResponse', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityAddedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityDeletedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityFeedbackEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityMarkEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityPinResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityPinnedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    pinned_activity: { type: 'PinActivityResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityReactionAddedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    reaction: { type: 'FeedsReactionResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityReactionDeletedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    reaction: { type: 'FeedsReactionResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityReactionUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    reaction: { type: 'FeedsReactionResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityRemovedFromFeedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    comments: { type: 'CommentResponse', isSingle: false },
-
-    latest_reactions: { type: 'FeedsReactionResponse', isSingle: false },
-
-    mentioned_users: { type: 'UserResponse', isSingle: false },
-
-    own_bookmarks: { type: 'BookmarkResponse', isSingle: false },
-
-    own_reactions: { type: 'FeedsReactionResponse', isSingle: false },
-
-    collections: { type: 'EnrichedCollectionResponse', isSingle: false },
-
-    reaction_groups: { type: 'FeedsReactionGroupResponse', isSingle: false },
-
-    user: { type: 'UserResponse', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    edited_at: { type: 'DatetimeType', isSingle: true },
-
-    expires_at: { type: 'DatetimeType', isSingle: true },
-
-    friend_reactions: { type: 'FeedsReactionResponse', isSingle: false },
-
-    current_feed: { type: 'FeedResponse', isSingle: true },
-
-    parent: { type: 'ActivityResponse', isSingle: true },
-
-    poll: { type: 'PollResponseData', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityRestoredEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityUnpinnedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    pinned_activity: { type: 'PinActivityResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ActivityUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.AddActivityResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activity: { type: 'ActivityResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.AddBookmarkResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    bookmark: { type: 'BookmarkResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.AddCommentBookmarkResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    bookmark: { type: 'BookmarkResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.AddCommentReactionResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    comment: { type: 'CommentResponse', isSingle: true },
-
-    reaction: { type: 'FeedsReactionResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.AddCommentResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    comment: { type: 'CommentResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.AddCommentsBatchResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    comments: { type: 'CommentResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.AddReactionResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    reaction: { type: 'FeedsReactionResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.AddUserGroupMembersResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    user_group: { type: 'UserGroupResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.AggregatedActivityResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    activities: { type: 'ActivityResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.AppUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.AppealItemResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.BanInfoResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    expires: { type: 'DatetimeType', isSingle: true },
-
-    created_by: { type: 'UserResponse', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.BlockListResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.BlockUsersResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.BlockedUserResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    blocked_user: { type: 'UserResponse', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.BookmarkAddedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    bookmark: { type: 'BookmarkResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.BookmarkDeletedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    bookmark: { type: 'BookmarkResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.BookmarkFolderDeletedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    bookmark_folder: { type: 'BookmarkFolderResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.BookmarkFolderResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.BookmarkFolderUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    bookmark_folder: { type: 'BookmarkFolderResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.BookmarkResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-
-    comment: { type: 'CommentResponse', isSingle: true },
-
-    folder: { type: 'BookmarkFolderResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.BookmarkUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    bookmark: { type: 'BookmarkResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CallParticipantResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    joined_at: { type: 'Timestamp', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CallResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'Timestamp', isSingle: true },
-
-    created_by: { type: 'UserResponse', isSingle: true },
-
-    egress: { type: 'EgressResponse', isSingle: true },
-
-    updated_at: { type: 'Timestamp', isSingle: true },
-
-    ended_at: { type: 'Timestamp', isSingle: true },
-
-    session: { type: 'CallSessionResponse', isSingle: true },
-
-    starts_at: { type: 'Timestamp', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CallSessionResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    participants: { type: 'CallParticipantResponse', isSingle: false },
-
-    accepted_by: { type: 'Timestamp', isSingle: false },
-
-    missed_by: { type: 'Timestamp', isSingle: false },
-
-    rejected_by: { type: 'Timestamp', isSingle: false },
-
-    ended_at: { type: 'Timestamp', isSingle: true },
-
-    live_ended_at: { type: 'Timestamp', isSingle: true },
-
-    live_started_at: { type: 'Timestamp', isSingle: true },
-
-    started_at: { type: 'Timestamp', isSingle: true },
-
-    timer_ends_at: { type: 'Timestamp', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ChannelConfigWithInfo = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    commands: { type: 'Command', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ChannelMemberResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    archived_at: { type: 'DatetimeType', isSingle: true },
-
-    ban_expires: { type: 'DatetimeType', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    invite_accepted_at: { type: 'DatetimeType', isSingle: true },
-
-    invite_rejected_at: { type: 'DatetimeType', isSingle: true },
-
-    pinned_at: { type: 'DatetimeType', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ChannelMute = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    expires: { type: 'DatetimeType', isSingle: true },
-
-    channel: { type: 'ChannelResponse', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ChannelResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    hide_messages_before: { type: 'DatetimeType', isSingle: true },
-
-    last_message_at: { type: 'DatetimeType', isSingle: true },
-
-    mute_expires_at: { type: 'DatetimeType', isSingle: true },
-
-    truncated_at: { type: 'DatetimeType', isSingle: true },
-
-    members: { type: 'ChannelMemberResponse', isSingle: false },
-
-    config: { type: 'ChannelConfigWithInfo', isSingle: true },
-
-    created_by: { type: 'UserResponse', isSingle: true },
-
-    truncated_by: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CollectionResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.Command = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CommentAddedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    comment: { type: 'CommentResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CommentDeletedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    comment: { type: 'CommentResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CommentReactionAddedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    comment: { type: 'CommentResponse', isSingle: true },
-
-    reaction: { type: 'FeedsReactionResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CommentReactionDeletedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    comment: { type: 'CommentResponse', isSingle: true },
-
-    reaction: { type: 'FeedsReactionResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CommentReactionUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    comment: { type: 'CommentResponse', isSingle: true },
-
-    reaction: { type: 'FeedsReactionResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CommentResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    mentioned_users: { type: 'UserResponse', isSingle: false },
-
-    own_reactions: { type: 'FeedsReactionResponse', isSingle: false },
-
-    user: { type: 'UserResponse', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    edited_at: { type: 'DatetimeType', isSingle: true },
-
-    latest_reactions: { type: 'FeedsReactionResponse', isSingle: false },
-
-    reaction_groups: { type: 'FeedsReactionGroupResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CommentRestoredEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    comment: { type: 'CommentResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CommentUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    comment: { type: 'CommentResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ConfigResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CreateBlockListResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    blocklist: { type: 'BlockListResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CreateCollectionsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    collections: { type: 'CollectionResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CreateFeedsBatchResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    feeds: { type: 'FeedResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CreateGuestResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CreateUserGroupResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    user_group: { type: 'UserGroupResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.DeleteActivityReactionResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    reaction: { type: 'FeedsReactionResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.DeleteBookmarkResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    bookmark: { type: 'BookmarkResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.DeleteCommentBookmarkResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    bookmark: { type: 'BookmarkResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.DeleteCommentReactionResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    comment: { type: 'CommentResponse', isSingle: true },
-
-    reaction: { type: 'FeedsReactionResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.DeleteCommentResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    comment: { type: 'CommentResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.DeviceResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.DraftPayloadResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    mentioned_users: { type: 'UserResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.DraftResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    message: { type: 'DraftPayloadResponse', isSingle: true },
-
-    channel: { type: 'ChannelResponse', isSingle: true },
-
-    parent_message: { type: 'MessageResponse', isSingle: true },
-
-    quoted_message: { type: 'MessageResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.EgressRTMPResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    started_at: { type: 'Timestamp', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.EgressResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    rtmps: { type: 'EgressRTMPResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.EnrichedCollection = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.EnrichedCollectionResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.EntityCreatorResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    deactivated_at: { type: 'DatetimeType', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    last_active: { type: 'DatetimeType', isSingle: true },
-
-    revoke_tokens_issued_before: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedCreatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    members: { type: 'FeedMemberResponse', isSingle: false },
-
-    feed: { type: 'FeedResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedDeletedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedGroupChangedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedGroupDeletedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedGroupRestoredEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedMemberAddedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    member: { type: 'FeedMemberResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedMemberRemovedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedMemberResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-
-    invite_accepted_at: { type: 'DatetimeType', isSingle: true },
-
-    invite_rejected_at: { type: 'DatetimeType', isSingle: true },
-
-    membership_level: { type: 'MembershipLevelResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedMemberUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    member: { type: 'FeedMemberResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedOwnData = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    own_followings: { type: 'FollowResponse', isSingle: false },
-
-    own_follows: { type: 'FollowResponse', isSingle: false },
-
-    own_membership: { type: 'FeedMemberResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    created_by: { type: 'UserResponse', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    own_followings: { type: 'FollowResponse', isSingle: false },
-
-    own_follows: { type: 'FollowResponse', isSingle: false },
-
-    own_membership: { type: 'FeedMemberResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedSuggestionResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    created_by: { type: 'UserResponse', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    own_followings: { type: 'FollowResponse', isSingle: false },
-
-    own_follows: { type: 'FollowResponse', isSingle: false },
-
-    own_membership: { type: 'FeedMemberResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    feed: { type: 'FeedResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedsReactionGroup = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    first_reaction_at: { type: 'DatetimeType', isSingle: true },
-
-    last_reaction_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedsReactionGroupResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    first_reaction_at: { type: 'DatetimeType', isSingle: true },
-
-    last_reaction_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedsReactionResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedsV3ActivityResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    comments: { type: 'FeedsV3CommentResponse', isSingle: false },
-
-    mentioned_users: { type: 'UserResponse', isSingle: false },
-
-    collections: { type: 'EnrichedCollection', isSingle: false },
-
-    reaction_groups: { type: 'FeedsReactionGroup', isSingle: false },
-
-    user: { type: 'UserResponse', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    edited_at: { type: 'DatetimeType', isSingle: true },
-
-    expires_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedsV3CommentResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    mentioned_users: { type: 'UserResponse', isSingle: false },
-
-    user: { type: 'UserResponse', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    edited_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FollowBatchResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created: { type: 'FollowResponse', isSingle: false },
-
-    follows: { type: 'FollowResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FollowCreatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    follow: { type: 'FollowResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FollowDeletedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    follow: { type: 'FollowResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FollowResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    source_feed: { type: 'FeedResponse', isSingle: true },
-
-    target_feed: { type: 'FeedResponse', isSingle: true },
-
-    request_accepted_at: { type: 'DatetimeType', isSingle: true },
-
-    request_rejected_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FollowUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    follow: { type: 'FollowResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FullUserResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    channel_mutes: { type: 'ChannelMute', isSingle: false },
-
-    devices: { type: 'DeviceResponse', isSingle: false },
-
-    mutes: { type: 'UserMuteResponse', isSingle: false },
-
-    ban_expires: { type: 'DatetimeType', isSingle: true },
-
-    deactivated_at: { type: 'DatetimeType', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    last_active: { type: 'DatetimeType', isSingle: true },
-
-    revoke_tokens_issued_before: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetActivityResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activity: { type: 'ActivityResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetAppealResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    item: { type: 'AppealItemResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetBlockedUsersResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    blocks: { type: 'BlockedUserResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetCommentRepliesResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    comments: { type: 'ThreadedCommentResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetCommentResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    comment: { type: 'CommentResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetCommentsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    comments: { type: 'ThreadedCommentResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetConfigResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    config: { type: 'ConfigResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetFollowSuggestionsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    suggestions: { type: 'FeedSuggestionResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetOrCreateFeedResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activities: { type: 'ActivityResponse', isSingle: false },
-
-    aggregated_activities: {
-      type: 'AggregatedActivityResponse',
-      isSingle: false,
-    },
-
-    followers: { type: 'FollowResponse', isSingle: false },
-
-    following: { type: 'FollowResponse', isSingle: false },
-
-    members: { type: 'FeedMemberResponse', isSingle: false },
-
-    pinned_activities: { type: 'ActivityPinResponse', isSingle: false },
-
-    feed: { type: 'FeedResponse', isSingle: true },
-
-    notification_status: { type: 'NotificationStatusResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetUserGroupResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    user_group: { type: 'UserGroupResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.HealthCheckEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-
-    me: { type: 'OwnUserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ListBlockListResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    blocklists: { type: 'BlockListResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ListDevicesResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    devices: { type: 'DeviceResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ListUserGroupsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    user_groups: { type: 'UserGroupResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.MembershipLevelResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.MessageResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    latest_reactions: { type: 'ReactionResponse', isSingle: false },
-
-    mentioned_users: { type: 'UserResponse', isSingle: false },
-
-    own_reactions: { type: 'ReactionResponse', isSingle: false },
-
-    user: { type: 'UserResponse', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    message_text_updated_at: { type: 'DatetimeType', isSingle: true },
-
-    pin_expires: { type: 'DatetimeType', isSingle: true },
-
-    pinned_at: { type: 'DatetimeType', isSingle: true },
-
-    thread_participants: { type: 'UserResponse', isSingle: false },
-
-    draft: { type: 'DraftResponse', isSingle: true },
-
-    member: { type: 'ChannelMemberResponse', isSingle: true },
-
-    pinned_by: { type: 'UserResponse', isSingle: true },
-
-    poll: { type: 'PollResponseData', isSingle: true },
-
-    quoted_message: { type: 'MessageResponse', isSingle: true },
-
-    reaction_groups: { type: 'ReactionGroupResponse', isSingle: false },
-
-    reminder: { type: 'ReminderResponseData', isSingle: true },
-
-    shared_location: { type: 'SharedLocationResponseData', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ModerationCustomActionEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    review_queue_item: { type: 'ReviewQueueItemResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-
-    message: { type: 'MessageResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ModerationFlagResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    review_queue_item: { type: 'ReviewQueueItemResponse', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ModerationFlaggedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ModerationMarkReviewedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    item: { type: 'ReviewQueueItemResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-
-    message: { type: 'MessageResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.MuteResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    mutes: { type: 'UserMuteResponse', isSingle: false },
-
-    own_user: { type: 'OwnUserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.NotificationFeedUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-
-    aggregated_activities: {
-      type: 'AggregatedActivityResponse',
-      isSingle: false,
-    },
-
-    notification_status: { type: 'NotificationStatusResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.NotificationStatusResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    last_read_at: { type: 'DatetimeType', isSingle: true },
-
-    last_seen_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.OwnBatchResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    data: { type: 'FeedOwnData', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.OwnUserResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    channel_mutes: { type: 'ChannelMute', isSingle: false },
-
-    devices: { type: 'DeviceResponse', isSingle: false },
-
-    mutes: { type: 'UserMuteResponse', isSingle: false },
-
-    deactivated_at: { type: 'DatetimeType', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    last_active: { type: 'DatetimeType', isSingle: true },
-
-    revoke_tokens_issued_before: { type: 'DatetimeType', isSingle: true },
-
-    push_preferences: { type: 'PushPreferencesResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PinActivityResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PollClosedFeedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    poll: { type: 'PollResponseData', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PollDeletedFeedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    poll: { type: 'PollResponseData', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PollResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    poll: { type: 'PollResponseData', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PollResponseData = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    latest_answers: { type: 'PollVoteResponseData', isSingle: false },
-
-    own_votes: { type: 'PollVoteResponseData', isSingle: false },
-
-    created_by: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PollUpdatedFeedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    poll: { type: 'PollResponseData', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PollVoteCastedFeedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    poll: { type: 'PollResponseData', isSingle: true },
-
-    poll_vote: { type: 'PollVoteResponseData', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PollVoteChangedFeedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    poll: { type: 'PollResponseData', isSingle: true },
-
-    poll_vote: { type: 'PollVoteResponseData', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PollVoteRemovedFeedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    poll: { type: 'PollResponseData', isSingle: true },
-
-    poll_vote: { type: 'PollVoteResponseData', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PollVoteResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    poll: { type: 'PollResponseData', isSingle: true },
-
-    vote: { type: 'PollVoteResponseData', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PollVoteResponseData = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PollVotesResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    votes: { type: 'PollVoteResponseData', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.PushPreferencesResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    disabled_until: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryActivitiesResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activities: { type: 'ActivityResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryActivityReactionsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    reactions: { type: 'FeedsReactionResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryAppealsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    items: { type: 'AppealItemResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryBookmarkFoldersResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    bookmark_folders: { type: 'BookmarkFolderResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryBookmarksResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    bookmarks: { type: 'BookmarkResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryCollectionsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    collections: { type: 'CollectionResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryCommentReactionsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    reactions: { type: 'FeedsReactionResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryCommentsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    comments: { type: 'CommentResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryFeedMembersResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    members: { type: 'FeedMemberResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryFeedsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    feeds: { type: 'FeedResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryFollowsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    follows: { type: 'FollowResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryModerationConfigsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    configs: { type: 'ConfigResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryPinnedActivitiesResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    pinned_activities: { type: 'ActivityPinResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryPollsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    polls: { type: 'PollResponseData', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryReviewQueueResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    items: { type: 'ReviewQueueItemResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.QueryUsersResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    users: { type: 'FullUserResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.Reaction = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ReactionGroupResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    first_reaction_at: { type: 'DatetimeType', isSingle: true },
-
-    last_reaction_at: { type: 'DatetimeType', isSingle: true },
-
-    latest_reactions_by: { type: 'ReactionGroupUserResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ReactionGroupUserResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ReactionResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ReadCollectionsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    collections: { type: 'CollectionResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.RejectFeedMemberInviteResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    member: { type: 'FeedMemberResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.RejectFollowResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    follow: { type: 'FollowResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ReminderResponseData = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    remind_at: { type: 'DatetimeType', isSingle: true },
-
-    channel: { type: 'ChannelResponse', isSingle: true },
-
-    message: { type: 'MessageResponse', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.RemoveUserGroupMembersResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    user_group: { type: 'UserGroupResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.RestoreActivityResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activity: { type: 'ActivityResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.RestoreCommentResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    comment: { type: 'CommentResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ReviewQueueItemResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    actions: { type: 'ActionLogResponse', isSingle: false },
-
-    bans: { type: 'BanInfoResponse', isSingle: false },
-
-    flags: { type: 'ModerationFlagResponse', isSingle: false },
-
-    completed_at: { type: 'DatetimeType', isSingle: true },
-
-    escalated_at: { type: 'DatetimeType', isSingle: true },
-
-    reviewed_at: { type: 'DatetimeType', isSingle: true },
-
-    appeal: { type: 'AppealItemResponse', isSingle: true },
-
-    assigned_to: { type: 'UserResponse', isSingle: true },
-
-    call: { type: 'CallResponse', isSingle: true },
-
-    entity_creator: { type: 'EntityCreatorResponse', isSingle: true },
-
-    feeds_v2_reaction: { type: 'Reaction', isSingle: true },
-
-    feeds_v3_activity: { type: 'FeedsV3ActivityResponse', isSingle: true },
-
-    feeds_v3_comment: { type: 'FeedsV3CommentResponse', isSingle: true },
-
-    message: { type: 'MessageResponse', isSingle: true },
-
-    reaction: { type: 'Reaction', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.SearchUserGroupsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    user_groups: { type: 'UserGroupResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.SharedLocationResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    end_at: { type: 'DatetimeType', isSingle: true },
-
-    channel: { type: 'ChannelResponse', isSingle: true },
-
-    message: { type: 'MessageResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.SharedLocationResponseData = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    end_at: { type: 'DatetimeType', isSingle: true },
-
-    channel: { type: 'ChannelResponse', isSingle: true },
-
-    message: { type: 'MessageResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.SharedLocationsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    active_live_locations: {
-      type: 'SharedLocationResponseData',
-      isSingle: false,
-    },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.SingleFollowResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    follow: { type: 'FollowResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.StoriesFeedUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-
-    activities: { type: 'ActivityResponse', isSingle: false },
-
-    aggregated_activities: {
-      type: 'AggregatedActivityResponse',
-      isSingle: false,
-    },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.SubmitActionResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    appeal_item: { type: 'AppealItemResponse', isSingle: true },
-
-    item: { type: 'ReviewQueueItemResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.ThreadedCommentResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    mentioned_users: { type: 'UserResponse', isSingle: false },
-
-    own_reactions: { type: 'FeedsReactionResponse', isSingle: false },
-
-    user: { type: 'UserResponse', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    edited_at: { type: 'DatetimeType', isSingle: true },
-
-    latest_reactions: { type: 'FeedsReactionResponse', isSingle: false },
-
-    replies: { type: 'ThreadedCommentResponse', isSingle: false },
-
-    reaction_groups: { type: 'FeedsReactionGroupResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.Timestamp = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    time: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UnfollowBatchResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    follows: { type: 'FollowResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UnfollowResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    follow: { type: 'FollowResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UnpinActivityResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activity: { type: 'ActivityResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateActivityPartialResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activity: { type: 'ActivityResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateActivityResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activity: { type: 'ActivityResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateBlockListResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    blocklist: { type: 'BlockListResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateBookmarkFolderResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    bookmark_folder: { type: 'BookmarkFolderResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateBookmarkResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    bookmark: { type: 'BookmarkResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateCollectionsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    collections: { type: 'CollectionResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateCommentBookmarkResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    bookmark: { type: 'BookmarkResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateCommentPartialResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    comment: { type: 'CommentResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateCommentResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    comment: { type: 'CommentResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateFeedMembersResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    added: { type: 'FeedMemberResponse', isSingle: false },
-
-    updated: { type: 'FeedMemberResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateFeedResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    feed: { type: 'FeedResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateFollowResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    follow: { type: 'FollowResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateUserGroupResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    user_group: { type: 'UserGroupResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpdateUsersResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    users: { type: 'FullUserResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpsertActivitiesResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    activities: { type: 'ActivityResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpsertConfigResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    config: { type: 'ConfigResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UpsertPushPreferencesResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    user_preferences: { type: 'PushPreferencesResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UserBannedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    expiration: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UserDeactivatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UserGroupMember = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UserGroupResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    members: { type: 'UserGroupMember', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UserMuteResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    expires: { type: 'DatetimeType', isSingle: true },
-
-    target: { type: 'UserResponse', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UserReactivatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UserResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    deactivated_at: { type: 'DatetimeType', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    last_active: { type: 'DatetimeType', isSingle: true },
-
-    revoke_tokens_issued_before: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UserUnbannedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UserUpdatedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
+  decoders['AcceptFeedMemberInviteResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "member": {type: "FeedMemberResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['AcceptFollowResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "follow": {type: "FollowResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActionLogResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "review_queue_item": {type: "ReviewQueueItemResponse", isSingle: true},
+            
+        
+                "target_user": {type: "UserResponse", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityAddedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityDeletedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityFeedbackEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityMarkEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityPinResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityPinnedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "pinned_activity": {type: "PinActivityResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityReactionAddedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+        
+                "reaction": {type: "FeedsReactionResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityReactionDeletedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+        
+                "reaction": {type: "FeedsReactionResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityReactionUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+        
+                "reaction": {type: "FeedsReactionResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityRemovedFromFeedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+              "comments": {type: "CommentResponse", isSingle: false},
+            
+        
+        
+        
+        
+              "latest_reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+              "mentioned_users": {type: "UserResponse", isSingle: false},
+            
+        
+              "own_bookmarks": {type: "BookmarkResponse", isSingle: false},
+            
+        
+              "own_reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+              "collections": {type: "EnrichedCollectionResponse", isSingle: false},
+            
+        
+        
+              "reaction_groups": {type: "FeedsReactionGroupResponse", isSingle: false},
+            
+        
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "edited_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "expires_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+              "friend_reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+                "current_feed": {type: "FeedResponse", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "parent": {type: "ActivityResponse", isSingle: true},
+            
+        
+                "poll": {type: "PollResponseData", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityRestoredEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityUnpinnedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "pinned_activity": {type: "PinActivityResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ActivityUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['AddActivityResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['AddBookmarkResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "bookmark": {type: "BookmarkResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['AddCommentBookmarkResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "bookmark": {type: "BookmarkResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['AddCommentReactionResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        
+                "reaction": {type: "FeedsReactionResponse", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['AddCommentResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['AddCommentsBatchResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "comments": {type: "CommentResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['AddReactionResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+                "reaction": {type: "FeedsReactionResponse", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['AddUserGroupMembersResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "user_group": {type: "UserGroupResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['AggregatedActivityResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+              "activities": {type: "ActivityResponse", isSingle: false},
+            
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['AppUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['AppealItemResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['BanInfoResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "expires": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "created_by": {type: "UserResponse", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['BlockListResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+        
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['BlockUsersResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['BlockedUserResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "blocked_user": {type: "UserResponse", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['BookmarkAddedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "bookmark": {type: "BookmarkResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['BookmarkDeletedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "bookmark": {type: "BookmarkResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['BookmarkFolderDeletedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "bookmark_folder": {type: "BookmarkFolderResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['BookmarkFolderResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['BookmarkFolderUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "bookmark_folder": {type: "BookmarkFolderResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['BookmarkResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        
+        
+                "folder": {type: "BookmarkFolderResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['BookmarkUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "bookmark": {type: "BookmarkResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CallResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "ended_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "starts_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "created_by": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChangeFeedVisibilityResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "feed": {type: "FeedResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChannelConfigWithInfo'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+              "commands": {type: "Command", isSingle: false},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChannelMemberResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "archived_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "ban_expires": {type: "DatetimeType", isSingle: true},
+            
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "invite_accepted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "invite_rejected_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "pinned_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChannelMute'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "expires": {type: "DatetimeType", isSingle: true},
+            
+        
+                "channel": {type: "ChannelResponse", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChannelResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "hide_messages_before": {type: "DatetimeType", isSingle: true},
+            
+        
+                "last_message_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "mute_expires_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "truncated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+              "members": {type: "ChannelMemberResponse", isSingle: false},
+            
+        
+        
+                "config": {type: "ChannelConfigWithInfo", isSingle: true},
+            
+        
+                "created_by": {type: "UserResponse", isSingle: true},
+            
+        
+                "truncated_by": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChatDraftPayloadResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+              "mentioned_users": {type: "UserResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChatDraftResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "message": {type: "ChatDraftPayloadResponse", isSingle: true},
+            
+        
+        
+                "parent_message": {type: "ChatMessageResponse", isSingle: true},
+            
+        
+                "quoted_message": {type: "ChatMessageResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChatMessageResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+              "latest_reactions": {type: "ChatReactionResponse", isSingle: false},
+            
+        
+              "mentioned_users": {type: "UserResponse", isSingle: false},
+            
+        
+              "own_reactions": {type: "ChatReactionResponse", isSingle: false},
+            
+        
+        
+        
+        
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "message_text_updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "pin_expires": {type: "DatetimeType", isSingle: true},
+            
+        
+                "pinned_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+              "thread_participants": {type: "UserResponse", isSingle: false},
+            
+        
+                "draft": {type: "ChatDraftResponse", isSingle: true},
+            
+        
+        
+        
+                "member": {type: "ChannelMemberResponse", isSingle: true},
+            
+        
+        
+                "pinned_by": {type: "UserResponse", isSingle: true},
+            
+        
+                "poll": {type: "PollResponseData", isSingle: true},
+            
+        
+                "quoted_message": {type: "ChatMessageResponse", isSingle: true},
+            
+        
+              "reaction_groups": {type: "ChatReactionGroupResponse", isSingle: false},
+            
+        
+                "reminder": {type: "ChatReminderResponseData", isSingle: true},
+            
+        
+                "shared_location": {type: "ChatSharedLocationResponseData", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChatReactionGroupResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "first_reaction_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "last_reaction_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+              "latest_reactions_by": {type: "ChatReactionGroupUserResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChatReactionGroupUserResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChatReactionResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChatReminderResponseData'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "remind_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "message": {type: "ChatMessageResponse", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ChatSharedLocationResponseData'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "end_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "message": {type: "ChatMessageResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CollectionResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['Command'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CommentAddedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CommentDeletedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CommentReactionAddedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        
+        
+                "reaction": {type: "FeedsReactionResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CommentReactionDeletedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        
+        
+                "reaction": {type: "FeedsReactionResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CommentReactionUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        
+        
+                "reaction": {type: "FeedsReactionResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CommentResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+              "mentioned_users": {type: "UserResponse", isSingle: false},
+            
+        
+              "own_reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "edited_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+              "latest_reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+        
+        
+              "reaction_groups": {type: "FeedsReactionGroupResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CommentRestoredEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CommentUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ConfigResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CreateBlockListResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "blocklist": {type: "BlockListResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CreateCollectionsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "collections": {type: "CollectionResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CreateFeedsBatchResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "feeds": {type: "FeedResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CreateGuestResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['CreateUserGroupResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "user_group": {type: "UserGroupResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['DeleteActivityReactionResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+                "reaction": {type: "FeedsReactionResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['DeleteBookmarkResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "bookmark": {type: "BookmarkResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['DeleteCommentBookmarkResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "bookmark": {type: "BookmarkResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['DeleteCommentReactionResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        
+                "reaction": {type: "FeedsReactionResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['DeleteCommentResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['DeviceResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['DraftPayloadResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+              "mentioned_users": {type: "UserResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['DraftResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "message": {type: "DraftPayloadResponse", isSingle: true},
+            
+        
+        
+                "channel": {type: "ChannelResponse", isSingle: true},
+            
+        
+                "parent_message": {type: "MessageResponse", isSingle: true},
+            
+        
+                "quoted_message": {type: "MessageResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['EnrichedCollectionResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['EntityCreatorResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "deactivated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "last_active": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "revoke_tokens_issued_before": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedCreatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+              "members": {type: "FeedMemberResponse", isSingle: false},
+            
+        
+        
+                "feed": {type: "FeedResponse", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedDeletedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedGroupChangedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedGroupDeletedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedGroupRestoredEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedMemberAddedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "member": {type: "FeedMemberResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedMemberRemovedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedMemberResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        
+                "invite_accepted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "invite_rejected_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "membership_level": {type: "MembershipLevelResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedMemberUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "member": {type: "FeedMemberResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedOwnData'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "own_followings": {type: "FollowResponse", isSingle: false},
+            
+        
+              "own_follows": {type: "FollowResponse", isSingle: false},
+            
+        
+                "own_membership": {type: "FeedMemberResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "created_by": {type: "UserResponse", isSingle: true},
+            
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+              "own_followings": {type: "FollowResponse", isSingle: false},
+            
+        
+              "own_follows": {type: "FollowResponse", isSingle: false},
+            
+        
+        
+        
+                "own_membership": {type: "FeedMemberResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedSuggestionResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "created_by": {type: "UserResponse", isSingle: true},
+            
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+              "own_followings": {type: "FollowResponse", isSingle: false},
+            
+        
+              "own_follows": {type: "FollowResponse", isSingle: false},
+            
+        
+        
+        
+        
+                "own_membership": {type: "FeedMemberResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "feed": {type: "FeedResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedsBookmarkResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedsEnrichedCollectionResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedsFeedResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "created_by": {type: "UserResponse", isSingle: true},
+            
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedsReactionGroupResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "first_reaction_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "last_reaction_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedsReactionResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedsV3ActivityResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+              "comments": {type: "FeedsV3CommentResponse", isSingle: false},
+            
+        
+        
+        
+        
+              "latest_reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+              "mentioned_users": {type: "UserResponse", isSingle: false},
+            
+        
+              "own_bookmarks": {type: "FeedsBookmarkResponse", isSingle: false},
+            
+        
+              "own_reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+              "collections": {type: "FeedsEnrichedCollectionResponse", isSingle: false},
+            
+        
+        
+              "reaction_groups": {type: "FeedsReactionGroupResponse", isSingle: false},
+            
+        
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "edited_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "expires_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+              "friend_reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+                "current_feed": {type: "FeedsFeedResponse", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "parent": {type: "FeedsV3ActivityResponse", isSingle: true},
+            
+        
+                "poll": {type: "PollResponseData", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FeedsV3CommentResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+              "mentioned_users": {type: "UserResponse", isSingle: false},
+            
+        
+              "own_reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "edited_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+              "latest_reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+        
+        
+              "reaction_groups": {type: "FeedsReactionGroupResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FollowBatchResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "created": {type: "FollowResponse", isSingle: false},
+            
+        
+              "follows": {type: "FollowResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FollowCreatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "follow": {type: "FollowResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FollowDeletedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "follow": {type: "FollowResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FollowResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "source_feed": {type: "FeedResponse", isSingle: true},
+            
+        
+                "target_feed": {type: "FeedResponse", isSingle: true},
+            
+        
+                "request_accepted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "request_rejected_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FollowUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "follow": {type: "FollowResponse", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['FullUserResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+              "channel_mutes": {type: "ChannelMute", isSingle: false},
+            
+        
+              "devices": {type: "DeviceResponse", isSingle: false},
+            
+        
+              "mutes": {type: "UserMuteResponse", isSingle: false},
+            
+        
+        
+        
+        
+                "ban_expires": {type: "DatetimeType", isSingle: true},
+            
+        
+                "deactivated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "last_active": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "revoke_tokens_issued_before": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['GetActivityResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['GetAppealResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "item": {type: "AppealItemResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['GetBlockedUsersResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "blocks": {type: "BlockedUserResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['GetCommentRepliesResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+              "comments": {type: "ThreadedCommentResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['GetCommentResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['GetCommentsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+              "comments": {type: "ThreadedCommentResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['GetConfigResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "config": {type: "ConfigResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['GetFollowSuggestionsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "suggestions": {type: "FeedSuggestionResponse", isSingle: false},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['GetOrCreateFeedResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+              "activities": {type: "ActivityResponse", isSingle: false},
+            
+        
+              "aggregated_activities": {type: "AggregatedActivityResponse", isSingle: false},
+            
+        
+              "followers": {type: "FollowResponse", isSingle: false},
+            
+        
+              "following": {type: "FollowResponse", isSingle: false},
+            
+        
+              "members": {type: "FeedMemberResponse", isSingle: false},
+            
+        
+              "pinned_activities": {type: "ActivityPinResponse", isSingle: false},
+            
+        
+                "feed": {type: "FeedResponse", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+                "notification_status": {type: "NotificationStatusResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['GetUserGroupResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "user_group": {type: "UserGroupResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['HealthCheckEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "me": {type: "OwnUserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ListBlockListResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "blocklists": {type: "BlockListResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ListDevicesResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "devices": {type: "DeviceResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ListUserGroupsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "user_groups": {type: "UserGroupResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['MembershipLevelResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['MessageResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+              "latest_reactions": {type: "ReactionResponse", isSingle: false},
+            
+        
+              "mentioned_users": {type: "UserResponse", isSingle: false},
+            
+        
+              "own_reactions": {type: "ReactionResponse", isSingle: false},
+            
+        
+        
+        
+        
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "message_text_updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "pin_expires": {type: "DatetimeType", isSingle: true},
+            
+        
+                "pinned_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+              "thread_participants": {type: "UserResponse", isSingle: false},
+            
+        
+                "draft": {type: "DraftResponse", isSingle: true},
+            
+        
+        
+        
+                "member": {type: "ChannelMemberResponse", isSingle: true},
+            
+        
+        
+                "pinned_by": {type: "UserResponse", isSingle: true},
+            
+        
+                "poll": {type: "PollResponseData", isSingle: true},
+            
+        
+                "quoted_message": {type: "MessageResponse", isSingle: true},
+            
+        
+              "reaction_groups": {type: "ReactionGroupResponse", isSingle: false},
+            
+        
+                "reminder": {type: "ReminderResponseData", isSingle: true},
+            
+        
+                "shared_location": {type: "SharedLocationResponseData", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ModerationCustomActionEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "review_queue_item": {type: "ReviewQueueItemResponse", isSingle: true},
+            
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "message": {type: "MessageResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ModerationFlagResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "review_queue_item": {type: "ReviewQueueItemResponse", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ModerationFlaggedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ModerationMarkReviewedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "item": {type: "ReviewQueueItemResponse", isSingle: true},
+            
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "message": {type: "MessageResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['MuteResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "mutes": {type: "UserMuteResponse", isSingle: false},
+            
+        
+        
+                "own_user": {type: "OwnUserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['NotificationFeedUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+              "aggregated_activities": {type: "AggregatedActivityResponse", isSingle: false},
+            
+        
+                "notification_status": {type: "NotificationStatusResponse", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['NotificationStatusResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+                "last_read_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "last_seen_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['OwnBatchResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "data": {type: "FeedOwnData", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['OwnUserResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+              "channel_mutes": {type: "ChannelMute", isSingle: false},
+            
+        
+              "devices": {type: "DeviceResponse", isSingle: false},
+            
+        
+              "mutes": {type: "UserMuteResponse", isSingle: false},
+            
+        
+        
+        
+        
+                "deactivated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "last_active": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "revoke_tokens_issued_before": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "push_preferences": {type: "PushPreferencesResponse", isSingle: true},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PinActivityResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PollClosedFeedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "poll": {type: "PollResponseData", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PollDeletedFeedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "poll": {type: "PollResponseData", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PollResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "poll": {type: "PollResponseData", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PollResponseData'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+              "latest_answers": {type: "PollVoteResponseData", isSingle: false},
+            
+        
+        
+              "own_votes": {type: "PollVoteResponseData", isSingle: false},
+            
+        
+        
+        
+        
+        
+        
+                "created_by": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PollUpdatedFeedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "poll": {type: "PollResponseData", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PollVoteCastedFeedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "poll": {type: "PollResponseData", isSingle: true},
+            
+        
+                "poll_vote": {type: "PollVoteResponseData", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PollVoteChangedFeedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "poll": {type: "PollResponseData", isSingle: true},
+            
+        
+                "poll_vote": {type: "PollVoteResponseData", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PollVoteRemovedFeedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "poll": {type: "PollResponseData", isSingle: true},
+            
+        
+                "poll_vote": {type: "PollVoteResponseData", isSingle: true},
+            
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PollVoteResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "poll": {type: "PollResponseData", isSingle: true},
+            
+        
+                "vote": {type: "PollVoteResponseData", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PollVoteResponseData'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PollVotesResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "votes": {type: "PollVoteResponseData", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['PushPreferencesResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+                "disabled_until": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryActivitiesResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "activities": {type: "ActivityResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryActivityReactionsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryAppealsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "items": {type: "AppealItemResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryBookmarkFoldersResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "bookmark_folders": {type: "BookmarkFolderResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryBookmarksResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "bookmarks": {type: "BookmarkResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryCollectionsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "collections": {type: "CollectionResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryCommentReactionsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryCommentsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "comments": {type: "CommentResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryFeedMembersResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "members": {type: "FeedMemberResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryFeedsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "feeds": {type: "FeedResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryFollowsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "follows": {type: "FollowResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryModerationConfigsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "configs": {type: "ConfigResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryPinnedActivitiesResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "pinned_activities": {type: "ActivityPinResponse", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryPollsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "polls": {type: "PollResponseData", isSingle: false},
+            
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryReviewQueueResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "items": {type: "ReviewQueueItemResponse", isSingle: false},
+            
+        
+        
+        
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['QueryUsersResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "users": {type: "FullUserResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['Reaction'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ReactionGroupResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "first_reaction_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "last_reaction_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+              "latest_reactions_by": {type: "ReactionGroupUserResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ReactionGroupUserResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ReactionResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ReadCollectionsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "collections": {type: "CollectionResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['RejectFeedMemberInviteResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "member": {type: "FeedMemberResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['RejectFollowResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "follow": {type: "FollowResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ReminderResponseData'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "remind_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "channel": {type: "ChannelResponse", isSingle: true},
+            
+        
+                "message": {type: "MessageResponse", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['RemoveUserGroupMembersResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "user_group": {type: "UserGroupResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['RestoreActivityResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['RestoreCommentResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ReviewQueueItemResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+              "actions": {type: "ActionLogResponse", isSingle: false},
+            
+        
+              "bans": {type: "BanInfoResponse", isSingle: false},
+            
+        
+              "flags": {type: "ModerationFlagResponse", isSingle: false},
+            
+        
+        
+                "completed_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "escalated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "reviewed_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "appeal": {type: "AppealItemResponse", isSingle: true},
+            
+        
+                "assigned_to": {type: "UserResponse", isSingle: true},
+            
+        
+                "call": {type: "CallResponse", isSingle: true},
+            
+        
+                "entity_creator": {type: "EntityCreatorResponse", isSingle: true},
+            
+        
+        
+        
+                "feeds_v2_reaction": {type: "Reaction", isSingle: true},
+            
+        
+                "feeds_v3_activity": {type: "FeedsV3ActivityResponse", isSingle: true},
+            
+        
+                "feeds_v3_comment": {type: "FeedsV3CommentResponse", isSingle: true},
+            
+        
+                "message": {type: "ChatMessageResponse", isSingle: true},
+            
+        
+        
+                "reaction": {type: "Reaction", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['SearchUserGroupsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "user_groups": {type: "UserGroupResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['SharedLocationResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "end_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "channel": {type: "ChannelResponse", isSingle: true},
+            
+        
+                "message": {type: "MessageResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['SharedLocationResponseData'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "end_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "channel": {type: "ChannelResponse", isSingle: true},
+            
+        
+                "message": {type: "MessageResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['SharedLocationsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "active_live_locations": {type: "SharedLocationResponseData", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['SingleFollowResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "follow": {type: "FollowResponse", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['StoriesFeedUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+              "activities": {type: "ActivityResponse", isSingle: false},
+            
+        
+              "aggregated_activities": {type: "AggregatedActivityResponse", isSingle: false},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['SubmitActionResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "appeal_item": {type: "AppealItemResponse", isSingle: true},
+            
+        
+                "item": {type: "ReviewQueueItemResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['ThreadedCommentResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+              "mentioned_users": {type: "UserResponse", isSingle: false},
+            
+        
+              "own_reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "edited_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+              "latest_reactions": {type: "FeedsReactionResponse", isSingle: false},
+            
+        
+              "replies": {type: "ThreadedCommentResponse", isSingle: false},
+            
+        
+        
+        
+        
+              "reaction_groups": {type: "FeedsReactionGroupResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UnfollowBatchResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "follows": {type: "FollowResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UnfollowResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "follow": {type: "FollowResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UnpinActivityResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateActivityPartialResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateActivityResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "activity": {type: "ActivityResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateBlockListResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "blocklist": {type: "BlockListResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateBookmarkFolderResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "bookmark_folder": {type: "BookmarkFolderResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateBookmarkResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "bookmark": {type: "BookmarkResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateCollectionsResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "collections": {type: "CollectionResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateCommentBookmarkResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "bookmark": {type: "BookmarkResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateCommentPartialResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateCommentResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "comment": {type: "CommentResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateFeedMembersResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "added": {type: "FeedMemberResponse", isSingle: false},
+            
+        
+        
+              "updated": {type: "FeedMemberResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateFeedResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "feed": {type: "FeedResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateFollowResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "follow": {type: "FollowResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateUserGroupResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "user_group": {type: "UserGroupResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpdateUsersResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+              "users": {type: "FullUserResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpsertActivitiesResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+              "activities": {type: "ActivityResponse", isSingle: false},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpsertConfigResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "config": {type: "ConfigResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UpsertPushPreferencesResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+        
+              "user_preferences": {type: "PushPreferencesResponse", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UserBannedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "expiration": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UserDeactivatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UserGroupMember'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UserGroupResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+              "members": {type: "UserGroupMember", isSingle: false},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UserMuteResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "expires": {type: "DatetimeType", isSingle: true},
+            
+        
+                "target": {type: "UserResponse", isSingle: true},
+            
+        
+                "user": {type: "UserResponse", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UserReactivatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UserResponse'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+        
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "updated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+                "deactivated_at": {type: "DatetimeType", isSingle: true},
+            
+        
+                "deleted_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "last_active": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+                "revoke_tokens_issued_before": {type: "DatetimeType", isSingle: true},
+            
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UserUnbannedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+        }
+    return decode(typeMappings, input)
+  }
+
+  decoders['UserUpdatedEvent'] = (input?: {[key: string]: any}) => {
+    const typeMappings: TypeMapping = {
+                "created_at": {type: "DatetimeType", isSingle: true},
+            
+        
+        
+        
+        
+                "received_at": {type: "DatetimeType", isSingle: true},
+            
+        }
+    return decode(typeMappings, input)
+  }

--- a/packages/feeds-client/src/gen/model-decoders/event-decoder-mapping.ts
+++ b/packages/feeds-client/src/gen/model-decoders/event-decoder-mapping.ts
@@ -1,170 +1,117 @@
-import type { WSEvent } from '../models';
+import { WSEvent } from '../models';
 import { decoders } from '../model-decoders/decoders';
 
-const eventDecoderMapping: Record<
-  WSEvent['type'],
-  (data: Record<string, any>) => WSEvent
-> = {
-  'app.updated': (data: Record<string, any>) => decoders.AppUpdatedEvent(data),
-
-  'feeds.activity.added': (data: Record<string, any>) =>
-    decoders.ActivityAddedEvent(data),
-
-  'feeds.activity.deleted': (data: Record<string, any>) =>
-    decoders.ActivityDeletedEvent(data),
-
-  'feeds.activity.feedback': (data: Record<string, any>) =>
-    decoders.ActivityFeedbackEvent(data),
-
-  'feeds.activity.marked': (data: Record<string, any>) =>
-    decoders.ActivityMarkEvent(data),
-
-  'feeds.activity.pinned': (data: Record<string, any>) =>
-    decoders.ActivityPinnedEvent(data),
-
-  'feeds.activity.reaction.added': (data: Record<string, any>) =>
-    decoders.ActivityReactionAddedEvent(data),
-
-  'feeds.activity.reaction.deleted': (data: Record<string, any>) =>
-    decoders.ActivityReactionDeletedEvent(data),
-
-  'feeds.activity.reaction.updated': (data: Record<string, any>) =>
-    decoders.ActivityReactionUpdatedEvent(data),
-
-  'feeds.activity.removed_from_feed': (data: Record<string, any>) =>
-    decoders.ActivityRemovedFromFeedEvent(data),
-
-  'feeds.activity.restored': (data: Record<string, any>) =>
-    decoders.ActivityRestoredEvent(data),
-
-  'feeds.activity.unpinned': (data: Record<string, any>) =>
-    decoders.ActivityUnpinnedEvent(data),
-
-  'feeds.activity.updated': (data: Record<string, any>) =>
-    decoders.ActivityUpdatedEvent(data),
-
-  'feeds.bookmark.added': (data: Record<string, any>) =>
-    decoders.BookmarkAddedEvent(data),
-
-  'feeds.bookmark.deleted': (data: Record<string, any>) =>
-    decoders.BookmarkDeletedEvent(data),
-
-  'feeds.bookmark.updated': (data: Record<string, any>) =>
-    decoders.BookmarkUpdatedEvent(data),
-
-  'feeds.bookmark_folder.deleted': (data: Record<string, any>) =>
-    decoders.BookmarkFolderDeletedEvent(data),
-
-  'feeds.bookmark_folder.updated': (data: Record<string, any>) =>
-    decoders.BookmarkFolderUpdatedEvent(data),
-
-  'feeds.comment.added': (data: Record<string, any>) =>
-    decoders.CommentAddedEvent(data),
-
-  'feeds.comment.deleted': (data: Record<string, any>) =>
-    decoders.CommentDeletedEvent(data),
-
-  'feeds.comment.reaction.added': (data: Record<string, any>) =>
-    decoders.CommentReactionAddedEvent(data),
-
-  'feeds.comment.reaction.deleted': (data: Record<string, any>) =>
-    decoders.CommentReactionDeletedEvent(data),
-
-  'feeds.comment.reaction.updated': (data: Record<string, any>) =>
-    decoders.CommentReactionUpdatedEvent(data),
-
-  'feeds.comment.restored': (data: Record<string, any>) =>
-    decoders.CommentRestoredEvent(data),
-
-  'feeds.comment.updated': (data: Record<string, any>) =>
-    decoders.CommentUpdatedEvent(data),
-
-  'feeds.feed.created': (data: Record<string, any>) =>
-    decoders.FeedCreatedEvent(data),
-
-  'feeds.feed.deleted': (data: Record<string, any>) =>
-    decoders.FeedDeletedEvent(data),
-
-  'feeds.feed.updated': (data: Record<string, any>) =>
-    decoders.FeedUpdatedEvent(data),
-
-  'feeds.feed_group.changed': (data: Record<string, any>) =>
-    decoders.FeedGroupChangedEvent(data),
-
-  'feeds.feed_group.deleted': (data: Record<string, any>) =>
-    decoders.FeedGroupDeletedEvent(data),
-
-  'feeds.feed_group.restored': (data: Record<string, any>) =>
-    decoders.FeedGroupRestoredEvent(data),
-
-  'feeds.feed_member.added': (data: Record<string, any>) =>
-    decoders.FeedMemberAddedEvent(data),
-
-  'feeds.feed_member.removed': (data: Record<string, any>) =>
-    decoders.FeedMemberRemovedEvent(data),
-
-  'feeds.feed_member.updated': (data: Record<string, any>) =>
-    decoders.FeedMemberUpdatedEvent(data),
-
-  'feeds.follow.created': (data: Record<string, any>) =>
-    decoders.FollowCreatedEvent(data),
-
-  'feeds.follow.deleted': (data: Record<string, any>) =>
-    decoders.FollowDeletedEvent(data),
-
-  'feeds.follow.updated': (data: Record<string, any>) =>
-    decoders.FollowUpdatedEvent(data),
-
-  'feeds.notification_feed.updated': (data: Record<string, any>) =>
-    decoders.NotificationFeedUpdatedEvent(data),
-
-  'feeds.poll.closed': (data: Record<string, any>) =>
-    decoders.PollClosedFeedEvent(data),
-
-  'feeds.poll.deleted': (data: Record<string, any>) =>
-    decoders.PollDeletedFeedEvent(data),
-
-  'feeds.poll.updated': (data: Record<string, any>) =>
-    decoders.PollUpdatedFeedEvent(data),
-
-  'feeds.poll.vote_casted': (data: Record<string, any>) =>
-    decoders.PollVoteCastedFeedEvent(data),
-
-  'feeds.poll.vote_changed': (data: Record<string, any>) =>
-    decoders.PollVoteChangedFeedEvent(data),
-
-  'feeds.poll.vote_removed': (data: Record<string, any>) =>
-    decoders.PollVoteRemovedFeedEvent(data),
-
-  'feeds.stories_feed.updated': (data: Record<string, any>) =>
-    decoders.StoriesFeedUpdatedEvent(data),
-
-  'health.check': (data: Record<string, any>) =>
-    decoders.HealthCheckEvent(data),
-
-  'moderation.custom_action': (data: Record<string, any>) =>
-    decoders.ModerationCustomActionEvent(data),
-
-  'moderation.flagged': (data: Record<string, any>) =>
-    decoders.ModerationFlaggedEvent(data),
-
-  'moderation.mark_reviewed': (data: Record<string, any>) =>
-    decoders.ModerationMarkReviewedEvent(data),
-
-  'user.banned': (data: Record<string, any>) => decoders.UserBannedEvent(data),
-
-  'user.deactivated': (data: Record<string, any>) =>
-    decoders.UserDeactivatedEvent(data),
-
-  'user.reactivated': (data: Record<string, any>) =>
-    decoders.UserReactivatedEvent(data),
-
-  'user.unbanned': (data: Record<string, any>) =>
-    decoders.UserUnbannedEvent(data),
-
-  'user.updated': (data: Record<string, any>) =>
-    decoders.UserUpdatedEvent(data),
-};
+const eventDecoderMapping: {[key in WSEvent['type']]: (data: Record<string, any>) => WSEvent  } = {
+    
+        'app.updated': (data: Record<string, any>) => decoders.AppUpdatedEvent(data),
+    
+        'feeds.activity.added': (data: Record<string, any>) => decoders.ActivityAddedEvent(data),
+    
+        'feeds.activity.deleted': (data: Record<string, any>) => decoders.ActivityDeletedEvent(data),
+    
+        'feeds.activity.feedback': (data: Record<string, any>) => decoders.ActivityFeedbackEvent(data),
+    
+        'feeds.activity.marked': (data: Record<string, any>) => decoders.ActivityMarkEvent(data),
+    
+        'feeds.activity.pinned': (data: Record<string, any>) => decoders.ActivityPinnedEvent(data),
+    
+        'feeds.activity.reaction.added': (data: Record<string, any>) => decoders.ActivityReactionAddedEvent(data),
+    
+        'feeds.activity.reaction.deleted': (data: Record<string, any>) => decoders.ActivityReactionDeletedEvent(data),
+    
+        'feeds.activity.reaction.updated': (data: Record<string, any>) => decoders.ActivityReactionUpdatedEvent(data),
+    
+        'feeds.activity.removed_from_feed': (data: Record<string, any>) => decoders.ActivityRemovedFromFeedEvent(data),
+    
+        'feeds.activity.restored': (data: Record<string, any>) => decoders.ActivityRestoredEvent(data),
+    
+        'feeds.activity.unpinned': (data: Record<string, any>) => decoders.ActivityUnpinnedEvent(data),
+    
+        'feeds.activity.updated': (data: Record<string, any>) => decoders.ActivityUpdatedEvent(data),
+    
+        'feeds.bookmark.added': (data: Record<string, any>) => decoders.BookmarkAddedEvent(data),
+    
+        'feeds.bookmark.deleted': (data: Record<string, any>) => decoders.BookmarkDeletedEvent(data),
+    
+        'feeds.bookmark.updated': (data: Record<string, any>) => decoders.BookmarkUpdatedEvent(data),
+    
+        'feeds.bookmark_folder.deleted': (data: Record<string, any>) => decoders.BookmarkFolderDeletedEvent(data),
+    
+        'feeds.bookmark_folder.updated': (data: Record<string, any>) => decoders.BookmarkFolderUpdatedEvent(data),
+    
+        'feeds.comment.added': (data: Record<string, any>) => decoders.CommentAddedEvent(data),
+    
+        'feeds.comment.deleted': (data: Record<string, any>) => decoders.CommentDeletedEvent(data),
+    
+        'feeds.comment.reaction.added': (data: Record<string, any>) => decoders.CommentReactionAddedEvent(data),
+    
+        'feeds.comment.reaction.deleted': (data: Record<string, any>) => decoders.CommentReactionDeletedEvent(data),
+    
+        'feeds.comment.reaction.updated': (data: Record<string, any>) => decoders.CommentReactionUpdatedEvent(data),
+    
+        'feeds.comment.restored': (data: Record<string, any>) => decoders.CommentRestoredEvent(data),
+    
+        'feeds.comment.updated': (data: Record<string, any>) => decoders.CommentUpdatedEvent(data),
+    
+        'feeds.feed.created': (data: Record<string, any>) => decoders.FeedCreatedEvent(data),
+    
+        'feeds.feed.deleted': (data: Record<string, any>) => decoders.FeedDeletedEvent(data),
+    
+        'feeds.feed.updated': (data: Record<string, any>) => decoders.FeedUpdatedEvent(data),
+    
+        'feeds.feed_group.changed': (data: Record<string, any>) => decoders.FeedGroupChangedEvent(data),
+    
+        'feeds.feed_group.deleted': (data: Record<string, any>) => decoders.FeedGroupDeletedEvent(data),
+    
+        'feeds.feed_group.restored': (data: Record<string, any>) => decoders.FeedGroupRestoredEvent(data),
+    
+        'feeds.feed_member.added': (data: Record<string, any>) => decoders.FeedMemberAddedEvent(data),
+    
+        'feeds.feed_member.removed': (data: Record<string, any>) => decoders.FeedMemberRemovedEvent(data),
+    
+        'feeds.feed_member.updated': (data: Record<string, any>) => decoders.FeedMemberUpdatedEvent(data),
+    
+        'feeds.follow.created': (data: Record<string, any>) => decoders.FollowCreatedEvent(data),
+    
+        'feeds.follow.deleted': (data: Record<string, any>) => decoders.FollowDeletedEvent(data),
+    
+        'feeds.follow.updated': (data: Record<string, any>) => decoders.FollowUpdatedEvent(data),
+    
+        'feeds.notification_feed.updated': (data: Record<string, any>) => decoders.NotificationFeedUpdatedEvent(data),
+    
+        'feeds.poll.closed': (data: Record<string, any>) => decoders.PollClosedFeedEvent(data),
+    
+        'feeds.poll.deleted': (data: Record<string, any>) => decoders.PollDeletedFeedEvent(data),
+    
+        'feeds.poll.updated': (data: Record<string, any>) => decoders.PollUpdatedFeedEvent(data),
+    
+        'feeds.poll.vote_casted': (data: Record<string, any>) => decoders.PollVoteCastedFeedEvent(data),
+    
+        'feeds.poll.vote_changed': (data: Record<string, any>) => decoders.PollVoteChangedFeedEvent(data),
+    
+        'feeds.poll.vote_removed': (data: Record<string, any>) => decoders.PollVoteRemovedFeedEvent(data),
+    
+        'feeds.stories_feed.updated': (data: Record<string, any>) => decoders.StoriesFeedUpdatedEvent(data),
+    
+        'health.check': (data: Record<string, any>) => decoders.HealthCheckEvent(data),
+    
+        'moderation.custom_action': (data: Record<string, any>) => decoders.ModerationCustomActionEvent(data),
+    
+        'moderation.flagged': (data: Record<string, any>) => decoders.ModerationFlaggedEvent(data),
+    
+        'moderation.mark_reviewed': (data: Record<string, any>) => decoders.ModerationMarkReviewedEvent(data),
+    
+        'user.banned': (data: Record<string, any>) => decoders.UserBannedEvent(data),
+    
+        'user.deactivated': (data: Record<string, any>) => decoders.UserDeactivatedEvent(data),
+    
+        'user.reactivated': (data: Record<string, any>) => decoders.UserReactivatedEvent(data),
+    
+        'user.unbanned': (data: Record<string, any>) => decoders.UserUnbannedEvent(data),
+    
+        'user.updated': (data: Record<string, any>) => decoders.UserUpdatedEvent(data),
+    
+}
 
 export const decodeWSEvent = (data: { type: string } & Record<string, any>) => {
   if (Object.hasOwn(eventDecoderMapping, data.type)) {

--- a/packages/feeds-client/src/gen/model-decoders/event-decoder-mapping.ts
+++ b/packages/feeds-client/src/gen/model-decoders/event-decoder-mapping.ts
@@ -1,117 +1,170 @@
-import { WSEvent } from '../models';
+import type { WSEvent } from '../models';
 import { decoders } from '../model-decoders/decoders';
 
-const eventDecoderMapping: {[key in WSEvent['type']]: (data: Record<string, any>) => WSEvent  } = {
-    
-        'app.updated': (data: Record<string, any>) => decoders.AppUpdatedEvent(data),
-    
-        'feeds.activity.added': (data: Record<string, any>) => decoders.ActivityAddedEvent(data),
-    
-        'feeds.activity.deleted': (data: Record<string, any>) => decoders.ActivityDeletedEvent(data),
-    
-        'feeds.activity.feedback': (data: Record<string, any>) => decoders.ActivityFeedbackEvent(data),
-    
-        'feeds.activity.marked': (data: Record<string, any>) => decoders.ActivityMarkEvent(data),
-    
-        'feeds.activity.pinned': (data: Record<string, any>) => decoders.ActivityPinnedEvent(data),
-    
-        'feeds.activity.reaction.added': (data: Record<string, any>) => decoders.ActivityReactionAddedEvent(data),
-    
-        'feeds.activity.reaction.deleted': (data: Record<string, any>) => decoders.ActivityReactionDeletedEvent(data),
-    
-        'feeds.activity.reaction.updated': (data: Record<string, any>) => decoders.ActivityReactionUpdatedEvent(data),
-    
-        'feeds.activity.removed_from_feed': (data: Record<string, any>) => decoders.ActivityRemovedFromFeedEvent(data),
-    
-        'feeds.activity.restored': (data: Record<string, any>) => decoders.ActivityRestoredEvent(data),
-    
-        'feeds.activity.unpinned': (data: Record<string, any>) => decoders.ActivityUnpinnedEvent(data),
-    
-        'feeds.activity.updated': (data: Record<string, any>) => decoders.ActivityUpdatedEvent(data),
-    
-        'feeds.bookmark.added': (data: Record<string, any>) => decoders.BookmarkAddedEvent(data),
-    
-        'feeds.bookmark.deleted': (data: Record<string, any>) => decoders.BookmarkDeletedEvent(data),
-    
-        'feeds.bookmark.updated': (data: Record<string, any>) => decoders.BookmarkUpdatedEvent(data),
-    
-        'feeds.bookmark_folder.deleted': (data: Record<string, any>) => decoders.BookmarkFolderDeletedEvent(data),
-    
-        'feeds.bookmark_folder.updated': (data: Record<string, any>) => decoders.BookmarkFolderUpdatedEvent(data),
-    
-        'feeds.comment.added': (data: Record<string, any>) => decoders.CommentAddedEvent(data),
-    
-        'feeds.comment.deleted': (data: Record<string, any>) => decoders.CommentDeletedEvent(data),
-    
-        'feeds.comment.reaction.added': (data: Record<string, any>) => decoders.CommentReactionAddedEvent(data),
-    
-        'feeds.comment.reaction.deleted': (data: Record<string, any>) => decoders.CommentReactionDeletedEvent(data),
-    
-        'feeds.comment.reaction.updated': (data: Record<string, any>) => decoders.CommentReactionUpdatedEvent(data),
-    
-        'feeds.comment.restored': (data: Record<string, any>) => decoders.CommentRestoredEvent(data),
-    
-        'feeds.comment.updated': (data: Record<string, any>) => decoders.CommentUpdatedEvent(data),
-    
-        'feeds.feed.created': (data: Record<string, any>) => decoders.FeedCreatedEvent(data),
-    
-        'feeds.feed.deleted': (data: Record<string, any>) => decoders.FeedDeletedEvent(data),
-    
-        'feeds.feed.updated': (data: Record<string, any>) => decoders.FeedUpdatedEvent(data),
-    
-        'feeds.feed_group.changed': (data: Record<string, any>) => decoders.FeedGroupChangedEvent(data),
-    
-        'feeds.feed_group.deleted': (data: Record<string, any>) => decoders.FeedGroupDeletedEvent(data),
-    
-        'feeds.feed_group.restored': (data: Record<string, any>) => decoders.FeedGroupRestoredEvent(data),
-    
-        'feeds.feed_member.added': (data: Record<string, any>) => decoders.FeedMemberAddedEvent(data),
-    
-        'feeds.feed_member.removed': (data: Record<string, any>) => decoders.FeedMemberRemovedEvent(data),
-    
-        'feeds.feed_member.updated': (data: Record<string, any>) => decoders.FeedMemberUpdatedEvent(data),
-    
-        'feeds.follow.created': (data: Record<string, any>) => decoders.FollowCreatedEvent(data),
-    
-        'feeds.follow.deleted': (data: Record<string, any>) => decoders.FollowDeletedEvent(data),
-    
-        'feeds.follow.updated': (data: Record<string, any>) => decoders.FollowUpdatedEvent(data),
-    
-        'feeds.notification_feed.updated': (data: Record<string, any>) => decoders.NotificationFeedUpdatedEvent(data),
-    
-        'feeds.poll.closed': (data: Record<string, any>) => decoders.PollClosedFeedEvent(data),
-    
-        'feeds.poll.deleted': (data: Record<string, any>) => decoders.PollDeletedFeedEvent(data),
-    
-        'feeds.poll.updated': (data: Record<string, any>) => decoders.PollUpdatedFeedEvent(data),
-    
-        'feeds.poll.vote_casted': (data: Record<string, any>) => decoders.PollVoteCastedFeedEvent(data),
-    
-        'feeds.poll.vote_changed': (data: Record<string, any>) => decoders.PollVoteChangedFeedEvent(data),
-    
-        'feeds.poll.vote_removed': (data: Record<string, any>) => decoders.PollVoteRemovedFeedEvent(data),
-    
-        'feeds.stories_feed.updated': (data: Record<string, any>) => decoders.StoriesFeedUpdatedEvent(data),
-    
-        'health.check': (data: Record<string, any>) => decoders.HealthCheckEvent(data),
-    
-        'moderation.custom_action': (data: Record<string, any>) => decoders.ModerationCustomActionEvent(data),
-    
-        'moderation.flagged': (data: Record<string, any>) => decoders.ModerationFlaggedEvent(data),
-    
-        'moderation.mark_reviewed': (data: Record<string, any>) => decoders.ModerationMarkReviewedEvent(data),
-    
-        'user.banned': (data: Record<string, any>) => decoders.UserBannedEvent(data),
-    
-        'user.deactivated': (data: Record<string, any>) => decoders.UserDeactivatedEvent(data),
-    
-        'user.reactivated': (data: Record<string, any>) => decoders.UserReactivatedEvent(data),
-    
-        'user.unbanned': (data: Record<string, any>) => decoders.UserUnbannedEvent(data),
-    
-        'user.updated': (data: Record<string, any>) => decoders.UserUpdatedEvent(data),
-    
-}
+const eventDecoderMapping: Record<
+  WSEvent['type'],
+  (data: Record<string, any>) => WSEvent
+> = {
+  'app.updated': (data: Record<string, any>) => decoders.AppUpdatedEvent(data),
+
+  'feeds.activity.added': (data: Record<string, any>) =>
+    decoders.ActivityAddedEvent(data),
+
+  'feeds.activity.deleted': (data: Record<string, any>) =>
+    decoders.ActivityDeletedEvent(data),
+
+  'feeds.activity.feedback': (data: Record<string, any>) =>
+    decoders.ActivityFeedbackEvent(data),
+
+  'feeds.activity.marked': (data: Record<string, any>) =>
+    decoders.ActivityMarkEvent(data),
+
+  'feeds.activity.pinned': (data: Record<string, any>) =>
+    decoders.ActivityPinnedEvent(data),
+
+  'feeds.activity.reaction.added': (data: Record<string, any>) =>
+    decoders.ActivityReactionAddedEvent(data),
+
+  'feeds.activity.reaction.deleted': (data: Record<string, any>) =>
+    decoders.ActivityReactionDeletedEvent(data),
+
+  'feeds.activity.reaction.updated': (data: Record<string, any>) =>
+    decoders.ActivityReactionUpdatedEvent(data),
+
+  'feeds.activity.removed_from_feed': (data: Record<string, any>) =>
+    decoders.ActivityRemovedFromFeedEvent(data),
+
+  'feeds.activity.restored': (data: Record<string, any>) =>
+    decoders.ActivityRestoredEvent(data),
+
+  'feeds.activity.unpinned': (data: Record<string, any>) =>
+    decoders.ActivityUnpinnedEvent(data),
+
+  'feeds.activity.updated': (data: Record<string, any>) =>
+    decoders.ActivityUpdatedEvent(data),
+
+  'feeds.bookmark.added': (data: Record<string, any>) =>
+    decoders.BookmarkAddedEvent(data),
+
+  'feeds.bookmark.deleted': (data: Record<string, any>) =>
+    decoders.BookmarkDeletedEvent(data),
+
+  'feeds.bookmark.updated': (data: Record<string, any>) =>
+    decoders.BookmarkUpdatedEvent(data),
+
+  'feeds.bookmark_folder.deleted': (data: Record<string, any>) =>
+    decoders.BookmarkFolderDeletedEvent(data),
+
+  'feeds.bookmark_folder.updated': (data: Record<string, any>) =>
+    decoders.BookmarkFolderUpdatedEvent(data),
+
+  'feeds.comment.added': (data: Record<string, any>) =>
+    decoders.CommentAddedEvent(data),
+
+  'feeds.comment.deleted': (data: Record<string, any>) =>
+    decoders.CommentDeletedEvent(data),
+
+  'feeds.comment.reaction.added': (data: Record<string, any>) =>
+    decoders.CommentReactionAddedEvent(data),
+
+  'feeds.comment.reaction.deleted': (data: Record<string, any>) =>
+    decoders.CommentReactionDeletedEvent(data),
+
+  'feeds.comment.reaction.updated': (data: Record<string, any>) =>
+    decoders.CommentReactionUpdatedEvent(data),
+
+  'feeds.comment.restored': (data: Record<string, any>) =>
+    decoders.CommentRestoredEvent(data),
+
+  'feeds.comment.updated': (data: Record<string, any>) =>
+    decoders.CommentUpdatedEvent(data),
+
+  'feeds.feed.created': (data: Record<string, any>) =>
+    decoders.FeedCreatedEvent(data),
+
+  'feeds.feed.deleted': (data: Record<string, any>) =>
+    decoders.FeedDeletedEvent(data),
+
+  'feeds.feed.updated': (data: Record<string, any>) =>
+    decoders.FeedUpdatedEvent(data),
+
+  'feeds.feed_group.changed': (data: Record<string, any>) =>
+    decoders.FeedGroupChangedEvent(data),
+
+  'feeds.feed_group.deleted': (data: Record<string, any>) =>
+    decoders.FeedGroupDeletedEvent(data),
+
+  'feeds.feed_group.restored': (data: Record<string, any>) =>
+    decoders.FeedGroupRestoredEvent(data),
+
+  'feeds.feed_member.added': (data: Record<string, any>) =>
+    decoders.FeedMemberAddedEvent(data),
+
+  'feeds.feed_member.removed': (data: Record<string, any>) =>
+    decoders.FeedMemberRemovedEvent(data),
+
+  'feeds.feed_member.updated': (data: Record<string, any>) =>
+    decoders.FeedMemberUpdatedEvent(data),
+
+  'feeds.follow.created': (data: Record<string, any>) =>
+    decoders.FollowCreatedEvent(data),
+
+  'feeds.follow.deleted': (data: Record<string, any>) =>
+    decoders.FollowDeletedEvent(data),
+
+  'feeds.follow.updated': (data: Record<string, any>) =>
+    decoders.FollowUpdatedEvent(data),
+
+  'feeds.notification_feed.updated': (data: Record<string, any>) =>
+    decoders.NotificationFeedUpdatedEvent(data),
+
+  'feeds.poll.closed': (data: Record<string, any>) =>
+    decoders.PollClosedFeedEvent(data),
+
+  'feeds.poll.deleted': (data: Record<string, any>) =>
+    decoders.PollDeletedFeedEvent(data),
+
+  'feeds.poll.updated': (data: Record<string, any>) =>
+    decoders.PollUpdatedFeedEvent(data),
+
+  'feeds.poll.vote_casted': (data: Record<string, any>) =>
+    decoders.PollVoteCastedFeedEvent(data),
+
+  'feeds.poll.vote_changed': (data: Record<string, any>) =>
+    decoders.PollVoteChangedFeedEvent(data),
+
+  'feeds.poll.vote_removed': (data: Record<string, any>) =>
+    decoders.PollVoteRemovedFeedEvent(data),
+
+  'feeds.stories_feed.updated': (data: Record<string, any>) =>
+    decoders.StoriesFeedUpdatedEvent(data),
+
+  'health.check': (data: Record<string, any>) =>
+    decoders.HealthCheckEvent(data),
+
+  'moderation.custom_action': (data: Record<string, any>) =>
+    decoders.ModerationCustomActionEvent(data),
+
+  'moderation.flagged': (data: Record<string, any>) =>
+    decoders.ModerationFlaggedEvent(data),
+
+  'moderation.mark_reviewed': (data: Record<string, any>) =>
+    decoders.ModerationMarkReviewedEvent(data),
+
+  'user.banned': (data: Record<string, any>) => decoders.UserBannedEvent(data),
+
+  'user.deactivated': (data: Record<string, any>) =>
+    decoders.UserDeactivatedEvent(data),
+
+  'user.reactivated': (data: Record<string, any>) =>
+    decoders.UserReactivatedEvent(data),
+
+  'user.unbanned': (data: Record<string, any>) =>
+    decoders.UserUnbannedEvent(data),
+
+  'user.updated': (data: Record<string, any>) =>
+    decoders.UserUpdatedEvent(data),
+};
 
 export const decodeWSEvent = (data: { type: string } & Record<string, any>) => {
   if (Object.hasOwn(eventDecoderMapping, data.type)) {

--- a/packages/feeds-client/src/gen/models/index.ts
+++ b/packages/feeds-client/src/gen/models/index.ts
@@ -1,10116 +1,17909 @@
-export interface AIImageConfig {
-  enabled: boolean;
 
-  ocr_rules: OCRRule[];
+    export interface AIImageConfig {
+    enabled: boolean;
+    
 
-  rules: AWSRekognitionRule[];
+        
+    ocr_rules: Array<OCRRule>;
+    
 
-  async?: boolean;
-}
+        
+    rules: Array<AWSRekognitionRule>;
+    
 
-export interface AIImageLabelDefinition {
-  description: string;
+        
+    async?: boolean;
+    
 
-  group: string;
+        }
+    
 
-  key: string;
 
-  label: string;
-}
 
-export interface AITextConfig {
-  enabled: boolean;
 
-  profile: string;
+    export interface AIImageLabelDefinition {
+    description: string;
+    
 
-  rules: BodyguardRule[];
+        
+    group: string;
+    
 
-  severity_rules: BodyguardSeverityRule[];
+        
+    key: string;
+    
 
-  async?: boolean;
-}
+        
+    label: string;
+    
 
-export interface AIVideoConfig {
-  enabled: boolean;
+        }
+    
 
-  rules: AWSRekognitionRule[];
 
-  async?: boolean;
-}
 
-export interface APIError {
-  /**
-   * API error code
-   */
-  code: number;
 
-  /**
-   * Request duration
-   */
-  duration: string;
+    export interface AITextConfig {
+    enabled: boolean;
+    
 
-  /**
-   * Message describing an error
-   */
-  message: string;
+        
+    profile: string;
+    
 
-  /**
-   * URL with additional information
-   */
-  more_info: string;
+        
+    rules: Array<BodyguardRule>;
+    
 
-  /**
-   * Response HTTP status code
-   */
-  status_code: number;
+        
+    severity_rules: Array<BodyguardSeverityRule>;
+    
 
-  /**
-   * Additional error-specific information
-   */
-  details: number[];
+        
+    async?: boolean;
+    
 
-  /**
-   * Flag that indicates if the error is unrecoverable, requests that return unrecoverable errors should not be retried, this error only applies to the request that caused it
-   */
-  unrecoverable?: boolean;
+        }
+    
 
-  /**
-   * Additional error info
-   */
-  exception_fields?: Record<string, string>;
-}
 
-export interface AWSRekognitionRule {
-  action:
-    | 'flag'
-    | 'shadow'
-    | 'remove'
-    | 'bounce'
-    | 'bounce_flag'
-    | 'bounce_remove';
 
-  label: string;
 
-  min_confidence: number;
+    export interface AIVideoConfig {
+    enabled: boolean;
+    
 
-  subclassifications?: Record<string, any>;
-}
+        
+    rules: Array<AWSRekognitionRule>;
+    
 
-export interface AcceptFeedMemberInviteRequest {}
+        
+    async?: boolean;
+    
 
-export interface AcceptFeedMemberInviteResponse {
-  duration: string;
+        }
+    
 
-  member: FeedMemberResponse;
-}
 
-export interface AcceptFollowRequest {
-  /**
-   * Fully qualified ID of the source feed
-   */
-  source: string;
 
-  /**
-   * Fully qualified ID of the target feed
-   */
-  target: string;
 
-  /**
-   * Optional role for the follower in the follow relationship
-   */
-  follower_role?: string;
-}
+    export interface APIError {
+    /**
+     * API error code
+     */
+    code: number;
+    
 
-export interface AcceptFollowResponse {
-  duration: string;
+        
+    /**
+     * Request duration
+     */
+    duration: string;
+    
 
-  follow: FollowResponse;
-}
+        
+    /**
+     * Message describing an error
+     */
+    message: string;
+    
 
-export interface Action {
-  name: string;
+        
+    /**
+     * URL with additional information
+     */
+    more_info: string;
+    
 
-  text: string;
+        
+    /**
+     * Response HTTP status code
+     */
+    status_code: number;
+    
 
-  type: string;
+        
+    /**
+     * Additional error-specific information
+     */
+    details: Array<number>;
+    
 
-  style?: string;
+        
+    /**
+     * Flag that indicates if the error is unrecoverable, requests that return unrecoverable errors should not be retried, this error only applies to the request that caused it
+     */
+    unrecoverable?: boolean;
+    
 
-  value?: string;
-}
+        
+    /**
+     * Additional error info
+     */
+    exception_fields?: Record<string, string>;
+    
 
-export interface ActionLogResponse {
-  /**
-   * Timestamp when the action was taken
-   */
-  created_at: Date;
+        }
+    
 
-  /**
-   * Unique identifier of the action log
-   */
-  id: string;
 
-  /**
-   * Reason for the moderation action
-   */
-  reason: string;
 
-  /**
-   * ID of the user who was the target of the action
-   */
-  target_user_id: string;
 
-  /**
-   * Type of moderation action
-   */
-  type: string;
+    export interface AWSRekognitionRule {
+    
+        action:| "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
 
-  /**
-   * ID of the user who performed the action
-   */
-  user_id: string;
+        
+    label: string;
+    
 
-  ai_providers: string[];
+        
+    min_confidence: number;
+    
 
-  /**
-   * Additional metadata about the action
-   */
-  custom: Record<string, any>;
+        
+    subclassifications?: Record<string, any>;
+    
 
-  review_queue_item?: ReviewQueueItemResponse;
+        }
+    
 
-  target_user?: UserResponse;
 
-  user?: UserResponse;
-}
 
-export interface ActionSequence {
-  action: string;
 
-  blur: boolean;
+    export interface AcceptFeedMemberInviteRequest {}
+    
 
-  cooldown_period: number;
 
-  threshold: number;
 
-  time_window: number;
 
-  warning: boolean;
+    export interface AcceptFeedMemberInviteResponse {
+    duration: string;
+    
 
-  warning_text: string;
-}
+        
+    member: FeedMemberResponse;
+    
 
-export interface ActivityAddedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        }
+    
 
-  fid: string;
 
-  activity: ActivityResponse;
 
-  custom: Record<string, any>;
 
-  /**
-   * The type of event: "feeds.activity.added" in this case
-   */
-  type: string;
+    export interface AcceptFollowRequest {
+    /**
+     * Fully qualified ID of the source feed
+     */
+    source: string;
+    
 
-  feed_visibility?: string;
+        
+    /**
+     * Fully qualified ID of the target feed
+     */
+    target: string;
+    
 
-  received_at?: Date;
+        
+    /**
+     * Optional role for the follower in the follow relationship
+     */
+    follower_role?: string;
+    
 
-  user?: UserResponseCommonFields;
-}
+        }
+    
 
-export interface ActivityDeletedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  fid: string;
 
-  activity: ActivityResponse;
 
-  custom: Record<string, any>;
+    export interface AcceptFollowResponse {
+    duration: string;
+    
 
-  /**
-   * The type of event: "feeds.activity.deleted" in this case
-   */
-  type: string;
+        
+    follow: FollowResponse;
+    
 
-  feed_visibility?: string;
+        }
+    
 
-  received_at?: Date;
 
-  user?: UserResponseCommonFields;
-}
 
-export interface ActivityFeedbackEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  activity_feedback: ActivityFeedbackEventPayload;
+    export interface Action {
+    name: string;
+    
 
-  custom: Record<string, any>;
+        
+    text: string;
+    
 
-  /**
-   * The type of event: "feeds.activity.feedback" in this case
-   */
-  type: string;
+        
+    type: string;
+    
 
-  received_at?: Date;
+        
+    style?: string;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    value?: string;
+    
 
-export interface ActivityFeedbackEventPayload {
-  /**
-   * The type of feedback action. One of: hide, show_more, show_less
-   */
+        }
+    
 
-  action: 'hide' | 'show_more' | 'show_less';
 
-  /**
-   * The activity that received feedback
-   */
-  activity_id: string;
 
-  /**
-   * When the feedback was created
-   */
-  created_at: Date;
 
-  /**
-   * When the feedback was last updated
-   */
-  updated_at: Date;
+    export interface ActionLogResponse {
+    /**
+     * Timestamp when the action was taken
+     */
+    created_at: Date;
+    
 
-  /**
-   * The feedback value (true/false)
-   */
-  value: string;
+        
+    /**
+     * Unique identifier of the action log
+     */
+    id: string;
+    
 
-  user: UserResponse;
-}
+        
+    /**
+     * Reason for the moderation action
+     */
+    reason: string;
+    
 
-export interface ActivityFeedbackRequest {
-  /**
-   * Whether to hide this activity
-   */
-  hide?: boolean;
+        
+    /**
+     * Classification of who triggered the action (e.g. user, moderator, automod, api_integration)
+     */
+    reporter_type: string;
+    
 
-  /**
-   * Whether to show less content like this
-   */
-  show_less?: boolean;
+        
+    /**
+     * ID of the user who was the target of the action
+     */
+    target_user_id: string;
+    
 
-  /**
-   * Whether to show more content like this
-   */
-  show_more?: boolean;
-}
+        
+    /**
+     * Type of moderation action
+     */
+    type: string;
+    
 
-export interface ActivityFeedbackResponse {
-  /**
-   * The ID of the activity that received feedback
-   */
-  activity_id: string;
+        
+    /**
+     * ID of the user who performed the action
+     */
+    user_id: string;
+    
 
-  duration: string;
-}
+        
+    ai_providers: Array<string>;
+    
 
-export interface ActivityMarkEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    /**
+     * Additional metadata about the action
+     */
+    custom: Record<string, any>;
+    
 
-  fid: string;
+        
+    review_queue_item?: ReviewQueueItemResponse;
+    
 
-  custom: Record<string, any>;
+        
+    target_user?: UserResponse;
+    
 
-  /**
-   * The type of event: "feeds.activity.marked" in this case
-   */
-  type: string;
+        
+    user?: UserResponse;
+    
 
-  feed_visibility?: string;
+        }
+    
 
-  /**
-   * Whether all activities were marked as read
-   */
-  mark_all_read?: boolean;
 
-  /**
-   * Whether all activities were marked as seen
-   */
-  mark_all_seen?: boolean;
 
-  received_at?: Date;
 
-  /**
-   * The IDs of activities marked as read
-   */
-  mark_read?: string[];
+    export interface ActionSequence {
+    action: string;
+    
 
-  /**
-   * The IDs of activities marked as seen
-   */
-  mark_seen?: string[];
+        
+    blur: boolean;
+    
 
-  /**
-   * The IDs of activities marked as watched
-   */
-  mark_watched?: string[];
+        
+    cooldown_period: number;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    threshold: number;
+    
 
-export interface ActivityPinResponse {
-  /**
-   * When the pin was created
-   */
-  created_at: Date;
+        
+    time_window: number;
+    
 
-  /**
-   * ID of the feed where activity is pinned
-   */
-  feed: string;
+        
+    warning: boolean;
+    
 
-  /**
-   * When the pin was last updated
-   */
-  updated_at: Date;
+        
+    warning_text: string;
+    
 
-  activity: ActivityResponse;
+        }
+    
 
-  user: UserResponse;
-}
 
-export interface ActivityPinnedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  /**
-   * The ID of the feed
-   */
-  fid: string;
 
-  custom: Record<string, any>;
+    export interface ActivityAddedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  pinned_activity: PinActivityResponse;
+        
+    fid: string;
+    
 
-  /**
-   * The type of event: "feeds.activity.pinned" in this case
-   */
-  type: string;
+        
+    activity: ActivityResponse;
+    
 
-  feed_visibility?: string;
+        
+    custom: Record<string, any>;
+    
 
-  received_at?: Date;
+        
+    /**
+     * The type of event: "feeds.activity.added" in this case
+     */
+    type: string;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    feed_visibility?: string;
+    
 
-export interface ActivityProcessorConfig {
-  type: string;
+        
+    received_at?: Date;
+    
 
-  openai_key?: string;
+        
+    user?: UserResponseCommonFields;
+    
 
-  config?: Record<string, any>;
-}
+        }
+    
 
-export interface ActivityReactionAddedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  fid: string;
 
-  activity: ActivityResponse;
 
-  custom: Record<string, any>;
+    export interface ActivityDeletedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  reaction: FeedsReactionResponse;
+        
+    fid: string;
+    
 
-  /**
-   * The type of event: "feeds.activity.reaction.added" in this case
-   */
-  type: string;
+        
+    activity: ActivityResponse;
+    
 
-  feed_visibility?: string;
+        
+    custom: Record<string, any>;
+    
 
-  received_at?: Date;
+        
+    /**
+     * The type of event: "feeds.activity.deleted" in this case
+     */
+    type: string;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    feed_visibility?: string;
+    
 
-export interface ActivityReactionDeletedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    received_at?: Date;
+    
 
-  fid: string;
+        
+    user?: UserResponseCommonFields;
+    
 
-  activity: ActivityResponse;
+        }
+    
 
-  custom: Record<string, any>;
 
-  reaction: FeedsReactionResponse;
 
-  /**
-   * The type of the reaction that was removed
-   */
-  type: string;
 
-  feed_visibility?: string;
+    export interface ActivityFeedbackEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  received_at?: Date;
+        
+    activity_feedback: ActivityFeedbackEventPayload;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    custom: Record<string, any>;
+    
 
-export interface ActivityReactionUpdatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    /**
+     * The type of event: "feeds.activity.feedback" in this case
+     */
+    type: string;
+    
 
-  fid: string;
+        
+    received_at?: Date;
+    
 
-  activity: ActivityResponse;
+        
+    user?: UserResponseCommonFields;
+    
 
-  custom: Record<string, any>;
+        }
+    
 
-  reaction: FeedsReactionResponse;
 
-  /**
-   * The type of event: "feeds.activity.reaction.updated" in this case
-   */
-  type: string;
 
-  feed_visibility?: string;
 
-  received_at?: Date;
+    export interface ActivityFeedbackEventPayload {
+    /**
+     * The type of feedback action. One of: hide, show_more, show_less
+     */
+    
+        action:| "hide" | "show_more" | "show_less" ;
 
-  user?: UserResponseCommonFields;
-}
+        
+    /**
+     * The activity that received feedback
+     */
+    activity_id: string;
+    
 
-export interface ActivityRemovedFromFeedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    /**
+     * When the feedback was created
+     */
+    created_at: Date;
+    
 
-  fid: string;
+        
+    /**
+     * When the feedback was last updated
+     */
+    updated_at: Date;
+    
 
-  activity: ActivityResponse;
+        
+    /**
+     * The feedback value (true/false)
+     */
+    value: string;
+    
 
-  custom: Record<string, any>;
+        
+    user: UserResponse;
+    
 
-  /**
-   * The type of event: "feeds.activity.removed_from_feed" in this case
-   */
-  type: string;
+        }
+    
 
-  feed_visibility?: string;
 
-  received_at?: Date;
 
-  user?: UserResponseCommonFields;
-}
 
-export interface ActivityRequest {
-  /**
-   * Type of activity
-   */
-  type: string;
+    export interface ActivityFeedbackRequest {
+    /**
+     * Whether to hide this activity
+     */
+    hide?: boolean;
+    
 
-  /**
-   * List of feeds to add the activity to with a default max limit of 25 feeds
-   */
-  feeds: string[];
+        
+    /**
+     * Whether to show less content like this
+     */
+    show_less?: boolean;
+    
 
-  /**
-   * @deprecated
-   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-   */
-  copy_custom_to_notification?: boolean;
+        
+    /**
+     * Whether to show more content like this
+     */
+    show_more?: boolean;
+    
 
-  /**
-   * Whether to create notification activities for mentioned users
-   */
-  create_notification_activity?: boolean;
+        }
+    
 
-  /**
-   * Expiration time for the activity
-   */
-  expires_at?: string;
 
-  /**
-   * Optional ID for the activity
-   */
-  id?: string;
 
-  /**
-   * ID of parent activity for replies/comments
-   */
-  parent_id?: string;
 
-  /**
-   * ID of a poll to attach to activity
-   */
-  poll_id?: string;
+    export interface ActivityFeedbackResponse {
+    /**
+     * The ID of the activity that received feedback
+     */
+    activity_id: string;
+    
 
-  /**
-   * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
-   */
+        
+    duration: string;
+    
 
-  restrict_replies?: 'everyone' | 'people_i_follow' | 'nobody';
+        }
+    
 
-  /**
-   * Whether to skip URL enrichment for the activity
-   */
-  skip_enrich_url?: boolean;
 
-  /**
-   * Whether to skip push notifications
-   */
-  skip_push?: boolean;
 
-  /**
-   * Text content of the activity
-   */
-  text?: string;
 
-  /**
-   * Visibility setting for the activity. One of: public, private, tag
-   */
+    export interface ActivityFilterConfig {
+    exclude_owner_activities: boolean;
+    
 
-  visibility?: 'public' | 'private' | 'tag';
+        }
+    
 
-  /**
-   * If visibility is 'tag', this is the tag name and is required
-   */
-  visibility_tag?: string;
 
-  /**
-   * List of attachments for the activity
-   */
-  attachments?: Attachment[];
 
-  /**
-   * Collections that this activity references
-   */
-  collection_refs?: string[];
 
-  /**
-   * Tags for filtering activities
-   */
-  filter_tags?: string[];
+    export interface ActivityMarkEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  /**
-   * Tags for indicating user interests
-   */
-  interest_tags?: string[];
+        
+    fid: string;
+    
 
-  /**
-   * List of users mentioned in the activity
-   */
-  mentioned_user_ids?: string[];
+        
+    custom: Record<string, any>;
+    
 
-  /**
-   * Custom data for the activity
-   */
-  custom?: Record<string, any>;
+        
+    /**
+     * The type of event: "feeds.activity.marked" in this case
+     */
+    type: string;
+    
 
-  location?: Location;
+        
+    feed_visibility?: string;
+    
 
-  /**
-   * Additional data for search indexing
-   */
-  search_data?: Record<string, any>;
-}
+        
+    /**
+     * Whether all activities were marked as read
+     */
+    mark_all_read?: boolean;
+    
 
-export interface ActivityResponse {
-  /**
-   * Number of bookmarks on the activity
-   */
-  bookmark_count: number;
+        
+    /**
+     * Whether all activities were marked as seen
+     */
+    mark_all_seen?: boolean;
+    
 
-  /**
-   * Number of comments on the activity
-   */
-  comment_count: number;
+        
+    received_at?: Date;
+    
 
-  /**
-   * When the activity was created
-   */
-  created_at: Date;
+        
+    /**
+     * The IDs of activities marked as read
+     */
+    mark_read?: Array<string>;
+    
 
-  /**
-   * If this activity is hidden by this user (using activity feedback)
-   */
-  hidden: boolean;
+        
+    /**
+     * The IDs of activities marked as seen
+     */
+    mark_seen?: Array<string>;
+    
 
-  /**
-   * Unique identifier for the activity
-   */
-  id: string;
+        
+    /**
+     * The IDs of activities marked as watched
+     */
+    mark_watched?: Array<string>;
+    
 
-  /**
-   * Popularity score of the activity
-   */
-  popularity: number;
+        
+    user?: UserResponseCommonFields;
+    
 
-  /**
-   * If this activity is obfuscated for this user. For premium content where you want to show a preview
-   */
-  preview: boolean;
+        }
+    
 
-  /**
-   * Number of reactions to the activity
-   */
-  reaction_count: number;
 
-  /**
-   * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
-   */
 
-  restrict_replies: 'everyone' | 'people_i_follow' | 'nobody';
 
-  /**
-   * Ranking score for this activity
-   */
-  score: number;
+    export interface ActivityPinResponse {
+    /**
+     * When the pin was created
+     */
+    created_at: Date;
+    
 
-  /**
-   * Number of times the activity was shared
-   */
-  share_count: number;
+        
+    /**
+     * ID of the feed where activity is pinned
+     */
+    feed: string;
+    
 
-  /**
-   * Type of activity
-   */
-  type: string;
+        
+    /**
+     * When the pin was last updated
+     */
+    updated_at: Date;
+    
 
-  /**
-   * When the activity was last updated
-   */
-  updated_at: Date;
+        
+    activity: ActivityResponse;
+    
 
-  /**
-   * Visibility setting for the activity. One of: public, private, tag
-   */
+        
+    user: UserResponse;
+    
 
-  visibility: 'public' | 'private' | 'tag';
+        }
+    
 
-  /**
-   * Media attachments for the activity
-   */
-  attachments: Attachment[];
 
-  /**
-   * Latest 5 comments of this activity (comment replies excluded)
-   */
-  comments: CommentResponse[];
 
-  /**
-   * List of feed IDs containing this activity
-   */
-  feeds: string[];
 
-  /**
-   * Tags for filtering
-   */
-  filter_tags: string[];
+    export interface ActivityPinnedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  /**
-   * Tags for user interests
-   */
-  interest_tags: string[];
+        
+    /**
+     * The ID of the feed
+     */
+    fid: string;
+    
 
-  /**
-   * Recent reactions to the activity
-   */
-  latest_reactions: FeedsReactionResponse[];
+        
+    custom: Record<string, any>;
+    
 
-  /**
-   * Users mentioned in the activity
-   */
-  mentioned_users: UserResponse[];
+        
+    pinned_activity: PinActivityResponse;
+    
 
-  /**
-   * Current user's bookmarks for this activity
-   */
-  own_bookmarks: BookmarkResponse[];
+        
+    /**
+     * The type of event: "feeds.activity.pinned" in this case
+     */
+    type: string;
+    
 
-  /**
-   * Current user's reactions to this activity
-   */
-  own_reactions: FeedsReactionResponse[];
+        
+    feed_visibility?: string;
+    
 
-  /**
-   * Enriched collection data referenced by this activity
-   */
-  collections: Record<string, EnrichedCollectionResponse>;
+        
+    received_at?: Date;
+    
 
-  /**
-   * Custom data for the activity
-   */
-  custom: Record<string, any>;
+        
+    user?: UserResponseCommonFields;
+    
 
-  /**
-   * Grouped reactions by type
-   */
-  reaction_groups: Record<string, FeedsReactionGroupResponse>;
+        }
+    
 
-  /**
-   * Data for search indexing
-   */
-  search_data: Record<string, any>;
 
-  user: UserResponse;
 
-  /**
-   * When the activity was deleted
-   */
-  deleted_at?: Date;
 
-  /**
-   * When the activity was last edited
-   */
-  edited_at?: Date;
+    export interface ActivityProcessorConfig {
+    type: string;
+    
 
-  /**
-   * When the activity will expire
-   */
-  expires_at?: Date;
+        
+    openai_key?: string;
+    
 
-  /**
-   * Total count of reactions from friends on this activity
-   */
-  friend_reaction_count?: number;
+        
+    config?: Record<string, any>;
+    
 
-  /**
-   * Whether this activity has been read. Only set for feed groups with notification config (track_seen/track_read enabled).
-   */
-  is_read?: boolean;
+        }
+    
 
-  /**
-   * Whether this activity has been seen. Only set for feed groups with notification config (track_seen/track_read enabled).
-   */
-  is_seen?: boolean;
 
-  is_watched?: boolean;
 
-  moderation_action?: string;
 
-  /**
-   * Which activity selector provided this activity (e.g., 'following', 'popular', 'interest'). Only set when using multiple activity selectors with ranking.
-   */
-  selector_source?: string;
+    export interface ActivityReactionAddedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  /**
-   * Text content of the activity
-   */
-  text?: string;
+        
+    fid: string;
+    
 
-  /**
-   * If visibility is 'tag', this is the tag name
-   */
-  visibility_tag?: string;
+        
+    activity: ActivityResponse;
+    
 
-  /**
-   * Reactions from users the current user follows or has mutual follows with
-   */
-  friend_reactions?: FeedsReactionResponse[];
+        
+    custom: Record<string, any>;
+    
 
-  current_feed?: FeedResponse;
+        
+    reaction: FeedsReactionResponse;
+    
 
-  location?: Location;
+        
+    /**
+     * The type of event: "feeds.activity.reaction.added" in this case
+     */
+    type: string;
+    
 
-  metrics?: Record<string, number>;
+        
+    feed_visibility?: string;
+    
 
-  moderation?: ModerationV2Response;
+        
+    received_at?: Date;
+    
 
-  notification_context?: NotificationContext;
+        
+    user?: UserResponseCommonFields;
+    
 
-  parent?: ActivityResponse;
+        }
+    
 
-  poll?: PollResponseData;
 
-  /**
-   * Variable values used at ranking time. Only included when include_score_vars is enabled in enrichment options.
-   */
-  score_vars?: Record<string, any>;
-}
 
-export interface ActivityRestoredEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  fid: string;
+    export interface ActivityReactionDeletedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  activity: ActivityResponse;
+        
+    fid: string;
+    
 
-  custom: Record<string, any>;
+        
+    activity: ActivityResponse;
+    
 
-  /**
-   * The type of the event
-   */
-  type: string;
+        
+    custom: Record<string, any>;
+    
 
-  feed_visibility?: string;
+        
+    reaction: FeedsReactionResponse;
+    
 
-  received_at?: Date;
+        
+    /**
+     * The type of the reaction that was removed
+     */
+    type: string;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    feed_visibility?: string;
+    
 
-export interface ActivitySelectorConfig {
-  cutoff_time: Date;
+        
+    received_at?: Date;
+    
 
-  cutoff_window?: string;
+        
+    user?: UserResponseCommonFields;
+    
 
-  min_popularity?: number;
+        }
+    
 
-  type?: string;
 
-  sort?: SortParam[];
 
-  filter?: Record<string, any>;
 
-  params?: Record<string, any>;
-}
+    export interface ActivityReactionUpdatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-export interface ActivityUnpinnedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    fid: string;
+    
 
-  /**
-   * The ID of the feed
-   */
-  fid: string;
+        
+    activity: ActivityResponse;
+    
 
-  custom: Record<string, any>;
+        
+    custom: Record<string, any>;
+    
 
-  pinned_activity: PinActivityResponse;
+        
+    reaction: FeedsReactionResponse;
+    
 
-  /**
-   * The type of event: "feeds.activity.unpinned" in this case
-   */
-  type: string;
+        
+    /**
+     * The type of event: "feeds.activity.reaction.updated" in this case
+     */
+    type: string;
+    
 
-  feed_visibility?: string;
+        
+    feed_visibility?: string;
+    
 
-  received_at?: Date;
+        
+    received_at?: Date;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    user?: UserResponseCommonFields;
+    
 
-export interface ActivityUpdatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        }
+    
 
-  fid: string;
 
-  activity: ActivityResponse;
 
-  custom: Record<string, any>;
 
-  /**
-   * The type of the event
-   */
-  type: string;
+    export interface ActivityRemovedFromFeedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  feed_visibility?: string;
+        
+    fid: string;
+    
 
-  received_at?: Date;
+        
+    activity: ActivityResponse;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    custom: Record<string, any>;
+    
 
-export interface AddActivityRequest {
-  /**
-   * Type of activity
-   */
-  type: string;
+        
+    /**
+     * The type of event: "feeds.activity.removed_from_feed" in this case
+     */
+    type: string;
+    
 
-  /**
-   * List of feeds to add the activity to with a default max limit of 25 feeds
-   */
-  feeds: string[];
+        
+    feed_visibility?: string;
+    
 
-  /**
-   * @deprecated
-   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-   */
-  copy_custom_to_notification?: boolean;
+        
+    received_at?: Date;
+    
 
-  /**
-   * Whether to create notification activities for mentioned users
-   */
-  create_notification_activity?: boolean;
+        
+    user?: UserResponseCommonFields;
+    
 
-  enrich_own_fields?: boolean;
+        }
+    
 
-  /**
-   * Expiration time for the activity
-   */
-  expires_at?: string;
 
-  /**
-   * Optional ID for the activity
-   */
-  id?: string;
 
-  /**
-   * ID of parent activity for replies/comments
-   */
-  parent_id?: string;
 
-  /**
-   * ID of a poll to attach to activity
-   */
-  poll_id?: string;
+    export interface ActivityRequest {
+    /**
+     * Type of activity
+     */
+    type: string;
+    
 
-  /**
-   * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
-   */
+        
+    /**
+     * List of feeds to add the activity to with a default max limit of 25 feeds
+     */
+    feeds: Array<string>;
+    
 
-  restrict_replies?: 'everyone' | 'people_i_follow' | 'nobody';
+        
+    /**
+     * @deprecated
+     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+     */
+    copy_custom_to_notification?: boolean;
+    
 
-  /**
-   * Whether to skip URL enrichment for the activity
-   */
-  skip_enrich_url?: boolean;
+        
+    /**
+     * Whether to create notification activities for mentioned users
+     */
+    create_notification_activity?: boolean;
+    
 
-  /**
-   * Whether to skip push notifications
-   */
-  skip_push?: boolean;
+        
+    /**
+     * Expiration time for the activity
+     */
+    expires_at?: string;
+    
 
-  /**
-   * Text content of the activity
-   */
-  text?: string;
+        
+    /**
+     * Optional ID for the activity
+     */
+    id?: string;
+    
 
-  /**
-   * Visibility setting for the activity. One of: public, private, tag
-   */
+        
+    /**
+     * ID of parent activity for replies/comments
+     */
+    parent_id?: string;
+    
 
-  visibility?: 'public' | 'private' | 'tag';
+        
+    /**
+     * ID of a poll to attach to activity
+     */
+    poll_id?: string;
+    
 
-  /**
-   * If visibility is 'tag', this is the tag name and is required
-   */
-  visibility_tag?: string;
+        
+    /**
+     * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
+     */
+    
+        restrict_replies?:| "everyone" | "people_i_follow" | "nobody" ;
 
-  /**
-   * List of attachments for the activity
-   */
-  attachments?: Attachment[];
+        
+    /**
+     * Whether to skip URL enrichment for the activity
+     */
+    skip_enrich_url?: boolean;
+    
 
-  /**
-   * Collections that this activity references
-   */
-  collection_refs?: string[];
+        
+    /**
+     * Whether to skip push notifications
+     */
+    skip_push?: boolean;
+    
 
-  /**
-   * Tags for filtering activities
-   */
-  filter_tags?: string[];
+        
+    /**
+     * Text content of the activity
+     */
+    text?: string;
+    
 
-  /**
-   * Tags for indicating user interests
-   */
-  interest_tags?: string[];
+        
+    /**
+     * Visibility setting for the activity. One of: public, private, tag
+     */
+    
+        visibility?:| "public" | "private" | "tag" ;
 
-  /**
-   * List of users mentioned in the activity
-   */
-  mentioned_user_ids?: string[];
+        
+    /**
+     * If visibility is 'tag', this is the tag name and is required
+     */
+    visibility_tag?: string;
+    
 
-  /**
-   * Custom data for the activity
-   */
-  custom?: Record<string, any>;
+        
+    /**
+     * List of attachments for the activity
+     */
+    attachments?: Array<Attachment>;
+    
 
-  location?: Location;
+        
+    /**
+     * Collections that this activity references
+     */
+    collection_refs?: Array<string>;
+    
 
-  /**
-   * Additional data for search indexing
-   */
-  search_data?: Record<string, any>;
-}
+        
+    /**
+     * Tags for filtering activities
+     */
+    filter_tags?: Array<string>;
+    
+
+        
+    /**
+     * Tags for indicating user interests
+     */
+    interest_tags?: Array<string>;
+    
+
+        
+    /**
+     * List of users mentioned in the activity
+     */
+    mentioned_user_ids?: Array<string>;
+    
+
+        
+    /**
+     * Custom data for the activity
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    location?: Location;
+    
+
+        
+    /**
+     * Additional data for search indexing
+     */
+    search_data?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface ActivityResponse {
+    /**
+     * Number of bookmarks on the activity
+     */
+    bookmark_count: number;
+    
+
+        
+    /**
+     * Number of comments on the activity
+     */
+    comment_count: number;
+    
+
+        
+    /**
+     * When the activity was created
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * If this activity is hidden by this user (using activity feedback)
+     */
+    hidden: boolean;
+    
+
+        
+    /**
+     * Unique identifier for the activity
+     */
+    id: string;
+    
+
+        
+    /**
+     * Popularity score of the activity
+     */
+    popularity: number;
+    
+
+        
+    /**
+     * If this activity is obfuscated for this user. For premium content where you want to show a preview
+     */
+    preview: boolean;
+    
+
+        
+    /**
+     * Number of reactions to the activity
+     */
+    reaction_count: number;
+    
+
+        
+    /**
+     * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
+     */
+    
+        restrict_replies:| "everyone" | "people_i_follow" | "nobody" ;
+
+        
+    /**
+     * Ranking score for this activity
+     */
+    score: number;
+    
+
+        
+    /**
+     * Number of times the activity was shared
+     */
+    share_count: number;
+    
+
+        
+    /**
+     * Type of activity
+     */
+    type: string;
+    
+
+        
+    /**
+     * When the activity was last updated
+     */
+    updated_at: Date;
+    
+
+        
+    /**
+     * Visibility setting for the activity. One of: public, private, tag
+     */
+    
+        visibility:| "public" | "private" | "tag" ;
+
+        
+    /**
+     * Media attachments for the activity
+     */
+    attachments: Array<Attachment>;
+    
+
+        
+    /**
+     * Latest 5 comments of this activity (comment replies excluded)
+     */
+    comments: Array<CommentResponse>;
+    
+
+        
+    /**
+     * List of feed IDs containing this activity
+     */
+    feeds: Array<string>;
+    
+
+        
+    /**
+     * Tags for filtering
+     */
+    filter_tags: Array<string>;
+    
+
+        
+    /**
+     * Tags for user interests
+     */
+    interest_tags: Array<string>;
+    
+
+        
+    /**
+     * Recent reactions to the activity
+     */
+    latest_reactions: Array<FeedsReactionResponse>;
+    
+
+        
+    /**
+     * Users mentioned in the activity
+     */
+    mentioned_users: Array<UserResponse>;
+    
+
+        
+    /**
+     * Current user's bookmarks for this activity
+     */
+    own_bookmarks: Array<BookmarkResponse>;
+    
+
+        
+    /**
+     * Current user's reactions to this activity
+     */
+    own_reactions: Array<FeedsReactionResponse>;
+    
+
+        
+    /**
+     * Enriched collection data referenced by this activity
+     */
+    collections: Record<string, EnrichedCollectionResponse>;
+    
+
+        
+    /**
+     * Custom data for the activity
+     */
+    custom: Record<string, any>;
+    
+
+        
+    /**
+     * Grouped reactions by type
+     */
+    reaction_groups: Record<string, FeedsReactionGroupResponse>;
+    
+
+        
+    /**
+     * Data for search indexing
+     */
+    search_data: Record<string, any>;
+    
+
+        
+    user: UserResponse;
+    
+
+        
+    /**
+     * When the activity was deleted
+     */
+    deleted_at?: Date;
+    
+
+        
+    /**
+     * When the activity was last edited
+     */
+    edited_at?: Date;
+    
+
+        
+    /**
+     * When the activity will expire
+     */
+    expires_at?: Date;
+    
+
+        
+    /**
+     * Total count of reactions from friends on this activity
+     */
+    friend_reaction_count?: number;
+    
+
+        
+    /**
+     * Whether this activity has been read. Only set for feed groups with notification config (track_seen/track_read enabled).
+     */
+    is_read?: boolean;
+    
+
+        
+    /**
+     * Whether this activity has been seen. Only set for feed groups with notification config (track_seen/track_read enabled).
+     */
+    is_seen?: boolean;
+    
+
+        
+    is_watched?: boolean;
+    
+
+        
+    moderation_action?: string;
+    
+
+        
+    /**
+     * Which activity selector provided this activity (e.g., 'following', 'popular', 'interest'). Only set when using multiple activity selectors with ranking.
+     */
+    selector_source?: string;
+    
+
+        
+    /**
+     * Text content of the activity
+     */
+    text?: string;
+    
+
+        
+    /**
+     * If visibility is 'tag', this is the tag name
+     */
+    visibility_tag?: string;
+    
+
+        
+    /**
+     * Reactions from users the current user follows or has mutual follows with
+     */
+    friend_reactions?: Array<FeedsReactionResponse>;
+    
+
+        
+    current_feed?: FeedResponse;
+    
+
+        
+    location?: Location;
+    
+
+        
+    metrics?: Record<string, number>;
+    
+
+        
+    moderation?: ModerationV2Response;
+    
+
+        
+    notification_context?: NotificationContext;
+    
+
+        
+    parent?: ActivityResponse;
+    
+
+        
+    poll?: PollResponseData;
+    
+
+        
+    /**
+     * Variable values used at ranking time. Only included when include_score_vars is enabled in enrichment options.
+     */
+    score_vars?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface ActivityRestoredEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    fid: string;
+    
+
+        
+    activity: ActivityResponse;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    /**
+     * The type of the event
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    user?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface ActivitySelectorConfig {
+    cutoff_time: Date;
+    
+
+        
+    cutoff_window?: string;
+    
+
+        
+    min_popularity?: number;
+    
+
+        
+    type?: string;
+    
+
+        
+    sort?: Array<SortParam>;
+    
+
+        
+    filter?: Record<string, any>;
+    
+
+        
+    params?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface ActivityUnpinnedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * The ID of the feed
+     */
+    fid: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    pinned_activity: PinActivityResponse;
+    
+
+        
+    /**
+     * The type of event: "feeds.activity.unpinned" in this case
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    user?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface ActivityUpdatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    fid: string;
+    
+
+        
+    activity: ActivityResponse;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    /**
+     * The type of the event
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    user?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface AddActivityRequest {
+    /**
+     * Type of activity
+     */
+    type: string;
+    
+
+        
+    /**
+     * List of feeds to add the activity to with a default max limit of 25 feeds
+     */
+    feeds: Array<string>;
+    
+
+        
+    /**
+     * @deprecated
+     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+     */
+    copy_custom_to_notification?: boolean;
+    
+
+        
+    /**
+     * Whether to create notification activities for mentioned users
+     */
+    create_notification_activity?: boolean;
+    
+
+        
+    enrich_own_fields?: boolean;
+    
+
+        
+    /**
+     * Expiration time for the activity
+     */
+    expires_at?: string;
+    
+
+        
+    /**
+     * Optional ID for the activity
+     */
+    id?: string;
+    
+
+        
+    /**
+     * ID of parent activity for replies/comments
+     */
+    parent_id?: string;
+    
+
+        
+    /**
+     * ID of a poll to attach to activity
+     */
+    poll_id?: string;
+    
+
+        
+    /**
+     * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
+     */
+    
+        restrict_replies?:| "everyone" | "people_i_follow" | "nobody" ;
+
+        
+    /**
+     * Whether to skip URL enrichment for the activity
+     */
+    skip_enrich_url?: boolean;
+    
+
+        
+    /**
+     * Whether to skip push notifications
+     */
+    skip_push?: boolean;
+    
+
+        
+    /**
+     * Text content of the activity
+     */
+    text?: string;
+    
+
+        
+    /**
+     * Visibility setting for the activity. One of: public, private, tag
+     */
+    
+        visibility?:| "public" | "private" | "tag" ;
+
+        
+    /**
+     * If visibility is 'tag', this is the tag name and is required
+     */
+    visibility_tag?: string;
+    
+
+        
+    /**
+     * List of attachments for the activity
+     */
+    attachments?: Array<Attachment>;
+    
+
+        
+    /**
+     * Collections that this activity references
+     */
+    collection_refs?: Array<string>;
+    
+
+        
+    /**
+     * Tags for filtering activities
+     */
+    filter_tags?: Array<string>;
+    
+
+        
+    /**
+     * Tags for indicating user interests
+     */
+    interest_tags?: Array<string>;
+    
+
+        
+    /**
+     * List of users mentioned in the activity
+     */
+    mentioned_user_ids?: Array<string>;
+    
+
+        
+    /**
+     * Custom data for the activity
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    location?: Location;
+    
+
+        
+    /**
+     * Additional data for search indexing
+     */
+    search_data?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface AddActivityResponse {
+    duration: string;
+    
+
+        
+    activity: ActivityResponse;
+    
+
+        
+    /**
+     * Number of mention notification activities created for mentioned users
+     */
+    mention_notifications_created?: number;
+    
+
+        }
+    
+
+
+
+
+    export interface AddBookmarkRequest {
+    /**
+     * ID of the folder to add the bookmark to
+     */
+    folder_id?: string;
+    
+
+        
+    /**
+     * Custom data for the bookmark
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    new_folder?: AddFolderRequest;
+    
+
+        }
+    
+
+
+
+
+    export interface AddBookmarkResponse {
+    duration: string;
+    
+
+        
+    bookmark: BookmarkResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface AddCommentBookmarkRequest {
+    /**
+     * ID of the folder to add the bookmark to
+     */
+    folder_id?: string;
+    
+
+        
+    /**
+     * Custom data for the bookmark
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    new_folder?: AddFolderRequest;
+    
+
+        }
+    
+
+
+
+
+    export interface AddCommentBookmarkResponse {
+    duration: string;
+    
+
+        
+    bookmark: BookmarkResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface AddCommentReactionRequest {
+    /**
+     * The type of reaction, eg upvote, like, ...
+     */
+    type: string;
+    
+
+        
+    /**
+     * @deprecated
+     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+     */
+    copy_custom_to_notification?: boolean;
+    
+
+        
+    /**
+     * Whether to create a notification activity for this reaction
+     */
+    create_notification_activity?: boolean;
+    
+
+        
+    /**
+     * Whether to enforce unique reactions per user (remove other reaction types from the user when adding this one)
+     */
+    enforce_unique?: boolean;
+    
+
+        
+    skip_push?: boolean;
+    
+
+        
+    /**
+     * Optional custom data to add to the reaction
+     */
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface AddCommentReactionResponse {
+    /**
+     * Duration of the request
+     */
+    duration: string;
+    
+
+        
+    comment: CommentResponse;
+    
+
+        
+    reaction: FeedsReactionResponse;
+    
+
+        
+    /**
+     * Whether a notification activity was successfully created
+     */
+    notification_created?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface AddCommentRequest {
+    /**
+     * Text content of the comment
+     */
+    comment?: string;
+    
+
+        
+    /**
+     * @deprecated
+     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+     */
+    copy_custom_to_notification?: boolean;
+    
+
+        
+    /**
+     * Whether to create a notification activity for this comment
+     */
+    create_notification_activity?: boolean;
+    
+
+        
+    /**
+     * Optional custom ID for the comment (max 255 characters). If not provided, a UUID will be generated.
+     */
+    id?: string;
+    
+
+        
+    /**
+     * ID of the object to comment on. Required for root comments
+     */
+    object_id?: string;
+    
+
+        
+    /**
+     * Type of the object to comment on. Required for root comments
+     */
+    object_type?: string;
+    
+
+        
+    /**
+     * ID of parent comment for replies. When provided, object_id and object_type are automatically inherited from the parent comment.
+     */
+    parent_id?: string;
+    
+
+        
+    /**
+     * Whether to skip URL enrichment for this comment
+     */
+    skip_enrich_url?: boolean;
+    
+
+        
+    skip_push?: boolean;
+    
+
+        
+    /**
+     * Media attachments for the reply
+     */
+    attachments?: Array<Attachment>;
+    
+
+        
+    /**
+     * List of users mentioned in the reply
+     */
+    mentioned_user_ids?: Array<string>;
+    
+
+        
+    /**
+     * Custom data for the comment
+     */
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface AddCommentResponse {
+    duration: string;
+    
+
+        
+    comment: CommentResponse;
+    
+
+        
+    /**
+     * Number of mention notification activities created for mentioned users
+     */
+    mention_notifications_created?: number;
+    
+
+        
+    /**
+     * Whether a notification activity was successfully created
+     */
+    notification_created?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface AddCommentsBatchRequest {
+    /**
+     * List of comments to add
+     */
+    comments: Array<AddCommentRequest>;
+    
+
+        }
+    
+
+
+
+
+    export interface AddCommentsBatchResponse {
+    duration: string;
+    
+
+        
+    /**
+     * List of comments added
+     */
+    comments: Array<CommentResponse>;
+    
+
+        }
+    
+
+
+
+
+    export interface AddFolderRequest {
+    /**
+     * Name of the folder
+     */
+    name: string;
+    
+
+        
+    /**
+     * Custom data for the folder
+     */
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface AddReactionRequest {
+    /**
+     * Type of reaction
+     */
+    type: string;
+    
+
+        
+    /**
+     * @deprecated
+     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+     */
+    copy_custom_to_notification?: boolean;
+    
+
+        
+    /**
+     * Whether to create a notification activity for this reaction
+     */
+    create_notification_activity?: boolean;
+    
+
+        
+    /**
+     * Whether to enforce unique reactions per user (remove other reaction types from the user when adding this one)
+     */
+    enforce_unique?: boolean;
+    
+
+        
+    skip_push?: boolean;
+    
+
+        
+    /**
+     * Custom data for the reaction
+     */
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface AddReactionResponse {
+    duration: string;
+    
+
+        
+    activity: ActivityResponse;
+    
+
+        
+    reaction: FeedsReactionResponse;
+    
+
+        
+    /**
+     * Whether a notification activity was successfully created
+     */
+    notification_created?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface AddUserGroupMembersRequest {
+    /**
+     * List of user IDs to add as members
+     */
+    member_ids: Array<string>;
+    
+
+        
+    /**
+     * Whether to add the members as group admins. Defaults to false
+     */
+    as_admin?: boolean;
+    
+
+        
+    team_id?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface AddUserGroupMembersResponse {
+    duration: string;
+    
+
+        
+    user_group?: UserGroupResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface AggregatedActivityResponse {
+    /**
+     * Number of activities in this aggregation
+     */
+    activity_count: number;
+    
+
+        
+    /**
+     * When the aggregation was created
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * Grouping identifier
+     */
+    group: string;
+    
+
+        
+    /**
+     * Ranking score for this aggregation
+     */
+    score: number;
+    
+
+        
+    /**
+     * When the aggregation was last updated
+     */
+    updated_at: Date;
+    
+
+        
+    /**
+     * Number of unique users in this aggregation
+     */
+    user_count: number;
+    
+
+        
+    /**
+     * Whether this activity group has been truncated due to exceeding the group size limit
+     */
+    user_count_truncated: boolean;
+    
+
+        
+    /**
+     * List of activities in this aggregation
+     */
+    activities: Array<ActivityResponse>;
+    
+
+        
+    /**
+     * Whether this aggregated group has been read. Only set for feed groups with notification config (track_seen/track_read enabled).
+     */
+    is_read?: boolean;
+    
+
+        
+    /**
+     * Whether this aggregated group has been seen. Only set for feed groups with notification config (track_seen/track_read enabled).
+     */
+    is_seen?: boolean;
+    
+
+        
+    is_watched?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface AggregationConfig {
+    activities_sort?: string;
+    
+
+        
+    format?: string;
+    
+
+        
+    group_size?: number;
+    
+
+        
+    score_strategy?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface AppEventResponse {
+    /**
+     * boolean
+     */
+    auto_translation_enabled: boolean;
+    
+
+        
+    /**
+     * string
+     */
+    name: string;
+    
+
+        
+    /**
+     * boolean
+     */
+    async_url_enrich_enabled?: boolean;
+    
+
+        
+    file_upload_config?: FileUploadConfig;
+    
+
+        
+    image_upload_config?: FileUploadConfig;
+    
+
+        }
+    
+
+
+
+
+    export interface AppResponseFields {
+    async_url_enrich_enabled: boolean;
+    
+
+        
+    auto_translation_enabled: boolean;
+    
+
+        
+    id: number;
+    
+
+        
+    name: string;
+    
+
+        
+    placement: string;
+    
+
+        
+    file_upload_config: FileUploadConfig;
+    
+
+        
+    image_upload_config: FileUploadConfig;
+    
+
+        }
+    
+
+
+
+
+    export interface AppUpdatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    app: AppEventResponse;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    /**
+     * The type of event: "app.updated" in this case
+     */
+    type: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        }
+    
+
+
+
+
+    export interface AppealItemResponse {
+    /**
+     * Reason Text of the Appeal Item
+     */
+    appeal_reason: string;
+    
+
+        
+    /**
+     * When the flag was created
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * ID of the entity
+     */
+    entity_id: string;
+    
+
+        
+    /**
+     * Type of entity
+     */
+    entity_type: string;
+    
+
+        
+    id: string;
+    
+
+        
+    /**
+     * Status of the Appeal Item
+     */
+    status: string;
+    
+
+        
+    /**
+     * When the flag was last updated
+     */
+    updated_at: Date;
+    
+
+        
+    /**
+     * Decision Reason of the Appeal Item
+     */
+    decision_reason?: string;
+    
+
+        
+    /**
+     * Attachments(e.g. Images) of the Appeal Item
+     */
+    attachments?: Array<string>;
+    
+
+        
+    entity_content?: ModerationPayload;
+    
+
+        
+    user?: UserResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface AppealRequest {
+    /**
+     * Explanation for why the content is being appealed
+     */
+    appeal_reason: string;
+    
+
+        
+    /**
+     * Unique identifier of the entity being appealed
+     */
+    entity_id: string;
+    
+
+        
+    /**
+     * Type of entity being appealed (e.g., message, user)
+     */
+    entity_type: string;
+    
+
+        
+    /**
+     * Array of Attachment URLs(e.g., images)
+     */
+    attachments?: Array<string>;
+    
+
+        }
+    
+
+
+
+
+    export interface AppealResponse {
+    /**
+     * Unique identifier of the created Appeal item
+     */
+    appeal_id: string;
+    
+
+        
+    duration: string;
+    
+
+        }
+    
+
+
+
+
+    export interface Attachment {
+    custom: Record<string, any>;
+    
+
+        
+    asset_url?: string;
+    
+
+        
+    author_icon?: string;
+    
+
+        
+    author_link?: string;
+    
+
+        
+    author_name?: string;
+    
+
+        
+    color?: string;
+    
+
+        
+    fallback?: string;
+    
+
+        
+    footer?: string;
+    
+
+        
+    footer_icon?: string;
+    
+
+        
+    image_url?: string;
+    
+
+        
+    og_scrape_url?: string;
+    
+
+        
+    original_height?: number;
+    
+
+        
+    original_width?: number;
+    
+
+        
+    pretext?: string;
+    
+
+        
+    text?: string;
+    
+
+        
+    thumb_url?: string;
+    
+
+        
+    title?: string;
+    
+
+        
+    title_link?: string;
+    
+
+        
+    /**
+     * Attachment type (e.g. image, video, url)
+     */
+    type?: string;
+    
+
+        
+    actions?: Array<Action>;
+    
+
+        
+    fields?: Array<Field>;
+    
+
+        
+    giphy?: Images;
+    
+
+        }
+    
+
+
+
+
+    export interface AutomodPlatformCircumventionConfig {
+    enabled: boolean;
+    
+
+        
+    rules: Array<AutomodRule>;
+    
+
+        
+    async?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface AutomodRule {
+    
+        action:| "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
+
+        
+    label: string;
+    
+
+        
+    threshold: number;
+    
+
+        }
+    
+
+
+
+
+    export interface AutomodSemanticFiltersConfig {
+    enabled: boolean;
+    
+
+        
+    rules: Array<AutomodSemanticFiltersRule>;
+    
+
+        
+    async?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface AutomodSemanticFiltersRule {
+    
+        action:| "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
+
+        
+    name: string;
+    
+
+        
+    threshold: number;
+    
+
+        }
+    
+
+
+
+
+    export interface AutomodToxicityConfig {
+    enabled: boolean;
+    
+
+        
+    rules: Array<AutomodRule>;
+    
+
+        
+    async?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface BanActionRequestPayload {
+    /**
+     * Also ban user from all channels this moderator creates in the future
+     */
+    ban_from_future_channels?: boolean;
+    
+
+        
+    /**
+     * Ban only from specific channel
+     */
+    channel_ban_only?: boolean;
+    
+
+        
+    channel_cid?: string;
+    
+
+        
+    /**
+     * Message deletion mode: soft, pruning, or hard
+     */
+    
+        delete_messages?:| "soft" | "pruning" | "hard" ;
+
+        
+    /**
+     * Whether to ban by IP address
+     */
+    ip_ban?: boolean;
+    
+
+        
+    /**
+     * Reason for the ban
+     */
+    reason?: string;
+    
+
+        
+    /**
+     * Whether this is a shadow ban
+     */
+    shadow?: boolean;
+    
+
+        
+    /**
+     * Optional: ban user directly without review item
+     */
+    target_user_id?: string;
+    
+
+        
+    /**
+     * Duration of ban in minutes
+     */
+    timeout?: number;
+    
+
+        }
+    
+
+
+
+
+    export interface BanInfoResponse {
+    /**
+     * When the ban was created
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * When the ban expires
+     */
+    expires?: Date;
+    
+
+        
+    /**
+     * Reason for the ban
+     */
+    reason?: string;
+    
+
+        
+    /**
+     * Whether this is a shadow ban
+     */
+    shadow?: boolean;
+    
+
+        
+    created_by?: UserResponse;
+    
+
+        
+    user?: UserResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface BanOptions {
+    
+        delete_messages?:| "soft" | "pruning" | "hard" ;
+
+        
+    duration?: number;
+    
+
+        
+    ip_ban?: boolean;
+    
+
+        
+    reason?: string;
+    
+
+        
+    shadow_ban?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface BanRequest {
+    /**
+     * ID of the user to ban
+     */
+    target_user_id: string;
+    
+
+        
+    /**
+     * ID of the user performing the ban
+     */
+    banned_by_id?: string;
+    
+
+        
+    /**
+     * Channel where the ban applies
+     */
+    channel_cid?: string;
+    
+
+        
+    
+        delete_messages?:| "soft" | "pruning" | "hard" ;
+
+        
+    /**
+     * Whether to ban the user's IP address
+     */
+    ip_ban?: boolean;
+    
+
+        
+    /**
+     * Optional explanation for the ban
+     */
+    reason?: string;
+    
 
-export interface AddActivityResponse {
-  duration: string;
+        
+    /**
+     * Whether this is a shadow ban
+     */
+    shadow?: boolean;
+    
+
+        
+    /**
+     * Duration of the ban in minutes
+     */
+    timeout?: number;
+    
+
+        
+    banned_by?: UserRequest;
+    
+
+        }
+    
+
+
+
+
+    export interface BanResponse {
+    duration: string;
+    
+
+        }
+    
+
+
+
+
+    export interface BlockActionRequestPayload {
+    /**
+     * Reason for blocking
+     */
+    reason?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface BlockListConfig {
+    enabled: boolean;
+    
+
+        
+    rules: Array<BlockListRule>;
+    
+
+        
+    async?: boolean;
+    
+
+        
+    match_substring?: boolean;
+    
 
-  activity: ActivityResponse;
+        }
+    
 
-  /**
-   * Number of mention notification activities created for mentioned users
-   */
-  mention_notifications_created?: number;
-}
 
-export interface AddBookmarkRequest {
-  /**
-   * ID of the folder to add the bookmark to
-   */
-  folder_id?: string;
 
-  /**
-   * Custom data for the bookmark
-   */
-  custom?: Record<string, any>;
 
-  new_folder?: AddFolderRequest;
-}
+    export interface BlockListOptions {
+    /**
+     * Blocklist behavior. One of: flag, block, shadow_block
+     */
+    
+        behavior:| "flag" | "block" | "shadow_block" ;
 
-export interface AddBookmarkResponse {
-  duration: string;
+        
+    /**
+     * Blocklist name
+     */
+    blocklist: string;
+    
 
-  bookmark: BookmarkResponse;
-}
+        }
+    
 
-export interface AddCommentBookmarkRequest {
-  /**
-   * ID of the folder to add the bookmark to
-   */
-  folder_id?: string;
 
-  /**
-   * Custom data for the bookmark
-   */
-  custom?: Record<string, any>;
 
-  new_folder?: AddFolderRequest;
-}
 
-export interface AddCommentBookmarkResponse {
-  duration: string;
+    export interface BlockListResponse {
+    is_leet_check_enabled: boolean;
+    
 
-  bookmark: BookmarkResponse;
-}
+        
+    is_plural_check_enabled: boolean;
+    
 
-export interface AddCommentReactionRequest {
-  /**
-   * The type of reaction, eg upvote, like, ...
-   */
-  type: string;
+        
+    /**
+     * Block list name
+     */
+    name: string;
+    
 
-  /**
-   * @deprecated
-   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-   */
-  copy_custom_to_notification?: boolean;
+        
+    /**
+     * Block list type. One of: regex, domain, domain_allowlist, email, email_allowlist, word
+     */
+    type: string;
+    
 
-  /**
-   * Whether to create a notification activity for this reaction
-   */
-  create_notification_activity?: boolean;
+        
+    /**
+     * List of words to block
+     */
+    words: Array<string>;
+    
 
-  /**
-   * Whether to enforce unique reactions per user (remove other reaction types from the user when adding this one)
-   */
-  enforce_unique?: boolean;
+        
+    /**
+     * Date/time of creation
+     */
+    created_at?: Date;
+    
 
-  skip_push?: boolean;
+        
+    id?: string;
+    
 
-  /**
-   * Optional custom data to add to the reaction
-   */
-  custom?: Record<string, any>;
-}
+        
+    team?: string;
+    
 
-export interface AddCommentReactionResponse {
-  /**
-   * Duration of the request
-   */
-  duration: string;
+        
+    /**
+     * Date/time of the last update
+     */
+    updated_at?: Date;
+    
 
-  comment: CommentResponse;
+        }
+    
 
-  reaction: FeedsReactionResponse;
 
-  /**
-   * Whether a notification activity was successfully created
-   */
-  notification_created?: boolean;
-}
 
-export interface AddCommentRequest {
-  /**
-   * Text content of the comment
-   */
-  comment?: string;
 
-  /**
-   * @deprecated
-   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-   */
-  copy_custom_to_notification?: boolean;
+    export interface BlockListRule {
+    
+        action:| "flag" | "mask_flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
 
-  /**
-   * Whether to create a notification activity for this comment
-   */
-  create_notification_activity?: boolean;
+        
+    name: string;
+    
 
-  /**
-   * Optional custom ID for the comment (max 255 characters). If not provided, a UUID will be generated.
-   */
-  id?: string;
+        
+    team: string;
+    
 
-  /**
-   * ID of the object to comment on. Required for root comments
-   */
-  object_id?: string;
+        }
+    
 
-  /**
-   * Type of the object to comment on. Required for root comments
-   */
-  object_type?: string;
 
-  /**
-   * ID of parent comment for replies. When provided, object_id and object_type are automatically inherited from the parent comment.
-   */
-  parent_id?: string;
 
-  /**
-   * Whether to skip URL enrichment for this comment
-   */
-  skip_enrich_url?: boolean;
 
-  skip_push?: boolean;
+    export interface BlockUsersRequest {
+    /**
+     * User id to block
+     */
+    blocked_user_id: string;
+    
 
-  /**
-   * Media attachments for the reply
-   */
-  attachments?: Attachment[];
+        }
+    
 
-  /**
-   * List of users mentioned in the reply
-   */
-  mentioned_user_ids?: string[];
 
-  /**
-   * Custom data for the comment
-   */
-  custom?: Record<string, any>;
-}
 
-export interface AddCommentResponse {
-  duration: string;
 
-  comment: CommentResponse;
+    export interface BlockUsersResponse {
+    /**
+     * User id who blocked another user
+     */
+    blocked_by_user_id: string;
+    
 
-  /**
-   * Number of mention notification activities created for mentioned users
-   */
-  mention_notifications_created?: number;
+        
+    /**
+     * User id who got blocked
+     */
+    blocked_user_id: string;
+    
 
-  /**
-   * Whether a notification activity was successfully created
-   */
-  notification_created?: boolean;
-}
+        
+    /**
+     * Timestamp when the user was blocked
+     */
+    created_at: Date;
+    
 
-export interface AddCommentsBatchRequest {
-  /**
-   * List of comments to add
-   */
-  comments: AddCommentRequest[];
-}
+        
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-export interface AddCommentsBatchResponse {
-  duration: string;
+        }
+    
 
-  /**
-   * List of comments added
-   */
-  comments: CommentResponse[];
-}
 
-export interface AddFolderRequest {
-  /**
-   * Name of the folder
-   */
-  name: string;
 
-  /**
-   * Custom data for the folder
-   */
-  custom?: Record<string, any>;
-}
 
-export interface AddReactionRequest {
-  /**
-   * Type of reaction
-   */
-  type: string;
+    export interface BlockedUserResponse {
+    /**
+     * ID of the user who got blocked
+     */
+    blocked_user_id: string;
+    
 
-  /**
-   * @deprecated
-   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-   */
-  copy_custom_to_notification?: boolean;
+        
+    created_at: Date;
+    
 
-  /**
-   * Whether to create a notification activity for this reaction
-   */
-  create_notification_activity?: boolean;
+        
+    /**
+     * ID of the user who blocked another user
+     */
+    user_id: string;
+    
 
-  /**
-   * Whether to enforce unique reactions per user (remove other reaction types from the user when adding this one)
-   */
-  enforce_unique?: boolean;
+        
+    blocked_user: UserResponse;
+    
 
-  skip_push?: boolean;
+        
+    user: UserResponse;
+    
 
-  /**
-   * Custom data for the reaction
-   */
-  custom?: Record<string, any>;
-}
+        }
+    
 
-export interface AddReactionResponse {
-  duration: string;
 
-  activity: ActivityResponse;
 
-  reaction: FeedsReactionResponse;
 
-  /**
-   * Whether a notification activity was successfully created
-   */
-  notification_created?: boolean;
-}
+    export interface BodyguardProfileSummary {
+    name: string;
+    
 
-export interface AddUserGroupMembersRequest {
-  /**
-   * List of user IDs to add as members
-   */
-  member_ids: string[];
+        
+    display_name?: string;
+    
 
-  /**
-   * Whether to add the members as group admins. Defaults to false
-   */
-  as_admin?: boolean;
+        }
+    
 
-  team_id?: string;
-}
 
-export interface AddUserGroupMembersResponse {
-  duration: string;
 
-  user_group?: UserGroupResponse;
-}
 
-export interface AggregatedActivityResponse {
-  /**
-   * Number of activities in this aggregation
-   */
-  activity_count: number;
+    export interface BodyguardRule {
+    
+        action:| "keep" | "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
 
-  /**
-   * When the aggregation was created
-   */
-  created_at: Date;
+        
+    label: string;
+    
 
-  /**
-   * Grouping identifier
-   */
-  group: string;
+        
+    severity_rules: Array<BodyguardSeverityRule>;
+    
 
-  /**
-   * Ranking score for this aggregation
-   */
-  score: number;
+        }
+    
 
-  /**
-   * When the aggregation was last updated
-   */
-  updated_at: Date;
 
-  /**
-   * Number of unique users in this aggregation
-   */
-  user_count: number;
 
-  /**
-   * Whether this activity group has been truncated due to exceeding the group size limit
-   */
-  user_count_truncated: boolean;
 
-  /**
-   * List of activities in this aggregation
-   */
-  activities: ActivityResponse[];
+    export interface BodyguardSeverityRule {
+    
+        action:| "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
 
-  /**
-   * Whether this aggregated group has been read. Only set for feed groups with notification config (track_seen/track_read enabled).
-   */
-  is_read?: boolean;
+        
+    
+        severity:| "low" | "medium" | "high" | "critical" ;
 
-  /**
-   * Whether this aggregated group has been seen. Only set for feed groups with notification config (track_seen/track_read enabled).
-   */
-  is_seen?: boolean;
+        }
+    
 
-  is_watched?: boolean;
-}
 
-export interface AggregationConfig {
-  activities_sort?: string;
 
-  format?: string;
 
-  group_size?: number;
+    export interface BookmarkAddedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  score_strategy?: string;
-}
+        
+    bookmark: BookmarkResponse;
+    
 
-export interface AppEventResponse {
-  /**
-   * boolean
-   */
-  auto_translation_enabled: boolean;
+        
+    custom: Record<string, any>;
+    
 
-  /**
-   * string
-   */
-  name: string;
+        
+    /**
+     * The type of event: "feeds.bookmark.added" in this case
+     */
+    type: string;
+    
 
-  /**
-   * boolean
-   */
-  async_url_enrich_enabled?: boolean;
+        
+    received_at?: Date;
+    
 
-  file_upload_config?: FileUploadConfig;
+        
+    user?: UserResponseCommonFields;
+    
 
-  image_upload_config?: FileUploadConfig;
-}
+        }
+    
 
-export interface AppResponseFields {
-  async_url_enrich_enabled: boolean;
 
-  auto_translation_enabled: boolean;
 
-  id: number;
 
-  name: string;
+    export interface BookmarkDeletedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  placement: string;
+        
+    bookmark: BookmarkResponse;
+    
 
-  file_upload_config: FileUploadConfig;
+        
+    custom: Record<string, any>;
+    
 
-  image_upload_config: FileUploadConfig;
-}
+        
+    /**
+     * The type of event: "feeds.bookmark.deleted" in this case
+     */
+    type: string;
+    
 
-export interface AppUpdatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    received_at?: Date;
+    
 
-  app: AppEventResponse;
+        
+    user?: UserResponseCommonFields;
+    
 
-  custom: Record<string, any>;
+        }
+    
 
-  /**
-   * The type of event: "app.updated" in this case
-   */
-  type: string;
 
-  received_at?: Date;
-}
 
-export interface AppealItemResponse {
-  /**
-   * Reason Text of the Appeal Item
-   */
-  appeal_reason: string;
 
-  /**
-   * When the flag was created
-   */
-  created_at: Date;
+    export interface BookmarkFolderDeletedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  /**
-   * ID of the entity
-   */
-  entity_id: string;
+        
+    bookmark_folder: BookmarkFolderResponse;
+    
 
-  /**
-   * Type of entity
-   */
-  entity_type: string;
+        
+    custom: Record<string, any>;
+    
 
-  id: string;
+        
+    /**
+     * The type of event: "feeds.bookmark_folder.deleted" in this case
+     */
+    type: string;
+    
 
-  /**
-   * Status of the Appeal Item
-   */
-  status: string;
+        
+    received_at?: Date;
+    
 
-  /**
-   * When the flag was last updated
-   */
-  updated_at: Date;
+        
+    user?: UserResponseCommonFields;
+    
 
-  /**
-   * Decision Reason of the Appeal Item
-   */
-  decision_reason?: string;
+        }
+    
 
-  /**
-   * Attachments(e.g. Images) of the Appeal Item
-   */
-  attachments?: string[];
 
-  entity_content?: ModerationPayload;
 
-  user?: UserResponse;
-}
 
-export interface AppealRequest {
-  /**
-   * Explanation for why the content is being appealed
-   */
-  appeal_reason: string;
+    export interface BookmarkFolderResponse {
+    /**
+     * When the folder was created
+     */
+    created_at: Date;
+    
 
-  /**
-   * Unique identifier of the entity being appealed
-   */
-  entity_id: string;
+        
+    /**
+     * Unique identifier for the folder
+     */
+    id: string;
+    
 
-  /**
-   * Type of entity being appealed (e.g., message, user)
-   */
-  entity_type: string;
+        
+    /**
+     * Name of the folder
+     */
+    name: string;
+    
 
-  /**
-   * Array of Attachment URLs(e.g., images)
-   */
-  attachments?: string[];
-}
+        
+    /**
+     * When the folder was last updated
+     */
+    updated_at: Date;
+    
 
-export interface AppealResponse {
-  /**
-   * Unique identifier of the created Appeal item
-   */
-  appeal_id: string;
+        
+    user: UserResponse;
+    
 
-  duration: string;
-}
+        
+    /**
+     * Custom data for the folder
+     */
+    custom?: Record<string, any>;
+    
 
-export interface Attachment {
-  custom: Record<string, any>;
+        }
+    
 
-  asset_url?: string;
 
-  author_icon?: string;
 
-  author_link?: string;
 
-  author_name?: string;
+    export interface BookmarkFolderUpdatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  color?: string;
+        
+    bookmark_folder: BookmarkFolderResponse;
+    
 
-  fallback?: string;
+        
+    custom: Record<string, any>;
+    
 
-  footer?: string;
+        
+    /**
+     * The type of event: "feeds.bookmark_folder.updated" in this case
+     */
+    type: string;
+    
 
-  footer_icon?: string;
+        
+    received_at?: Date;
+    
 
-  image_url?: string;
+        
+    user?: UserResponseCommonFields;
+    
 
-  og_scrape_url?: string;
+        }
+    
 
-  original_height?: number;
 
-  original_width?: number;
 
-  pretext?: string;
 
-  text?: string;
+    export interface BookmarkResponse {
+    /**
+     * When the bookmark was created
+     */
+    created_at: Date;
+    
 
-  thumb_url?: string;
+        
+    /**
+     * ID of the bookmarked object
+     */
+    object_id: string;
+    
 
-  title?: string;
+        
+    /**
+     * Type of the bookmarked object (activity or comment)
+     */
+    object_type: string;
+    
 
-  title_link?: string;
+        
+    /**
+     * When the bookmark was last updated
+     */
+    updated_at: Date;
+    
 
-  /**
-   * Attachment type (e.g. image, video, url)
-   */
-  type?: string;
+        
+    activity: ActivityResponse;
+    
 
-  actions?: Action[];
+        
+    user: UserResponse;
+    
 
-  fields?: Field[];
+        
+    activity_id?: string;
+    
 
-  giphy?: Images;
-}
+        
+    comment?: CommentResponse;
+    
 
-export interface AudioSettingsResponse {
-  access_request_enabled: boolean;
+        
+    /**
+     * Custom data for the bookmark
+     */
+    custom?: Record<string, any>;
+    
 
-  default_device: string;
+        
+    folder?: BookmarkFolderResponse;
+    
 
-  hifi_audio_enabled: boolean;
+        }
+    
 
-  mic_default_on: boolean;
 
-  opus_dtx_enabled: boolean;
 
-  redundant_coding_enabled: boolean;
 
-  speaker_default_on: boolean;
+    export interface BookmarkUpdatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  noise_cancellation?: NoiseCancellationSettings;
-}
+        
+    bookmark: BookmarkResponse;
+    
 
-export interface AutomodPlatformCircumventionConfig {
-  enabled: boolean;
+        
+    custom: Record<string, any>;
+    
 
-  rules: AutomodRule[];
+        
+    /**
+     * The type of event: "feeds.bookmark.updated" in this case
+     */
+    type: string;
+    
 
-  async?: boolean;
-}
+        
+    received_at?: Date;
+    
 
-export interface AutomodRule {
-  action:
-    | 'flag'
-    | 'shadow'
-    | 'remove'
-    | 'bounce'
-    | 'bounce_flag'
-    | 'bounce_remove';
+        
+    user?: UserResponseCommonFields;
+    
 
-  label: string;
+        }
+    
 
-  threshold: number;
-}
 
-export interface AutomodSemanticFiltersConfig {
-  enabled: boolean;
 
-  rules: AutomodSemanticFiltersRule[];
 
-  async?: boolean;
-}
+    export interface BulkDeleteActionConfigRequest {
+    /**
+     * UUIDs of the action configs to delete
+     */
+    ids: Array<string>;
+    
 
-export interface AutomodSemanticFiltersRule {
-  action:
-    | 'flag'
-    | 'shadow'
-    | 'remove'
-    | 'bounce'
-    | 'bounce_flag'
-    | 'bounce_remove';
+        }
+    
 
-  name: string;
 
-  threshold: number;
-}
 
-export interface AutomodToxicityConfig {
-  enabled: boolean;
 
-  rules: AutomodRule[];
+    export interface BulkDeleteActionConfigResponse {
+    /**
+     * Number of action configs deleted
+     */
+    deleted: number;
+    
 
-  async?: boolean;
-}
+        
+    duration: string;
+    
 
-export interface BackstageSettingsResponse {
-  enabled: boolean;
+        }
+    
 
-  join_ahead_time_seconds?: number;
-}
 
-export interface BanActionRequestPayload {
-  /**
-   * Also ban user from all channels this moderator creates in the future
-   */
-  ban_from_future_channels?: boolean;
 
-  /**
-   * Ban only from specific channel
-   */
-  channel_ban_only?: boolean;
 
-  channel_cid?: string;
+    export interface BulkUpsertActionConfigRequest {
+    /**
+     * List of action configs to create or update
+     */
+    action_configs: Array<UpsertActionConfigItem>;
+    
 
-  /**
-   * Message deletion mode: soft, pruning, or hard
-   */
+        }
+    
 
-  delete_messages?: 'soft' | 'pruning' | 'hard';
 
-  /**
-   * Whether to ban by IP address
-   */
-  ip_ban?: boolean;
 
-  /**
-   * Reason for the ban
-   */
-  reason?: string;
 
-  /**
-   * Whether this is a shadow ban
-   */
-  shadow?: boolean;
+    export interface BulkUpsertActionConfigResponse {
+    duration: string;
+    
 
-  /**
-   * Optional: ban user directly without review item
-   */
-  target_user_id?: string;
+        
+    /**
+     * The created or updated action configs in the same order as the request
+     */
+    action_configs: Array<ModerationActionConfigResponse>;
+    
 
-  /**
-   * Duration of ban in minutes
-   */
-  timeout?: number;
-}
+        }
+    
 
-export interface BanInfoResponse {
-  /**
-   * When the ban was created
-   */
-  created_at: Date;
 
-  /**
-   * When the ban expires
-   */
-  expires?: Date;
 
-  /**
-   * Reason for the ban
-   */
-  reason?: string;
 
-  /**
-   * Whether this is a shadow ban
-   */
-  shadow?: boolean;
+    export interface BypassActionRequest {
+    enabled?: boolean;
+    
 
-  created_by?: UserResponse;
+        }
+    
 
-  user?: UserResponse;
-}
 
-export interface BanOptions {
-  delete_messages?: 'soft' | 'pruning' | 'hard';
 
-  duration?: number;
 
-  ip_ban?: boolean;
+    export interface CallActionOptions {
+    duration?: number;
+    
 
-  reason?: string;
+        
+    flag_reason?: string;
+    
 
-  shadow_ban?: boolean;
-}
+        
+    kick_reason?: string;
+    
 
-export interface BanRequest {
-  /**
-   * ID of the user to ban
-   */
-  target_user_id: string;
+        
+    mute_audio?: boolean;
+    
 
-  /**
-   * ID of the user performing the ban
-   */
-  banned_by_id?: string;
+        
+    mute_video?: boolean;
+    
 
-  /**
-   * Channel where the ban applies
-   */
-  channel_cid?: string;
+        
+    reason?: string;
+    
 
-  delete_messages?: 'soft' | 'pruning' | 'hard';
+        
+    warning_text?: string;
+    
 
-  /**
-   * Whether to ban the user's IP address
-   */
-  ip_ban?: boolean;
+        }
+    
 
-  /**
-   * Optional explanation for the ban
-   */
-  reason?: string;
 
-  /**
-   * Whether this is a shadow ban
-   */
-  shadow?: boolean;
 
-  /**
-   * Duration of the ban in minutes
-   */
-  timeout?: number;
 
-  banned_by?: UserRequest;
-}
+    export interface CallCustomPropertyParameters {
+    operator?: string;
+    
 
-export interface BanResponse {
-  duration: string;
-}
+        
+    property_key?: string;
+    
 
-export interface BlockActionRequestPayload {
-  /**
-   * Reason for blocking
-   */
-  reason?: string;
-}
+        }
+    
 
-export interface BlockListConfig {
-  enabled: boolean;
 
-  rules: BlockListRule[];
 
-  async?: boolean;
 
-  match_substring?: boolean;
-}
+    export interface CallResponse {
+    backstage: boolean;
+    
 
-export interface BlockListOptions {
-  /**
-   * Blocklist behavior. One of: flag, block, shadow_block
-   */
+        
+    captioning: boolean;
+    
 
-  behavior: 'flag' | 'block' | 'shadow_block';
+        
+    cid: string;
+    
 
-  /**
-   * Blocklist name
-   */
-  blocklist: string;
-}
+        
+    created_at: Date;
+    
 
-export interface BlockListResponse {
-  is_leet_check_enabled: boolean;
+        
+    current_session_id: string;
+    
 
-  is_plural_check_enabled: boolean;
+        
+    id: string;
+    
 
-  /**
-   * Block list name
-   */
-  name: string;
+        
+    recording: boolean;
+    
 
-  /**
-   * Block list type. One of: regex, domain, domain_allowlist, email, email_allowlist, word
-   */
-  type: string;
+        
+    transcribing: boolean;
+    
 
-  /**
-   * List of words to block
-   */
-  words: string[];
+        
+    translating: boolean;
+    
 
-  /**
-   * Date/time of creation
-   */
-  created_at?: Date;
+        
+    type: string;
+    
 
-  id?: string;
+        
+    updated_at: Date;
+    
 
-  team?: string;
+        
+    blocked_user_ids: Array<string>;
+    
 
-  /**
-   * Date/time of the last update
-   */
-  updated_at?: Date;
-}
+        
+    custom: Record<string, any>;
+    
 
-export interface BlockListRule {
-  action:
-    | 'flag'
-    | 'mask_flag'
-    | 'shadow'
-    | 'remove'
-    | 'bounce'
-    | 'bounce_flag'
-    | 'bounce_remove';
+        
+    channel_cid?: string;
+    
 
-  name: string;
+        
+    ended_at?: Date;
+    
 
-  team: string;
-}
+        
+    join_ahead_time_seconds?: number;
+    
 
-export interface BlockUsersRequest {
-  /**
-   * User id to block
-   */
-  blocked_user_id: string;
-}
+        
+    routing_number?: string;
+    
 
-export interface BlockUsersResponse {
-  /**
-   * User id who blocked another user
-   */
-  blocked_by_user_id: string;
+        
+    starts_at?: Date;
+    
 
-  /**
-   * User id who got blocked
-   */
-  blocked_user_id: string;
+        
+    team?: string;
+    
 
-  /**
-   * Timestamp when the user was blocked
-   */
-  created_at: Date;
+        
+    created_by?: UserResponse;
+    
 
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
-}
+        }
+    
 
-export interface BlockedUserResponse {
-  /**
-   * ID of the user who got blocked
-   */
-  blocked_user_id: string;
 
-  created_at: Date;
 
-  /**
-   * ID of the user who blocked another user
-   */
-  user_id: string;
 
-  blocked_user: UserResponse;
+    export interface CallRuleActionSequence {
+    violation_number?: number;
+    
 
-  user: UserResponse;
-}
+        
+    actions?: Array<string>;
+    
 
-export interface BodyguardRule {
-  action:
-    | 'flag'
-    | 'shadow'
-    | 'remove'
-    | 'bounce'
-    | 'bounce_flag'
-    | 'bounce_remove';
+        
+    call_options?: CallActionOptions;
+    
 
-  label: string;
+        }
+    
 
-  severity_rules: BodyguardSeverityRule[];
-}
 
-export interface BodyguardSeverityRule {
-  action:
-    | 'flag'
-    | 'shadow'
-    | 'remove'
-    | 'bounce'
-    | 'bounce_flag'
-    | 'bounce_remove';
 
-  severity: 'low' | 'medium' | 'high' | 'critical';
-}
 
-export interface BookmarkAddedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+    export interface CallTypeRuleParameters {
+    call_type?: string;
+    
 
-  bookmark: BookmarkResponse;
+        }
+    
 
-  custom: Record<string, any>;
 
-  /**
-   * The type of event: "feeds.bookmark.added" in this case
-   */
-  type: string;
 
-  received_at?: Date;
 
-  user?: UserResponseCommonFields;
-}
+    export interface CallViolationCountParameters {
+    threshold?: number;
+    
 
-export interface BookmarkDeletedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    time_window?: string;
+    
 
-  bookmark: BookmarkResponse;
+        }
+    
 
-  custom: Record<string, any>;
 
-  /**
-   * The type of event: "feeds.bookmark.deleted" in this case
-   */
-  type: string;
 
-  received_at?: Date;
 
-  user?: UserResponseCommonFields;
-}
+    export interface CastPollVoteRequest {
+    vote?: VoteData;
+    
 
-export interface BookmarkFolderDeletedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        }
+    
 
-  bookmark_folder: BookmarkFolderResponse;
 
-  custom: Record<string, any>;
 
-  /**
-   * The type of event: "feeds.bookmark_folder.deleted" in this case
-   */
-  type: string;
 
-  received_at?: Date;
+    export interface ChangeFeedVisibilityRequest {
+    /**
+     * Feed visibility level: public, visible, followers, members, or private
+     */
+    
+        visibility:| "public" | "visible" | "followers" | "members" | "private" ;
 
-  user?: UserResponseCommonFields;
-}
+        
+    /**
+     * What to do with existing pending follows when loosening visibility from 'followers': auto_approve (default) or reject
+     */
+    
+        pending_follows_action?:| "auto_approve" | "reject" ;
 
-export interface BookmarkFolderResponse {
-  /**
-   * When the folder was created
-   */
-  created_at: Date;
+        }
+    
 
-  /**
-   * Unique identifier for the folder
-   */
-  id: string;
 
-  /**
-   * Name of the folder
-   */
-  name: string;
 
-  /**
-   * When the folder was last updated
-   */
-  updated_at: Date;
 
-  user: UserResponse;
+    export interface ChangeFeedVisibilityResponse {
+    duration: string;
+    
 
-  /**
-   * Custom data for the folder
-   */
-  custom?: Record<string, any>;
-}
+        
+    feed: FeedResponse;
+    
 
-export interface BookmarkFolderUpdatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        }
+    
 
-  bookmark_folder: BookmarkFolderResponse;
 
-  custom: Record<string, any>;
 
-  /**
-   * The type of event: "feeds.bookmark_folder.updated" in this case
-   */
-  type: string;
 
-  received_at?: Date;
+    export interface ChannelConfigWithInfo {
+    
+        automod:| "disabled" | "simple" | "AI" ;
 
-  user?: UserResponseCommonFields;
-}
+        
+    
+        automod_behavior:| "flag" | "block" | "shadow_block" ;
 
-export interface BookmarkResponse {
-  /**
-   * When the bookmark was created
-   */
-  created_at: Date;
+        
+    connect_events: boolean;
+    
 
-  /**
-   * ID of the bookmarked object
-   */
-  object_id: string;
+        
+    count_messages: boolean;
+    
 
-  /**
-   * Type of the bookmarked object (activity or comment)
-   */
-  object_type: string;
+        
+    created_at: Date;
+    
 
-  /**
-   * When the bookmark was last updated
-   */
-  updated_at: Date;
+        
+    custom_events: boolean;
+    
 
-  activity: ActivityResponse;
+        
+    delivery_events: boolean;
+    
 
-  user: UserResponse;
+        
+    mark_messages_pending: boolean;
+    
 
-  activity_id?: string;
+        
+    max_message_length: number;
+    
 
-  comment?: CommentResponse;
+        
+    mutes: boolean;
+    
 
-  /**
-   * Custom data for the bookmark
-   */
-  custom?: Record<string, any>;
+        
+    name: string;
+    
 
-  folder?: BookmarkFolderResponse;
-}
+        
+    polls: boolean;
+    
 
-export interface BookmarkUpdatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    push_notifications: boolean;
+    
 
-  bookmark: BookmarkResponse;
+        
+    quotes: boolean;
+    
 
-  custom: Record<string, any>;
+        
+    reactions: boolean;
+    
 
-  /**
-   * The type of event: "feeds.bookmark.updated" in this case
-   */
-  type: string;
+        
+    read_events: boolean;
+    
 
-  received_at?: Date;
+        
+    reminders: boolean;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    replies: boolean;
+    
 
-export interface BroadcastSettingsResponse {
-  enabled: boolean;
+        
+    search: boolean;
+    
 
-  hls: HLSSettingsResponse;
+        
+    shared_locations: boolean;
+    
 
-  rtmp: RTMPSettingsResponse;
-}
+        
+    skip_last_msg_update_for_system_msgs: boolean;
+    
 
-export interface BypassActionRequest {
-  enabled?: boolean;
-}
+        
+    typing_events: boolean;
+    
 
-export interface CallActionOptions {
-  duration?: number;
+        
+    updated_at: Date;
+    
 
-  flag_reason?: string;
+        
+    uploads: boolean;
+    
 
-  kick_reason?: string;
+        
+    url_enrichment: boolean;
+    
 
-  mute_audio?: boolean;
+        
+    user_message_reminders: boolean;
+    
 
-  mute_video?: boolean;
+        
+    commands: Array<Command>;
+    
 
-  reason?: string;
+        
+    blocklist?: string;
+    
 
-  warning_text?: string;
-}
+        
+    
+        blocklist_behavior?:| "flag" | "block" | "shadow_block" ;
 
-export interface CallCustomPropertyParameters {
-  operator?: string;
+        
+    partition_size?: number;
+    
 
-  property_key?: string;
-}
+        
+    partition_ttl?: string;
+    
 
-export interface CallIngressResponse {
-  rtmp: RTMPIngress;
+        
+    
+        push_level?:| "all" | "all_mentions" | "mentions" | "direct_mentions" | "none" ;
 
-  srt: SRTIngress;
+        
+    allowed_flag_reasons?: Array<string>;
+    
 
-  whip: WHIPIngress;
-}
+        
+    blocklists?: Array<BlockListOptions>;
+    
 
-export interface CallParticipantResponse {
-  role: string;
+        
+    automod_thresholds?: Thresholds;
+    
 
-  user_session_id: string;
+        
+    chat_preferences?: ChatPreferences;
+    
 
-  joined_at: Timestamp;
+        
+    grants?: Record<string, Array<string>>;
+    
 
-  user: UserResponse;
-}
+        }
+    
 
-export interface CallResponse {
-  backstage: boolean;
 
-  captioning: boolean;
 
-  cid: string;
 
-  current_session_id: string;
+    export interface ChannelMemberResponse {
+    /**
+     * Whether member is banned this channel or not
+     */
+    banned: boolean;
+    
 
-  id: string;
+        
+    /**
+     * Role of the member in the channel
+     */
+    channel_role: string;
+    
 
-  recording: boolean;
+        
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  transcribing: boolean;
+        
+    notifications_muted: boolean;
+    
 
-  translating: boolean;
+        
+    /**
+     * Whether member is shadow banned in this channel or not
+     */
+    shadow_banned: boolean;
+    
 
-  type: string;
+        
+    /**
+     * Date/time of the last update
+     */
+    updated_at: Date;
+    
 
-  blocked_user_ids: string[];
+        
+    custom: Record<string, any>;
+    
 
-  created_at: Timestamp;
+        
+    archived_at?: Date;
+    
 
-  created_by: UserResponse;
+        
+    /**
+     * Expiration date of the ban
+     */
+    ban_expires?: Date;
+    
 
-  custom: Record<string, any>;
+        
+    deleted_at?: Date;
+    
 
-  egress: EgressResponse;
+        
+    /**
+     * Date when invite was accepted
+     */
+    invite_accepted_at?: Date;
+    
 
-  ingress: CallIngressResponse;
+        
+    /**
+     * Date when invite was rejected
+     */
+    invite_rejected_at?: Date;
+    
 
-  settings: CallSettingsResponse;
+        
+    /**
+     * Whether member was invited or not
+     */
+    invited?: boolean;
+    
 
-  updated_at: Timestamp;
+        
+    /**
+     * Whether member is channel moderator or not
+     */
+    is_moderator?: boolean;
+    
 
-  channel_cid?: string;
+        
+    pinned_at?: Date;
+    
 
-  join_ahead_time_seconds?: number;
+        
+    /**
+     * Permission level of the member in the channel (DEPRECATED: use channel_role instead). One of: member, moderator, admin, owner
+     */
+    role?: string;
+    
 
-  routing_number?: string;
+        
+    status?: string;
+    
 
-  team?: string;
+        
+    user_id?: string;
+    
 
-  ended_at?: Timestamp;
+        
+    deleted_messages?: Array<string>;
+    
 
-  session?: CallSessionResponse;
+        
+    user?: UserResponse;
+    
 
-  starts_at?: Timestamp;
+        }
+    
 
-  thumbnails?: ThumbnailResponse;
-}
 
-export interface CallRuleActionSequence {
-  violation_number?: number;
 
-  actions?: string[];
 
-  call_options?: CallActionOptions;
-}
+    export interface ChannelMessageCountRuleParameters {
+    operator?: string;
+    
 
-export interface CallSessionResponse {
-  anonymous_participant_count: number;
+        
+    threshold?: number;
+    
 
-  id: string;
+        }
+    
 
-  participants: CallParticipantResponse[];
 
-  accepted_by: Record<string, Timestamp>;
 
-  missed_by: Record<string, Timestamp>;
 
-  participants_count_by_role: Record<string, number>;
+    export interface ChannelMute {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  rejected_by: Record<string, Timestamp>;
+        
+    /**
+     * Date/time of the last update
+     */
+    updated_at: Date;
+    
 
-  ended_at?: Timestamp;
+        
+    /**
+     * Date/time of mute expiration
+     */
+    expires?: Date;
+    
 
-  live_ended_at?: Timestamp;
+        
+    channel?: ChannelResponse;
+    
 
-  live_started_at?: Timestamp;
+        
+    user?: UserResponse;
+    
 
-  started_at?: Timestamp;
+        }
+    
 
-  timer_ends_at?: Timestamp;
-}
 
-export interface CallSettingsResponse {
-  audio: AudioSettingsResponse;
-
-  backstage: BackstageSettingsResponse;
-
-  broadcasting: BroadcastSettingsResponse;
-
-  frame_recording: FrameRecordingSettingsResponse;
-
-  geofencing: GeofenceSettingsResponse;
-
-  individual_recording: IndividualRecordingSettingsResponse;
-
-  limits: LimitsSettingsResponse;
-
-  raw_recording: RawRecordingSettingsResponse;
-
-  recording: RecordSettingsResponse;
-
-  ring: RingSettingsResponse;
-
-  screensharing: ScreensharingSettingsResponse;
-
-  session: SessionSettingsResponse;
-
-  thumbnails: ThumbnailsSettingsResponse;
-
-  transcription: TranscriptionSettingsResponse;
-
-  video: VideoSettingsResponse;
-
-  ingress?: IngressSettingsResponse;
-}
-
-export interface CallTypeRuleParameters {
-  call_type?: string;
-}
-
-export interface CallViolationCountParameters {
-  threshold?: number;
-
-  time_window?: string;
-}
-
-export interface CastPollVoteRequest {
-  vote?: VoteData;
-}
-
-export interface ChannelConfigWithInfo {
-  automod: 'disabled' | 'simple' | 'AI';
-
-  automod_behavior: 'flag' | 'block' | 'shadow_block';
-
-  connect_events: boolean;
-
-  count_messages: boolean;
-
-  created_at: Date;
-
-  custom_events: boolean;
-
-  delivery_events: boolean;
-
-  mark_messages_pending: boolean;
-
-  max_message_length: number;
-
-  mutes: boolean;
-
-  name: string;
-
-  polls: boolean;
-
-  push_notifications: boolean;
-
-  quotes: boolean;
-
-  reactions: boolean;
-
-  read_events: boolean;
-
-  reminders: boolean;
-
-  replies: boolean;
-
-  search: boolean;
-
-  shared_locations: boolean;
-
-  skip_last_msg_update_for_system_msgs: boolean;
-
-  typing_events: boolean;
-
-  updated_at: Date;
-
-  uploads: boolean;
-
-  url_enrichment: boolean;
-
-  user_message_reminders: boolean;
-
-  commands: Command[];
-
-  blocklist?: string;
-
-  blocklist_behavior?: 'flag' | 'block' | 'shadow_block';
-
-  partition_size?: number;
-
-  partition_ttl?: string;
-
-  push_level?: 'all' | 'all_mentions' | 'mentions' | 'direct_mentions' | 'none';
-
-  allowed_flag_reasons?: string[];
-
-  blocklists?: BlockListOptions[];
-
-  automod_thresholds?: Thresholds;
-
-  chat_preferences?: ChatPreferences;
-
-  grants?: Record<string, string[]>;
-}
-
-export interface ChannelMemberResponse {
-  /**
-   * Whether member is banned this channel or not
-   */
-  banned: boolean;
-
-  /**
-   * Role of the member in the channel
-   */
-  channel_role: string;
-
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
-
-  notifications_muted: boolean;
-
-  /**
-   * Whether member is shadow banned in this channel or not
-   */
-  shadow_banned: boolean;
-
-  /**
-   * Date/time of the last update
-   */
-  updated_at: Date;
-
-  custom: Record<string, any>;
-
-  archived_at?: Date;
-
-  /**
-   * Expiration date of the ban
-   */
-  ban_expires?: Date;
-
-  deleted_at?: Date;
-
-  /**
-   * Date when invite was accepted
-   */
-  invite_accepted_at?: Date;
-
-  /**
-   * Date when invite was rejected
-   */
-  invite_rejected_at?: Date;
-
-  /**
-   * Whether member was invited or not
-   */
-  invited?: boolean;
-
-  /**
-   * Whether member is channel moderator or not
-   */
-  is_moderator?: boolean;
-
-  pinned_at?: Date;
-
-  /**
-   * Permission level of the member in the channel (DEPRECATED: use channel_role instead). One of: member, moderator, admin, owner
-   */
-  role?: string;
-
-  status?: string;
-
-  user_id?: string;
-
-  deleted_messages?: string[];
-
-  user?: UserResponse;
-}
-
-export interface ChannelMute {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
-
-  /**
-   * Date/time of the last update
-   */
-  updated_at: Date;
-
-  /**
-   * Date/time of mute expiration
-   */
-  expires?: Date;
-
-  channel?: ChannelResponse;
-
-  user?: UserResponse;
-}
 
 export const ChannelOwnCapability = {
-  BAN_CHANNEL_MEMBERS: 'ban-channel-members',
-  CAST_POLL_VOTE: 'cast-poll-vote',
-  CONNECT_EVENTS: 'connect-events',
-  CREATE_ATTACHMENT: 'create-attachment',
-  DELETE_ANY_MESSAGE: 'delete-any-message',
-  DELETE_CHANNEL: 'delete-channel',
-  DELETE_OWN_MESSAGE: 'delete-own-message',
-  DELIVERY_EVENTS: 'delivery-events',
-  FLAG_MESSAGE: 'flag-message',
-  FREEZE_CHANNEL: 'freeze-channel',
-  JOIN_CHANNEL: 'join-channel',
-  LEAVE_CHANNEL: 'leave-channel',
-  MUTE_CHANNEL: 'mute-channel',
-  PIN_MESSAGE: 'pin-message',
-  QUERY_POLL_VOTES: 'query-poll-votes',
-  QUOTE_MESSAGE: 'quote-message',
-  READ_EVENTS: 'read-events',
-  SEARCH_MESSAGES: 'search-messages',
-  SEND_CUSTOM_EVENTS: 'send-custom-events',
-  SEND_LINKS: 'send-links',
-  SEND_MESSAGE: 'send-message',
-  SEND_POLL: 'send-poll',
-  SEND_REACTION: 'send-reaction',
-  SEND_REPLY: 'send-reply',
-  SEND_RESTRICTED_VISIBILITY_MESSAGE: 'send-restricted-visibility-message',
-  SEND_TYPING_EVENTS: 'send-typing-events',
-  SET_CHANNEL_COOLDOWN: 'set-channel-cooldown',
-  SHARE_LOCATION: 'share-location',
-  SKIP_SLOW_MODE: 'skip-slow-mode',
-  SLOW_MODE: 'slow-mode',
-  TYPING_EVENTS: 'typing-events',
-  UPDATE_ANY_MESSAGE: 'update-any-message',
-  UPDATE_CHANNEL: 'update-channel',
-  UPDATE_CHANNEL_MEMBERS: 'update-channel-members',
-  UPDATE_OWN_MESSAGE: 'update-own-message',
-  UPDATE_THREAD: 'update-thread',
-  UPLOAD_FILE: 'upload-file',
+    BAN_CHANNEL_MEMBERS: 'ban-channel-members',
+    CAST_POLL_VOTE: 'cast-poll-vote',
+    CONNECT_EVENTS: 'connect-events',
+    CREATE_ATTACHMENT: 'create-attachment',
+    DELETE_ANY_MESSAGE: 'delete-any-message',
+    DELETE_CHANNEL: 'delete-channel',
+    DELETE_OWN_MESSAGE: 'delete-own-message',
+    DELIVERY_EVENTS: 'delivery-events',
+    FLAG_MESSAGE: 'flag-message',
+    FREEZE_CHANNEL: 'freeze-channel',
+    JOIN_CHANNEL: 'join-channel',
+    LEAVE_CHANNEL: 'leave-channel',
+    MUTE_CHANNEL: 'mute-channel',
+    PIN_MESSAGE: 'pin-message',
+    QUERY_POLL_VOTES: 'query-poll-votes',
+    QUOTE_MESSAGE: 'quote-message',
+    READ_EVENTS: 'read-events',
+    SEARCH_MESSAGES: 'search-messages',
+    SEND_CUSTOM_EVENTS: 'send-custom-events',
+    SEND_LINKS: 'send-links',
+    SEND_MESSAGE: 'send-message',
+    SEND_POLL: 'send-poll',
+    SEND_REACTION: 'send-reaction',
+    SEND_REPLY: 'send-reply',
+    SEND_RESTRICTED_VISIBILITY_MESSAGE: 'send-restricted-visibility-message',
+    SEND_TYPING_EVENTS: 'send-typing-events',
+    SET_CHANNEL_COOLDOWN: 'set-channel-cooldown',
+    SHARE_LOCATION: 'share-location',
+    SKIP_SLOW_MODE: 'skip-slow-mode',
+    SLOW_MODE: 'slow-mode',
+    TYPING_EVENTS: 'typing-events',
+    UPDATE_ANY_MESSAGE: 'update-any-message',
+    UPDATE_CHANNEL: 'update-channel',
+    UPDATE_CHANNEL_MEMBERS: 'update-channel-members',
+    UPDATE_OWN_MESSAGE: 'update-own-message',
+    UPDATE_THREAD: 'update-thread',
+    UPLOAD_FILE: 'upload-file',
 } as const;
 
-export type ChannelOwnCapability =
-  (typeof ChannelOwnCapability)[keyof typeof ChannelOwnCapability];
-
-export interface ChannelPushPreferencesResponse {
-  chat_level?: string;
-
-  disabled_until?: Date;
-
-  chat_preferences?: ChatPreferencesResponse;
-}
-
-export interface ChannelResponse {
-  /**
-   * Channel CID (<type>:<id>)
-   */
-  cid: string;
-
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
-
-  disabled: boolean;
-
-  /**
-   * Whether channel is frozen or not
-   */
-  frozen: boolean;
-
-  /**
-   * Channel unique ID
-   */
-  id: string;
-
-  /**
-   * Type of the channel
-   */
-  type: string;
-
-  /**
-   * Date/time of the last update
-   */
-  updated_at: Date;
-
-  /**
-   * Custom data for this object
-   */
-  custom: Record<string, any>;
-
-  /**
-   * Whether auto translation is enabled or not
-   */
-  auto_translation_enabled?: boolean;
-
-  /**
-   * Language to translate to when auto translation is active
-   */
-  auto_translation_language?: string;
-
-  /**
-   * Whether this channel is blocked by current user or not
-   */
-  blocked?: boolean;
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type ChannelOwnCapability = typeof ChannelOwnCapability[keyof typeof ChannelOwnCapability]
+
+
+
+
+    export interface ChannelPushPreferencesResponse {
+    chat_level?: string;
+    
+
+        
+    disabled_until?: Date;
+    
+
+        
+    chat_preferences?: ChatPreferencesResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface ChannelResponse {
+    /**
+     * Channel CID (<type>:<id>)
+     */
+    cid: string;
+    
+
+        
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    disabled: boolean;
+    
+
+        
+    /**
+     * Whether channel is frozen or not
+     */
+    frozen: boolean;
+    
+
+        
+    /**
+     * Channel unique ID
+     */
+    id: string;
+    
+
+        
+    /**
+     * Type of the channel
+     */
+    type: string;
+    
+
+        
+    /**
+     * Date/time of the last update
+     */
+    updated_at: Date;
+    
+
+        
+    /**
+     * Custom data for this object
+     */
+    custom: Record<string, any>;
+    
+
+        
+    /**
+     * Whether auto translation is enabled or not
+     */
+    auto_translation_enabled?: boolean;
+    
+
+        
+    /**
+     * Language to translate to when auto translation is active
+     */
+    auto_translation_language?: string;
+    
+
+        
+    /**
+     * Whether this channel is blocked by current user or not
+     */
+    blocked?: boolean;
+    
+
+        
+    /**
+     * Cooldown period after sending each message
+     */
+    cooldown?: number;
+    
+
+        
+    /**
+     * Date/time of deletion
+     */
+    deleted_at?: Date;
+    
+
+        
+    /**
+     * Whether this channel is hidden by current user or not
+     */
+    hidden?: boolean;
+    
+
+        
+    /**
+     * Date since when the message history is accessible
+     */
+    hide_messages_before?: Date;
+    
+
+        
+    /**
+     * Date of the last message sent
+     */
+    last_message_at?: Date;
+    
+
+        
+    /**
+     * Number of members in the channel
+     */
+    member_count?: number;
+    
+
+        
+    /**
+     * Number of messages in the channel
+     */
+    message_count?: number;
+    
+
+        
+    /**
+     * Date of mute expiration
+     */
+    mute_expires_at?: Date;
+    
+
+        
+    /**
+     * Whether this channel is muted or not
+     */
+    muted?: boolean;
+    
+
+        
+    /**
+     * Team the channel belongs to (multi-tenant only)
+     */
+    team?: string;
+    
+
+        
+    /**
+     * Date of the latest truncation of the channel
+     */
+    truncated_at?: Date;
+    
+
+        
+    /**
+     * List of filter tags associated with the channel
+     */
+    filter_tags?: Array<string>;
+    
+
+        
+    /**
+     * List of channel members (max 100)
+     */
+    members?: Array<ChannelMemberResponse>;
+    
+
+        
+    /**
+     * List of channel capabilities of authenticated user
+     */
+    own_capabilities?: Array<ChannelOwnCapability>;
+    
+
+        
+    config?: ChannelConfigWithInfo;
+    
+
+        
+    created_by?: UserResponse;
+    
+
+        
+    truncated_by?: UserResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface ChatDraftPayloadResponse {
+    id: string;
+    
+
+        
+    text: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    html?: string;
+    
+
+        
+    mml?: string;
+    
+
+        
+    parent_id?: string;
+    
+
+        
+    poll_id?: string;
+    
+
+        
+    quoted_message_id?: string;
+    
+
+        
+    show_in_channel?: boolean;
+    
+
+        
+    silent?: boolean;
+    
+
+        
+    type?: string;
+    
+
+        
+    attachments?: Array<Attachment>;
+    
+
+        
+    mentioned_users?: Array<UserResponse>;
+    
+
+        }
+    
+
+
+
+
+    export interface ChatDraftResponse {
+    channel_cid: string;
+    
+
+        
+    created_at: Date;
+    
+
+        
+    message: ChatDraftPayloadResponse;
+    
+
+        
+    parent_id?: string;
+    
+
+        
+    parent_message?: ChatMessageResponse;
+    
+
+        
+    quoted_message?: ChatMessageResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface ChatMessageResponse {
+    cid: string;
+    
+
+        
+    created_at: Date;
+    
+
+        
+    deleted_reply_count: number;
+    
+
+        
+    html: string;
+    
+
+        
+    id: string;
+    
+
+        
+    mentioned_channel: boolean;
+    
+
+        
+    mentioned_here: boolean;
+    
+
+        
+    pinned: boolean;
+    
+
+        
+    reply_count: number;
+    
+
+        
+    shadowed: boolean;
+    
+
+        
+    silent: boolean;
+    
+
+        
+    text: string;
+    
+
+        
+    type: string;
+    
+
+        
+    updated_at: Date;
+    
+
+        
+    attachments: Array<Attachment>;
+    
+
+        
+    latest_reactions: Array<ChatReactionResponse>;
+    
+
+        
+    mentioned_users: Array<UserResponse>;
+    
+
+        
+    own_reactions: Array<ChatReactionResponse>;
+    
+
+        
+    restricted_visibility: Array<string>;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    reaction_counts: Record<string, number>;
+    
+
+        
+    reaction_scores: Record<string, number>;
+    
+
+        
+    user: UserResponse;
+    
+
+        
+    command?: string;
+    
+
+        
+    deleted_at?: Date;
+    
+
+        
+    deleted_for_me?: boolean;
+    
+
+        
+    message_text_updated_at?: Date;
+    
+
+        
+    mml?: string;
+    
+
+        
+    parent_id?: string;
+    
+
+        
+    pin_expires?: Date;
+    
+
+        
+    pinned_at?: Date;
+    
+
+        
+    poll_id?: string;
+    
+
+        
+    quoted_message_id?: string;
+    
+
+        
+    show_in_channel?: boolean;
+    
 
-  /**
-   * Cooldown period after sending each message
-   */
-  cooldown?: number;
+        
+    mentioned_group_ids?: Array<string>;
+    
 
-  /**
-   * Date/time of deletion
-   */
-  deleted_at?: Date;
+        
+    mentioned_roles?: Array<string>;
+    
 
-  /**
-   * Whether this channel is hidden by current user or not
-   */
-  hidden?: boolean;
+        
+    thread_participants?: Array<UserResponse>;
+    
 
-  /**
-   * Date since when the message history is accessible
-   */
-  hide_messages_before?: Date;
+        
+    draft?: ChatDraftResponse;
+    
 
-  /**
-   * Date of the last message sent
-   */
-  last_message_at?: Date;
+        
+    i18n?: Record<string, string>;
+    
 
-  /**
-   * Number of members in the channel
-   */
-  member_count?: number;
+        
+    image_labels?: Record<string, Array<string>>;
+    
 
-  /**
-   * Number of messages in the channel
-   */
-  message_count?: number;
+        
+    member?: ChannelMemberResponse;
+    
 
-  /**
-   * Date of mute expiration
-   */
-  mute_expires_at?: Date;
+        
+    moderation?: ChatModerationV2Response;
+    
 
-  /**
-   * Whether this channel is muted or not
-   */
-  muted?: boolean;
+        
+    pinned_by?: UserResponse;
+    
 
-  /**
-   * Team the channel belongs to (multi-tenant only)
-   */
-  team?: string;
+        
+    poll?: PollResponseData;
+    
 
-  /**
-   * Date of the latest truncation of the channel
-   */
-  truncated_at?: Date;
+        
+    quoted_message?: ChatMessageResponse;
+    
 
-  /**
-   * List of filter tags associated with the channel
-   */
-  filter_tags?: string[];
+        
+    reaction_groups?: Record<string, ChatReactionGroupResponse>;
+    
 
-  /**
-   * List of channel members (max 100)
-   */
-  members?: ChannelMemberResponse[];
+        
+    reminder?: ChatReminderResponseData;
+    
 
-  /**
-   * List of channel capabilities of authenticated user
-   */
-  own_capabilities?: ChannelOwnCapability[];
+        
+    shared_location?: ChatSharedLocationResponseData;
+    
 
-  config?: ChannelConfigWithInfo;
+        }
+    
 
-  created_by?: UserResponse;
 
-  truncated_by?: UserResponse;
-}
 
-export interface ChatPreferences {
-  channel_mentions?: string;
 
-  default_preference?: string;
+    export interface ChatModerationV2Response {
+    action: string;
+    
 
-  direct_mentions?: string;
+        
+    original_text: string;
+    
 
-  distinct_channel_messages?: string;
+        
+    blocklist_matched?: string;
+    
 
-  group_mentions?: string;
+        
+    platform_circumvented?: boolean;
+    
 
-  here_mentions?: string;
+        
+    semantic_filter_matched?: string;
+    
 
-  role_mentions?: string;
+        
+    blocklists_matched?: Array<string>;
+    
 
-  thread_replies?: string;
-}
+        
+    image_harms?: Array<string>;
+    
 
-export interface ChatPreferencesInput {
-  channel_mentions?: 'all' | 'none';
+        
+    text_harms?: Array<string>;
+    
 
-  default_preference?: 'all' | 'none';
+        }
+    
 
-  direct_mentions?: 'all' | 'none';
 
-  group_mentions?: 'all' | 'none';
 
-  here_mentions?: 'all' | 'none';
 
-  role_mentions?: 'all' | 'none';
+    export interface ChatPreferences {
+    channel_mentions?: string;
+    
 
-  thread_replies?: 'all' | 'none';
-}
+        
+    default_preference?: string;
+    
 
-export interface ChatPreferencesResponse {
-  channel_mentions?: string;
+        
+    direct_mentions?: string;
+    
 
-  default_preference?: string;
+        
+    distinct_channel_messages?: string;
+    
 
-  direct_mentions?: string;
+        
+    group_mentions?: string;
+    
 
-  group_mentions?: string;
+        
+    here_mentions?: string;
+    
 
-  here_mentions?: string;
+        
+    role_mentions?: string;
+    
 
-  role_mentions?: string;
+        
+    thread_replies?: string;
+    
 
-  thread_replies?: string;
-}
+        }
+    
 
-export interface ClosedCaptionRuleParameters {
-  threshold?: number;
 
-  harm_labels?: string[];
 
-  llm_harm_labels?: Record<string, string>;
-}
 
-export interface CollectionRequest {
-  /**
-   * Name/type of the collection
-   */
-  name: string;
+    export interface ChatPreferencesInput {
+    
+        channel_mentions?:| "all" | "none" ;
 
-  /**
-   * Custom data for the collection (required, must contain at least one key)
-   */
-  custom: Record<string, any>;
+        
+    
+        default_preference?:| "all" | "none" ;
 
-  /**
-   * Unique identifier for the collection within its name (optional, will be auto-generated if not provided)
-   */
-  id?: string;
-}
+        
+    
+        direct_mentions?:| "all" | "none" ;
 
-export interface CollectionResponse {
-  /**
-   * Unique identifier for the collection within its name
-   */
-  id: string;
+        
+    
+        group_mentions?:| "all" | "none" ;
 
-  /**
-   * Name/type of the collection
-   */
-  name: string;
+        
+    
+        here_mentions?:| "all" | "none" ;
 
-  /**
-   * When the collection was created
-   */
-  created_at?: Date;
+        
+    
+        role_mentions?:| "all" | "none" ;
 
-  /**
-   * When the collection was last updated
-   */
-  updated_at?: Date;
+        
+    
+        thread_replies?:| "all" | "none" ;
 
-  /**
-   * ID of the user who owns this collection
-   */
-  user_id?: string;
+        }
+    
 
-  /**
-   * Custom data for the collection
-   */
-  custom?: Record<string, any>;
-}
 
-export interface Command {
-  /**
-   * Arguments help text, shown in commands auto-completion
-   */
-  args: string;
 
-  /**
-   * Description, shown in commands auto-completion
-   */
-  description: string;
 
-  /**
-   * Unique command name
-   */
-  name: string;
+    export interface ChatPreferencesResponse {
+    channel_mentions?: string;
+    
 
-  /**
-   * Set name used for grouping commands
-   */
-  set: string;
+        
+    default_preference?: string;
+    
 
-  /**
-   * Date/time of creation
-   */
-  created_at?: Date;
+        
+    direct_mentions?: string;
+    
 
-  /**
-   * Date/time of the last update
-   */
-  updated_at?: Date;
-}
+        
+    group_mentions?: string;
+    
 
-export interface CommentAddedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    here_mentions?: string;
+    
 
-  fid: string;
+        
+    role_mentions?: string;
+    
 
-  activity: ActivityResponse;
+        
+    thread_replies?: string;
+    
 
-  comment: CommentResponse;
+        }
+    
 
-  custom: Record<string, any>;
 
-  /**
-   * The type of event: "feeds.comment.added" in this case
-   */
-  type: string;
 
-  feed_visibility?: string;
 
-  received_at?: Date;
+    export interface ChatReactionGroupResponse {
+    count: number;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    first_reaction_at: Date;
+    
 
-export interface CommentDeletedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    last_reaction_at: Date;
+    
 
-  fid: string;
+        
+    sum_scores: number;
+    
 
-  comment: CommentResponse;
+        
+    latest_reactions_by: Array<ChatReactionGroupUserResponse>;
+    
 
-  custom: Record<string, any>;
+        }
+    
 
-  /**
-   * The type of event: "feeds.comment.deleted" in this case
-   */
-  type: string;
 
-  feed_visibility?: string;
 
-  received_at?: Date;
 
-  user?: UserResponseCommonFields;
-}
+    export interface ChatReactionGroupUserResponse {
+    created_at: Date;
+    
 
-export interface CommentReactionAddedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    user_id: string;
+    
 
-  fid: string;
+        
+    user?: UserResponse;
+    
 
-  activity: ActivityResponse;
+        }
+    
 
-  comment: CommentResponse;
 
-  custom: Record<string, any>;
 
-  reaction: FeedsReactionResponse;
 
-  /**
-   * The type of event: "feeds.comment.reaction.added" in this case
-   */
-  type: string;
+    export interface ChatReactionResponse {
+    created_at: Date;
+    
 
-  feed_visibility?: string;
+        
+    message_id: string;
+    
 
-  received_at?: Date;
+        
+    score: number;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    type: string;
+    
 
-export interface CommentReactionDeletedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    updated_at: Date;
+    
 
-  fid: string;
+        
+    user_id: string;
+    
 
-  comment: CommentResponse;
+        
+    custom: Record<string, any>;
+    
 
-  custom: Record<string, any>;
+        
+    user: UserResponse;
+    
 
-  reaction: FeedsReactionResponse;
+        }
+    
 
-  /**
-   * The type of reaction that was removed
-   */
-  type: string;
 
-  feed_visibility?: string;
 
-  received_at?: Date;
-}
 
-export interface CommentReactionUpdatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+    export interface ChatReminderResponseData {
+    channel_cid: string;
+    
 
-  fid: string;
+        
+    created_at: Date;
+    
 
-  activity: ActivityResponse;
+        
+    message_id: string;
+    
 
-  comment: CommentResponse;
+        
+    updated_at: Date;
+    
 
-  custom: Record<string, any>;
+        
+    user_id: string;
+    
 
-  reaction: FeedsReactionResponse;
+        
+    remind_at?: Date;
+    
 
-  /**
-   * The type of event: "feeds.comment.reaction.updated" in this case
-   */
-  type: string;
+        
+    message?: ChatMessageResponse;
+    
 
-  feed_visibility?: string;
+        
+    user?: UserResponse;
+    
 
-  received_at?: Date;
+        }
+    
 
-  user?: UserResponseCommonFields;
-}
 
-export interface CommentResponse {
-  bookmark_count: number;
 
-  /**
-   * Confidence score of the comment
-   */
-  confidence_score: number;
 
-  /**
-   * When the comment was created
-   */
-  created_at: Date;
+    export interface ChatSharedLocationResponseData {
+    channel_cid: string;
+    
 
-  /**
-   * Number of downvotes for this comment
-   */
-  downvote_count: number;
+        
+    created_at: Date;
+    
 
-  /**
-   * Unique identifier for the comment
-   */
-  id: string;
+        
+    created_by_device_id: string;
+    
 
-  /**
-   * ID of the object this comment is associated with
-   */
-  object_id: string;
+        
+    latitude: number;
+    
 
-  /**
-   * Type of the object this comment is associated with
-   */
-  object_type: string;
+        
+    longitude: number;
+    
 
-  /**
-   * Number of reactions to this comment
-   */
-  reaction_count: number;
+        
+    message_id: string;
+    
 
-  /**
-   * Number of replies to this comment
-   */
-  reply_count: number;
+        
+    updated_at: Date;
+    
 
-  /**
-   * Score of the comment based on reactions
-   */
-  score: number;
+        
+    user_id: string;
+    
 
-  /**
-   * Status of the comment. One of: active, deleted, removed, hidden
-   */
+        
+    end_at?: Date;
+    
 
-  status: 'active' | 'deleted' | 'removed' | 'hidden' | 'shadow_blocked';
+        
+    message?: ChatMessageResponse;
+    
 
-  /**
-   * When the comment was last updated
-   */
-  updated_at: Date;
+        }
+    
 
-  /**
-   * Number of upvotes for this comment
-   */
-  upvote_count: number;
 
-  /**
-   * Users mentioned in the comment
-   */
-  mentioned_users: UserResponse[];
 
-  /**
-   * Current user's reactions to this activity
-   */
-  own_reactions: FeedsReactionResponse[];
 
-  user: UserResponse;
+    export interface ClosedCaptionRuleParameters {
+    threshold?: number;
+    
 
-  /**
-   * Controversy score of the comment
-   */
-  controversy_score?: number;
+        
+    harm_labels?: Array<string>;
+    
 
-  /**
-   * When the comment was deleted
-   */
-  deleted_at?: Date;
+        
+    llm_harm_labels?: Record<string, string>;
+    
 
-  /**
-   * When the comment was last edited
-   */
-  edited_at?: Date;
+        }
+    
 
-  /**
-   * ID of parent comment for nested replies
-   */
-  parent_id?: string;
 
-  /**
-   * Text content of the comment
-   */
-  text?: string;
 
-  /**
-   * Attachments associated with the comment
-   */
-  attachments?: Attachment[];
 
-  /**
-   * Recent reactions to the comment
-   */
-  latest_reactions?: FeedsReactionResponse[];
+    export interface CollectionRequest {
+    /**
+     * Name/type of the collection
+     */
+    name: string;
+    
 
-  /**
-   * Custom data for the comment
-   */
-  custom?: Record<string, any>;
+        
+    /**
+     * Custom data for the collection (required, must contain at least one key)
+     */
+    custom: Record<string, any>;
+    
 
-  moderation?: ModerationV2Response;
+        
+    /**
+     * Unique identifier for the collection within its name (optional, will be auto-generated if not provided)
+     */
+    id?: string;
+    
 
-  /**
-   * Grouped reactions by type
-   */
-  reaction_groups?: Record<string, FeedsReactionGroupResponse>;
-}
+        }
+    
 
-export interface CommentRestoredEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  fid: string;
 
-  comment: CommentResponse;
 
-  custom: Record<string, any>;
+    export interface CollectionResponse {
+    /**
+     * Unique identifier for the collection within its name
+     */
+    id: string;
+    
 
-  /**
-   * The type of event: "feeds.comment.restored" in this case
-   */
-  type: string;
+        
+    /**
+     * Name/type of the collection
+     */
+    name: string;
+    
 
-  feed_visibility?: string;
+        
+    /**
+     * When the collection was created
+     */
+    created_at?: Date;
+    
 
-  received_at?: Date;
+        
+    /**
+     * When the collection was last updated
+     */
+    updated_at?: Date;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    /**
+     * ID of the user who owns this collection
+     */
+    user_id?: string;
+    
 
-export interface CommentUpdatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    /**
+     * Custom data for the collection
+     */
+    custom?: Record<string, any>;
+    
 
-  fid: string;
+        }
+    
 
-  comment: CommentResponse;
 
-  custom: Record<string, any>;
 
-  /**
-   * The type of event: "feeds.comment.updated" in this case
-   */
-  type: string;
 
-  feed_visibility?: string;
+    export interface Command {
+    /**
+     * Arguments help text, shown in commands auto-completion
+     */
+    args: string;
+    
 
-  received_at?: Date;
+        
+    /**
+     * Description, shown in commands auto-completion
+     */
+    description: string;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    /**
+     * Unique command name
+     */
+    name: string;
+    
 
-export interface CompositeRecordingResponse {
-  status: string;
-}
+        
+    /**
+     * Set name used for grouping commands
+     */
+    set: string;
+    
 
-export interface ConfigResponse {
-  /**
-   * Whether moderation should be performed asynchronously
-   */
-  async: boolean;
+        
+    /**
+     * Date/time of creation
+     */
+    created_at?: Date;
+    
 
-  /**
-   * When the configuration was created
-   */
-  created_at: Date;
+        
+    /**
+     * Date/time of the last update
+     */
+    updated_at?: Date;
+    
 
-  /**
-   * Unique identifier for the moderation configuration
-   */
-  key: string;
+        }
+    
 
-  /**
-   * Team associated with the configuration
-   */
-  team: string;
 
-  /**
-   * When the configuration was last updated
-   */
-  updated_at: Date;
 
-  supported_video_call_harm_types: string[];
 
-  /**
-   * Configurable image moderation label definitions for dashboard rendering
-   */
-  ai_image_label_definitions?: AIImageLabelDefinition[];
+    export interface CommentAddedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  ai_image_config?: AIImageConfig;
+        
+    fid: string;
+    
 
-  /**
-   * Available L2 subclassifications per L1 image moderation label, based on the active provider
-   */
-  ai_image_subclassifications?: Record<string, string[]>;
+        
+    activity: ActivityResponse;
+    
 
-  ai_text_config?: AITextConfig;
+        
+    comment: CommentResponse;
+    
 
-  ai_video_config?: AIVideoConfig;
+        
+    custom: Record<string, any>;
+    
 
-  automod_platform_circumvention_config?: AutomodPlatformCircumventionConfig;
+        
+    /**
+     * The type of event: "feeds.comment.added" in this case
+     */
+    type: string;
+    
 
-  automod_semantic_filters_config?: AutomodSemanticFiltersConfig;
+        
+    feed_visibility?: string;
+    
 
-  automod_toxicity_config?: AutomodToxicityConfig;
+        
+    received_at?: Date;
+    
 
-  block_list_config?: BlockListConfig;
+        
+    user?: UserResponseCommonFields;
+    
 
-  llm_config?: LLMConfig;
+        }
+    
 
-  velocity_filter_config?: VelocityFilterConfig;
 
-  video_call_rule_config?: VideoCallRuleConfig;
-}
 
-export interface ConnectUserDetailsRequest {
-  id: string;
 
-  image?: string;
+    export interface CommentDeletedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  invisible?: boolean;
+        
+    fid: string;
+    
 
-  language?: string;
+        
+    comment: CommentResponse;
+    
 
-  name?: string;
+        
+    custom: Record<string, any>;
+    
 
-  custom?: Record<string, any>;
+        
+    /**
+     * The type of event: "feeds.comment.deleted" in this case
+     */
+    type: string;
+    
 
-  privacy_settings?: PrivacySettingsResponse;
-}
+        
+    feed_visibility?: string;
+    
 
-export interface ContentCountRuleParameters {
-  threshold?: number;
+        
+    received_at?: Date;
+    
 
-  time_window?: string;
-}
+        
+    user?: UserResponseCommonFields;
+    
 
-export interface CreateBlockListRequest {
-  /**
-   * Block list name
-   */
-  name: string;
+        }
+    
 
-  /**
-   * List of words to block
-   */
-  words: string[];
 
-  is_leet_check_enabled?: boolean;
 
-  is_plural_check_enabled?: boolean;
 
-  team?: string;
+    export interface CommentReactionAddedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  /**
-   * Block list type. One of: regex, domain, domain_allowlist, email, email_allowlist, word
-   */
+        
+    fid: string;
+    
 
-  type?:
-    | 'regex'
-    | 'domain'
-    | 'domain_allowlist'
-    | 'email'
-    | 'email_allowlist'
-    | 'word';
-}
+        
+    activity: ActivityResponse;
+    
 
-export interface CreateBlockListResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        
+    comment: CommentResponse;
+    
 
-  blocklist?: BlockListResponse;
-}
+        
+    custom: Record<string, any>;
+    
 
-export interface CreateCollectionsRequest {
-  /**
-   * List of collections to create
-   */
-  collections: CollectionRequest[];
-}
+        
+    reaction: FeedsReactionResponse;
+    
 
-export interface CreateCollectionsResponse {
-  duration: string;
+        
+    /**
+     * The type of event: "feeds.comment.reaction.added" in this case
+     */
+    type: string;
+    
 
-  /**
-   * List of created collections
-   */
-  collections: CollectionResponse[];
-}
+        
+    feed_visibility?: string;
+    
 
-export interface CreateDeviceRequest {
-  /**
-   * Device ID
-   */
-  id: string;
+        
+    received_at?: Date;
+    
 
-  /**
-   * Push provider
-   */
+        
+    user?: UserResponseCommonFields;
+    
 
-  push_provider: 'firebase' | 'apn' | 'huawei' | 'xiaomi';
+        }
+    
 
-  /**
-   * Push provider name
-   */
-  push_provider_name?: string;
 
-  /**
-   * When true the token is for Apple VoIP push notifications
-   */
-  voip_token?: boolean;
-}
 
-export interface CreateFeedsBatchRequest {
-  /**
-   * List of feeds to create
-   */
-  feeds: FeedRequest[];
 
-  /**
-   * If true, enriches the created feeds with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-   */
-  enrich_own_fields?: boolean;
-}
+    export interface CommentReactionDeletedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-export interface CreateFeedsBatchResponse {
-  duration: string;
+        
+    fid: string;
+    
 
-  /**
-   * List of created feeds
-   */
-  feeds: FeedResponse[];
-}
+        
+    comment: CommentResponse;
+    
 
-export interface CreateGuestRequest {
-  user: UserRequest;
-}
+        
+    custom: Record<string, any>;
+    
 
-export interface CreateGuestResponse {
-  /**
-   * the access token to authenticate the user
-   */
-  access_token: string;
+        
+    reaction: FeedsReactionResponse;
+    
 
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        
+    /**
+     * The type of reaction that was removed
+     */
+    type: string;
+    
 
-  user: UserResponse;
-}
+        
+    feed_visibility?: string;
+    
 
-export interface CreatePollOptionRequest {
-  /**
-   * Option text
-   */
-  text: string;
+        
+    received_at?: Date;
+    
 
-  custom?: Record<string, any>;
-}
+        }
+    
 
-export interface CreatePollRequest {
-  /**
-   * The name of the poll
-   */
-  name: string;
 
-  /**
-   * Indicates whether users can suggest user defined answers
-   */
-  allow_answers?: boolean;
 
-  allow_user_suggested_options?: boolean;
 
-  /**
-   * A description of the poll
-   */
-  description?: string;
+    export interface CommentReactionUpdatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  /**
-   * Indicates whether users can cast multiple votes
-   */
-  enforce_unique_vote?: boolean;
+        
+    fid: string;
+    
 
-  id?: string;
+        
+    activity: ActivityResponse;
+    
 
-  /**
-   * Indicates whether the poll is open for voting
-   */
-  is_closed?: boolean;
+        
+    comment: CommentResponse;
+    
 
-  /**
-   * Indicates the maximum amount of votes a user can cast
-   */
-  max_votes_allowed?: number;
+        
+    custom: Record<string, any>;
+    
 
-  voting_visibility?: 'anonymous' | 'public';
+        
+    reaction: FeedsReactionResponse;
+    
 
-  options?: PollOptionInput[];
+        
+    /**
+     * The type of event: "feeds.comment.reaction.updated" in this case
+     */
+    type: string;
+    
 
-  custom?: Record<string, any>;
-}
+        
+    feed_visibility?: string;
+    
 
-export interface CreateUserGroupRequest {
-  /**
-   * The user friendly name of the user group
-   */
-  name: string;
+        
+    received_at?: Date;
+    
 
-  /**
-   * An optional description for the group
-   */
-  description?: string;
+        
+    user?: UserResponseCommonFields;
+    
 
-  /**
-   * Optional user group ID. If not provided, a UUID v7 will be generated
-   */
-  id?: string;
+        }
+    
 
-  /**
-   * Optional team ID to scope the group to a team
-   */
-  team_id?: string;
 
-  /**
-   * Optional initial list of user IDs to add as members
-   */
-  member_ids?: string[];
-}
 
-export interface CreateUserGroupResponse {
-  duration: string;
 
-  user_group?: UserGroupResponse;
-}
+    export interface CommentResponse {
+    bookmark_count: number;
+    
 
-export interface CustomActionRequestPayload {
-  /**
-   * Custom action identifier
-   */
-  id?: string;
+        
+    /**
+     * Confidence score of the comment
+     */
+    confidence_score: number;
+    
 
-  /**
-   * Custom action options
-   */
-  options?: Record<string, any>;
-}
+        
+    /**
+     * When the comment was created
+     */
+    created_at: Date;
+    
 
-export interface Data {
-  id: string;
-}
+        
+    /**
+     * Number of downvotes for this comment
+     */
+    downvote_count: number;
+    
 
-export interface DecayFunctionConfig {
-  base?: string;
+        
+    /**
+     * Unique identifier for the comment
+     */
+    id: string;
+    
 
-  decay?: string;
+        
+    /**
+     * ID of the object this comment is associated with
+     */
+    object_id: string;
+    
 
-  direction?: string;
+        
+    /**
+     * Type of the object this comment is associated with
+     */
+    object_type: string;
+    
 
-  offset?: string;
+        
+    /**
+     * Number of reactions to this comment
+     */
+    reaction_count: number;
+    
 
-  origin?: string;
+        
+    /**
+     * Number of replies to this comment
+     */
+    reply_count: number;
+    
 
-  scale?: string;
-}
+        
+    /**
+     * Score of the comment based on reactions
+     */
+    score: number;
+    
 
-export interface DeleteActivitiesRequest {
-  /**
-   * List of activity IDs to delete
-   */
-  ids: string[];
+        
+    /**
+     * Status of the comment. One of: active, deleted, removed, hidden
+     */
+    
+        status:| "active" | "deleted" | "removed" | "hidden" | "shadow_blocked" ;
 
-  /**
-   * Whether to also delete any notification activities created from mentions in these activities
-   */
-  delete_notification_activity?: boolean;
+        
+    /**
+     * When the comment was last updated
+     */
+    updated_at: Date;
+    
 
-  /**
-   * Whether to permanently delete the activities
-   */
-  hard_delete?: boolean;
-}
+        
+    /**
+     * Number of upvotes for this comment
+     */
+    upvote_count: number;
+    
 
-export interface DeleteActivitiesResponse {
-  duration: string;
+        
+    /**
+     * Users mentioned in the comment
+     */
+    mentioned_users: Array<UserResponse>;
+    
 
-  /**
-   * List of activity IDs that were successfully deleted
-   */
-  deleted_ids: string[];
-}
+        
+    /**
+     * Current user's reactions to this activity
+     */
+    own_reactions: Array<FeedsReactionResponse>;
+    
 
-export interface DeleteActivityReactionResponse {
-  duration: string;
+        
+    user: UserResponse;
+    
 
-  activity: ActivityResponse;
+        
+    /**
+     * Controversy score of the comment
+     */
+    controversy_score?: number;
+    
 
-  reaction: FeedsReactionResponse;
-}
+        
+    /**
+     * When the comment was deleted
+     */
+    deleted_at?: Date;
+    
 
-export interface DeleteActivityRequestPayload {
-  /**
-   * ID of the activity to delete (alternative to item_id)
-   */
-  entity_id?: string;
+        
+    /**
+     * When the comment was last edited
+     */
+    edited_at?: Date;
+    
 
-  /**
-   * Type of the entity (required for delete_activity to distinguish v2 vs v3)
-   */
-  entity_type?: string;
+        
+    /**
+     * ID of parent comment for nested replies
+     */
+    parent_id?: string;
+    
 
-  /**
-   * Whether to permanently delete the activity
-   */
-  hard_delete?: boolean;
+        
+    /**
+     * Text content of the comment
+     */
+    text?: string;
+    
 
-  /**
-   * Reason for deletion
-   */
-  reason?: string;
-}
+        
+    /**
+     * Attachments associated with the comment
+     */
+    attachments?: Array<Attachment>;
+    
 
-export interface DeleteActivityResponse {
-  duration: string;
-}
+        
+    /**
+     * Recent reactions to the comment
+     */
+    latest_reactions?: Array<FeedsReactionResponse>;
+    
 
-export interface DeleteBookmarkFolderResponse {
-  duration: string;
-}
+        
+    /**
+     * Custom data for the comment
+     */
+    custom?: Record<string, any>;
+    
 
-export interface DeleteBookmarkResponse {
-  duration: string;
+        
+    moderation?: ModerationV2Response;
+    
 
-  bookmark: BookmarkResponse;
-}
+        
+    /**
+     * Grouped reactions by type
+     */
+    reaction_groups?: Record<string, FeedsReactionGroupResponse>;
+    
 
-export interface DeleteCollectionsResponse {
-  duration: string;
-}
+        }
+    
 
-export interface DeleteCommentBookmarkResponse {
-  duration: string;
 
-  bookmark: BookmarkResponse;
-}
 
-export interface DeleteCommentReactionResponse {
-  duration: string;
 
-  comment: CommentResponse;
+    export interface CommentRestoredEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  reaction: FeedsReactionResponse;
-}
+        
+    fid: string;
+    
 
-export interface DeleteCommentRequestPayload {
-  /**
-   * ID of the comment to delete (alternative to item_id)
-   */
-  entity_id?: string;
+        
+    comment: CommentResponse;
+    
 
-  /**
-   * Type of the entity
-   */
-  entity_type?: string;
+        
+    custom: Record<string, any>;
+    
 
-  /**
-   * Whether to permanently delete the comment
-   */
-  hard_delete?: boolean;
+        
+    /**
+     * The type of event: "feeds.comment.restored" in this case
+     */
+    type: string;
+    
 
-  /**
-   * Reason for deletion
-   */
-  reason?: string;
-}
+        
+    feed_visibility?: string;
+    
 
-export interface DeleteCommentResponse {
-  duration: string;
+        
+    received_at?: Date;
+    
 
-  activity: ActivityResponse;
+        
+    user?: UserResponseCommonFields;
+    
 
-  comment: CommentResponse;
-}
+        }
+    
 
-export interface DeleteFeedResponse {
-  duration: string;
 
-  /**
-   * The ID of the async task that will handle feed cleanup and hard deletion
-   */
-  task_id: string;
-}
 
-export interface DeleteMessageRequestPayload {
-  /**
-   * ID of the message to delete (alternative to item_id)
-   */
-  entity_id?: string;
 
-  /**
-   * Type of the entity
-   */
-  entity_type?: string;
+    export interface CommentUpdatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  /**
-   * Whether to permanently delete the message
-   */
-  hard_delete?: boolean;
+        
+    fid: string;
+    
 
-  /**
-   * Reason for deletion
-   */
-  reason?: string;
-}
+        
+    comment: CommentResponse;
+    
 
-export interface DeleteModerationConfigResponse {
-  duration: string;
-}
+        
+    custom: Record<string, any>;
+    
 
-export interface DeleteReactionRequestPayload {
-  /**
-   * ID of the reaction to delete (alternative to item_id)
-   */
-  entity_id?: string;
+        
+    /**
+     * The type of event: "feeds.comment.updated" in this case
+     */
+    type: string;
+    
 
-  /**
-   * Type of the entity
-   */
-  entity_type?: string;
+        
+    feed_visibility?: string;
+    
 
-  /**
-   * Whether to permanently delete the reaction
-   */
-  hard_delete?: boolean;
+        
+    received_at?: Date;
+    
 
-  /**
-   * Reason for deletion
-   */
-  reason?: string;
-}
+        
+    user?: UserResponseCommonFields;
+    
 
-export interface DeleteUserRequestPayload {
-  /**
-   * Also delete all user conversations
-   */
-  delete_conversation_channels?: boolean;
+        }
+    
 
-  /**
-   * Delete flagged feeds content
-   */
-  delete_feeds_content?: boolean;
 
-  /**
-   * ID of the user to delete (alternative to item_id)
-   */
-  entity_id?: string;
 
-  /**
-   * Type of the entity
-   */
-  entity_type?: string;
 
-  /**
-   * Whether to permanently delete the user
-   */
-  hard_delete?: boolean;
+    export interface ConfigResponse {
+    /**
+     * Whether moderation should be performed asynchronously
+     */
+    async: boolean;
+    
 
-  /**
-   * Also delete all user messages
-   */
-  mark_messages_deleted?: boolean;
+        
+    /**
+     * When the configuration was created
+     */
+    created_at: Date;
+    
 
-  /**
-   * Reason for deletion
-   */
-  reason?: string;
-}
+        
+    /**
+     * Unique identifier for the moderation configuration
+     */
+    key: string;
+    
 
-export interface DeliveryReceiptsResponse {
-  enabled: boolean;
-}
+        
+    /**
+     * Team associated with the configuration
+     */
+    team: string;
+    
 
-export interface DeviceResponse {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    /**
+     * When the configuration was last updated
+     */
+    updated_at: Date;
+    
 
-  /**
-   * Device ID
-   */
-  id: string;
+        
+    supported_video_call_harm_types: Array<string>;
+    
 
-  /**
-   * Push provider
-   */
-  push_provider: string;
+        
+    /**
+     * Configurable image moderation label definitions for dashboard rendering
+     */
+    ai_image_label_definitions?: Array<AIImageLabelDefinition>;
+    
 
-  /**
-   * User ID
-   */
-  user_id: string;
+        
+    /**
+     * Names of Bodyguard credential profiles registered on this app. The dashboard uses this list to render the profile picker on the AI Text section.
+     */
+    available_bodyguard_profiles?: Array<BodyguardProfileSummary>;
+    
 
-  /**
-   * Whether device is disabled or not
-   */
-  disabled?: boolean;
+        
+    ai_image_config?: AIImageConfig;
+    
 
-  /**
-   * Reason explaining why device had been disabled
-   */
-  disabled_reason?: string;
+        
+    /**
+     * Available L2 subclassifications per L1 image moderation label, based on the active provider
+     */
+    ai_image_subclassifications?: Record<string, Array<string>>;
+    
 
-  /**
-   * Push provider name
-   */
-  push_provider_name?: string;
+        
+    ai_text_config?: AITextConfig;
+    
 
-  /**
-   * When true the token is for Apple VoIP push notifications
-   */
-  voip?: boolean;
-}
+        
+    ai_video_config?: AIVideoConfig;
+    
 
-export interface DraftPayloadResponse {
-  /**
-   * Message ID is unique string identifier of the message
-   */
-  id: string;
+        
+    automod_platform_circumvention_config?: AutomodPlatformCircumventionConfig;
+    
 
-  /**
-   * Text of the message
-   */
-  text: string;
+        
+    automod_semantic_filters_config?: AutomodSemanticFiltersConfig;
+    
 
-  custom: Record<string, any>;
+        
+    automod_toxicity_config?: AutomodToxicityConfig;
+    
 
-  /**
-   * Contains HTML markup of the message
-   */
-  html?: string;
+        
+    block_list_config?: BlockListConfig;
+    
 
-  /**
-   * MML content of the message
-   */
-  mml?: string;
+        
+    llm_config?: LLMConfig;
+    
 
-  /**
-   * ID of parent message (thread)
-   */
-  parent_id?: string;
+        
+    velocity_filter_config?: VelocityFilterConfig;
+    
 
-  /**
-   * Identifier of the poll to include in the message
-   */
-  poll_id?: string;
+        
+    video_call_rule_config?: VideoCallRuleConfig;
+    
 
-  quoted_message_id?: string;
+        }
+    
 
-  /**
-   * Whether thread reply should be shown in the channel as well
-   */
-  show_in_channel?: boolean;
 
-  /**
-   * Whether message is silent or not
-   */
-  silent?: boolean;
 
-  /**
-   * Contains type of the message. One of: regular, system
-   */
-  type?: string;
 
-  /**
-   * Array of message attachments
-   */
-  attachments?: Attachment[];
+    export interface ConnectUserDetailsRequest {
+    id: string;
+    
 
-  /**
-   * List of mentioned users
-   */
-  mentioned_users?: UserResponse[];
-}
+        
+    image?: string;
+    
 
-export interface DraftResponse {
-  channel_cid: string;
+        
+    invisible?: boolean;
+    
 
-  created_at: Date;
+        
+    language?: string;
+    
 
-  message: DraftPayloadResponse;
+        
+    name?: string;
+    
 
-  parent_id?: string;
+        
+    custom?: Record<string, any>;
+    
 
-  channel?: ChannelResponse;
+        
+    privacy_settings?: PrivacySettingsResponse;
+    
 
-  parent_message?: MessageResponse;
+        }
+    
 
-  quoted_message?: MessageResponse;
-}
 
-export interface EgressHLSResponse {
-  playlist_url: string;
 
-  status: string;
-}
 
-export interface EgressRTMPResponse {
-  name: string;
+    export interface ContentCountRuleParameters {
+    threshold?: number;
+    
 
-  started_at: Timestamp;
+        
+    time_window?: string;
+    
 
-  stream_key?: string;
+        }
+    
 
-  stream_url?: string;
-}
 
-export interface EgressResponse {
-  broadcasting: boolean;
 
-  rtmps: EgressRTMPResponse[];
 
-  composite_recording?: CompositeRecordingResponse;
+    export interface CreateBlockListRequest {
+    /**
+     * Block list name
+     */
+    name: string;
+    
 
-  frame_recording?: FrameRecordingResponse;
+        
+    /**
+     * List of words to block
+     */
+    words: Array<string>;
+    
 
-  hls?: EgressHLSResponse;
+        
+    is_leet_check_enabled?: boolean;
+    
 
-  individual_recording?: IndividualRecordingResponse;
+        
+    is_plural_check_enabled?: boolean;
+    
 
-  raw_recording?: RawRecordingResponse;
-}
+        
+    team?: string;
+    
 
-export interface EnrichedActivity {
-  foreign_id?: string;
+        
+    /**
+     * Block list type. One of: regex, domain, domain_allowlist, email, email_allowlist, word
+     */
+    
+        type?:| "regex" | "domain" | "domain_allowlist" | "email" | "email_allowlist" | "word" ;
 
-  id?: string;
+        }
+    
 
-  score?: number;
 
-  verb?: string;
 
-  to?: string[];
 
-  actor?: Data;
+    export interface CreateBlockListResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  latest_reactions?: Record<string, EnrichedReaction[]>;
+        
+    blocklist?: BlockListResponse;
+    
 
-  object?: Data;
+        }
+    
 
-  origin?: Data;
 
-  own_reactions?: Record<string, EnrichedReaction[]>;
 
-  reaction_counts?: Record<string, number>;
 
-  target?: Data;
-}
+    export interface CreateCollectionsRequest {
+    /**
+     * List of collections to create
+     */
+    collections: Array<CollectionRequest>;
+    
 
-export interface EnrichedCollection {
-  created_at: Date;
+        }
+    
 
-  id: string;
 
-  name: string;
 
-  status: string;
 
-  updated_at: Date;
+    export interface CreateCollectionsResponse {
+    duration: string;
+    
 
-  user_id: string;
+        
+    /**
+     * List of created collections
+     */
+    collections: Array<CollectionResponse>;
+    
 
-  custom: Record<string, any>;
-}
+        }
+    
 
-export interface EnrichedCollectionResponse {
-  /**
-   * Unique identifier for the collection within its name
-   */
-  id: string;
 
-  /**
-   * Name/type of the collection
-   */
-  name: string;
 
-  /**
-   * Enrichment status of the collection. One of: ok, notfound
-   */
 
-  status: 'ok' | 'notfound';
+    export interface CreateDeviceRequest {
+    /**
+     * Device ID
+     */
+    id: string;
+    
 
-  /**
-   * When the collection was created
-   */
-  created_at?: Date;
+        
+    /**
+     * Push provider
+     */
+    
+        push_provider:| "firebase" | "apn" | "huawei" | "xiaomi" ;
 
-  /**
-   * When the collection was last updated
-   */
-  updated_at?: Date;
+        
+    /**
+     * Push provider name
+     */
+    push_provider_name?: string;
+    
 
-  /**
-   * ID of the user who owns this collection
-   */
-  user_id?: string;
+        
+    /**
+     * When true the token is for Apple VoIP push notifications
+     */
+    voip_token?: boolean;
+    
 
-  /**
-   * Custom data for the collection
-   */
-  custom?: Record<string, any>;
-}
+        }
+    
 
-export interface EnrichedReaction {
-  activity_id: string;
 
-  kind: string;
 
-  user_id: string;
 
-  id?: string;
+    export interface CreateFeedsBatchRequest {
+    /**
+     * List of feeds to create
+     */
+    feeds: Array<FeedRequest>;
+    
 
-  parent?: string;
+        
+    /**
+     * If true, enriches the created feeds with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+     */
+    enrich_own_fields?: boolean;
+    
 
-  target_feeds?: string[];
+        }
+    
 
-  children_counts?: Record<string, number>;
 
-  created_at?: Time;
 
-  data?: Record<string, any>;
 
-  latest_children?: Record<string, EnrichedReaction[]>;
+    export interface CreateFeedsBatchResponse {
+    duration: string;
+    
 
-  own_children?: Record<string, EnrichedReaction[]>;
+        
+    /**
+     * List of created feeds
+     */
+    feeds: Array<FeedResponse>;
+    
 
-  updated_at?: Time;
+        }
+    
 
-  user?: Data;
-}
 
-export interface EnrichmentOptions {
-  /**
-   * Default: false. When true, includes fetching and enriching own_followings (follows where activity author's feeds follow current user's feeds).
-   */
-  enrich_own_followings?: boolean;
 
-  /**
-   * Default: false. When true, includes score_vars in activity responses containing variable values used at ranking time.
-   */
-  include_score_vars?: boolean;
 
-  /**
-   * Default: false. When true, skips all activity enrichments.
-   */
-  skip_activity?: boolean;
+    export interface CreateGuestRequest {
+    user: UserRequest;
+    
 
-  /**
-   * Default: false. When true, skips enriching collections on activities.
-   */
-  skip_activity_collections?: boolean;
+        }
+    
 
-  /**
-   * Default: false. When true, skips enriching comments on activities.
-   */
-  skip_activity_comments?: boolean;
 
-  /**
-   * Default: false. When true, skips enriching current_feed on activities. Note: CurrentFeed is still computed for permission checks, but enrichment is skipped.
-   */
-  skip_activity_current_feed?: boolean;
 
-  /**
-   * Default: false. When true, skips enriching mentioned users on activities.
-   */
-  skip_activity_mentioned_users?: boolean;
 
-  /**
-   * Default: false. When true, skips enriching own bookmarks on activities.
-   */
-  skip_activity_own_bookmarks?: boolean;
+    export interface CreateGuestResponse {
+    /**
+     * the access token to authenticate the user
+     */
+    access_token: string;
+    
 
-  /**
-   * Default: false. When true, skips enriching parent activities.
-   */
-  skip_activity_parents?: boolean;
+        
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  /**
-   * Default: false. When true, skips enriching poll data on activities.
-   */
-  skip_activity_poll?: boolean;
+        
+    user: UserResponse;
+    
 
-  /**
-   * Default: false. When true, skips fetching and enriching latest and own reactions on activities. Note: If reactions are already denormalized in the database, they will still be included.
-   */
-  skip_activity_reactions?: boolean;
+        }
+    
 
-  /**
-   * Default: false. When true, skips refreshing image URLs on activities.
-   */
-  skip_activity_refresh_image_urls?: boolean;
 
-  /**
-   * Default: false. When true, skips all enrichments.
-   */
-  skip_all?: boolean;
 
-  /**
-   * Default: false. When true, skips enriching user data on feed members.
-   */
-  skip_feed_member_user?: boolean;
 
-  /**
-   * Default: false. When true, skips fetching and enriching followers. Note: If followers_pagination is explicitly provided, followers will be fetched regardless of this setting.
-   */
-  skip_followers?: boolean;
+    export interface CreatePollOptionRequest {
+    /**
+     * Option text
+     */
+    text: string;
+    
 
-  /**
-   * Default: false. When true, skips fetching and enriching following. Note: If following_pagination is explicitly provided, following will be fetched regardless of this setting.
-   */
-  skip_following?: boolean;
+        
+    custom?: Record<string, any>;
+    
 
-  /**
-   * Default: false. When true, skips computing and including capabilities for feeds.
-   */
-  skip_own_capabilities?: boolean;
+        }
+    
 
-  /**
-   * Default: false. When true, skips fetching and enriching own_follows (follows where user's feeds follow target feeds).
-   */
-  skip_own_follows?: boolean;
 
-  /**
-   * Default: false. When true, skips enriching pinned activities.
-   */
-  skip_pins?: boolean;
-}
 
-export interface EntityCreatorResponse {
-  /**
-   * Number of minor actions performed on the user
-   */
-  ban_count: number;
 
-  banned: boolean;
+    export interface CreatePollRequest {
+    /**
+     * The name of the poll
+     */
+    name: string;
+    
 
-  created_at: Date;
+        
+    /**
+     * Indicates whether users can suggest user defined answers
+     */
+    allow_answers?: boolean;
+    
 
-  /**
-   * Number of major actions performed on the user
-   */
-  deleted_content_count: number;
+        
+    allow_user_suggested_options?: boolean;
+    
 
-  /**
-   * Number of flag actions performed on the user
-   */
-  flagged_count: number;
+        
+    /**
+     * A description of the poll
+     */
+    description?: string;
+    
 
-  id: string;
+        
+    /**
+     * Indicates whether users can cast multiple votes
+     */
+    enforce_unique_vote?: boolean;
+    
 
-  language: string;
+        
+    id?: string;
+    
 
-  online: boolean;
+        
+    /**
+     * Indicates whether the poll is open for voting
+     */
+    is_closed?: boolean;
+    
 
-  role: string;
+        
+    /**
+     * Indicates the maximum amount of votes a user can cast
+     */
+    max_votes_allowed?: number;
+    
 
-  updated_at: Date;
+        
+    
+        voting_visibility?:| "anonymous" | "public" ;
 
-  blocked_user_ids: string[];
+        
+    options?: Array<PollOptionInput>;
+    
 
-  teams: string[];
+        
+    custom?: Record<string, any>;
+    
 
-  custom: Record<string, any>;
+        }
+    
 
-  avg_response_time?: number;
 
-  deactivated_at?: Date;
 
-  deleted_at?: Date;
 
-  image?: string;
+    export interface CreateUserGroupRequest {
+    /**
+     * The user friendly name of the user group
+     */
+    name: string;
+    
 
-  last_active?: Date;
+        
+    /**
+     * An optional description for the group
+     */
+    description?: string;
+    
 
-  name?: string;
+        
+    /**
+     * Optional user group ID. If not provided, a UUID v7 will be generated
+     */
+    id?: string;
+    
 
-  revoke_tokens_issued_before?: Date;
+        
+    /**
+     * Optional team ID to scope the group to a team
+     */
+    team_id?: string;
+    
 
-  teams_role?: Record<string, string>;
-}
+        
+    /**
+     * Optional initial list of user IDs to add as members
+     */
+    member_ids?: Array<string>;
+    
 
-export interface EscalatePayload {
-  /**
-   * Additional context for the reviewer
-   */
-  notes?: string;
+        }
+    
 
-  /**
-   * Priority of the escalation (low, medium, high)
-   */
-  priority?: string;
 
-  /**
-   * Reason for the escalation (from configured escalation_reasons)
-   */
-  reason?: string;
-}
 
-export interface EscalationMetadata {
-  notes?: string;
 
-  priority?: string;
+    export interface CreateUserGroupResponse {
+    duration: string;
+    
 
-  reason?: string;
-}
+        
+    user_group?: UserGroupResponse;
+    
 
-export interface FeedCreatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        }
+    
 
-  fid: string;
 
-  members: FeedMemberResponse[];
 
-  custom: Record<string, any>;
 
-  feed: FeedResponse;
+    export interface CustomActionRequestPayload {
+    /**
+     * Custom action identifier
+     */
+    id?: string;
+    
 
-  user: UserResponseCommonFields;
+        
+    /**
+     * Custom action options
+     */
+    options?: Record<string, any>;
+    
 
-  /**
-   * The type of event: "feeds.feed.created" in this case
-   */
-  type: string;
+        }
+    
 
-  feed_visibility?: string;
 
-  received_at?: Date;
-}
 
-export interface FeedDeletedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  fid: string;
+    export interface Data {
+    id: string;
+    
 
-  custom: Record<string, any>;
+        }
+    
 
-  /**
-   * The type of event: "feeds.feed.deleted" in this case
-   */
-  type: string;
 
-  feed_visibility?: string;
 
-  received_at?: Date;
 
-  user?: UserResponseCommonFields;
-}
+    export interface DecayFunctionConfig {
+    base?: string;
+    
 
-export interface FeedGroup {
-  aggregation_version: number;
+        
+    decay?: string;
+    
 
-  app_pk: number;
+        
+    direction?: string;
+    
 
-  created_at: Date;
+        
+    offset?: string;
+    
 
-  default_visibility: string;
+        
+    origin?: string;
+    
 
-  group_id: string;
+        
+    scale?: string;
+    
 
-  updated_at: Date;
+        }
+    
 
-  activity_processors: ActivityProcessorConfig[];
 
-  activity_selectors: ActivitySelectorConfig[];
 
-  custom: Record<string, any>;
 
-  deleted_at?: Date;
+    export interface DeleteActionConfigResponse {
+    /**
+     * Number of action configs deleted (0 or 1)
+     */
+    deleted: number;
+    
 
-  last_feed_get_at?: Date;
+        
+    duration: string;
+    
 
-  aggregation?: AggregationConfig;
+        }
+    
 
-  notification?: NotificationConfig;
 
-  push_notification?: PushNotificationConfig;
 
-  ranking?: RankingConfig;
 
-  stories?: StoriesConfig;
-}
+    export interface DeleteActivitiesRequest {
+    /**
+     * List of activity IDs to delete
+     */
+    ids: Array<string>;
+    
 
-export interface FeedGroupChangedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    /**
+     * Whether to also delete any notification activities created from mentions in these activities
+     */
+    delete_notification_activity?: boolean;
+    
 
-  fid: string;
+        
+    /**
+     * Whether to permanently delete the activities
+     */
+    hard_delete?: boolean;
+    
 
-  custom: Record<string, any>;
+        }
+    
 
-  /**
-   * The type of event: "feeds.feed_group.changed" in this case
-   */
-  type: string;
 
-  feed_visibility?: string;
 
-  received_at?: Date;
 
-  feed_group?: FeedGroup;
+    export interface DeleteActivitiesResponse {
+    duration: string;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    /**
+     * List of activity IDs that were successfully deleted
+     */
+    deleted_ids: Array<string>;
+    
 
-export interface FeedGroupDeletedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        }
+    
 
-  fid: string;
 
-  /**
-   * The ID of the feed group that was deleted
-   */
-  group_id: string;
 
-  custom: Record<string, any>;
 
-  /**
-   * The type of event: "feeds.feed_group.deleted" in this case
-   */
-  type: string;
+    export interface DeleteActivityReactionResponse {
+    duration: string;
+    
 
-  feed_visibility?: string;
+        
+    activity: ActivityResponse;
+    
 
-  received_at?: Date;
-}
+        
+    reaction: FeedsReactionResponse;
+    
 
-export interface FeedGroupRestoredEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        }
+    
 
-  fid: string;
 
-  /**
-   * The ID of the feed group that was restored
-   */
-  group_id: string;
 
-  custom: Record<string, any>;
 
-  /**
-   * The type of event: "feeds.feed_group.restored" in this case
-   */
-  type: string;
+    export interface DeleteActivityRequestPayload {
+    /**
+     * ID of the activity to delete (alternative to item_id)
+     */
+    entity_id?: string;
+    
 
-  feed_visibility?: string;
+        
+    /**
+     * Type of the entity (required for delete_activity to distinguish v2 vs v3)
+     */
+    entity_type?: string;
+    
 
-  received_at?: Date;
-}
+        
+    /**
+     * Whether to permanently delete the activity
+     */
+    hard_delete?: boolean;
+    
 
-export interface FeedInput {
-  description?: string;
+        
+    /**
+     * Reason for deletion
+     */
+    reason?: string;
+    
 
-  name?: string;
+        }
+    
 
-  visibility?: 'public' | 'visible' | 'followers' | 'members' | 'private';
 
-  filter_tags?: string[];
 
-  members?: FeedMemberRequest[];
 
-  custom?: Record<string, any>;
+    export interface DeleteActivityResponse {
+    duration: string;
+    
 
-  location?: Location;
-}
+        }
+    
 
-export interface FeedMemberAddedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  fid: string;
 
-  custom: Record<string, any>;
 
-  member: FeedMemberResponse;
+    export interface DeleteBookmarkFolderResponse {
+    duration: string;
+    
 
-  /**
-   * The type of event: "feeds.feed_member.added" in this case
-   */
-  type: string;
+        }
+    
 
-  feed_visibility?: string;
 
-  received_at?: Date;
 
-  user?: UserResponseCommonFields;
-}
 
-export interface FeedMemberRemovedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+    export interface DeleteBookmarkResponse {
+    duration: string;
+    
 
-  fid: string;
+        
+    bookmark: BookmarkResponse;
+    
 
-  member_id: string;
+        }
+    
 
-  custom: Record<string, any>;
 
-  /**
-   * The type of event: "feeds.feed_member.removed" in this case
-   */
-  type: string;
 
-  feed_visibility?: string;
 
-  received_at?: Date;
+    export interface DeleteCollectionsResponse {
+    duration: string;
+    
 
-  user?: UserResponseCommonFields;
-}
+        }
+    
 
-export interface FeedMemberRequest {
-  /**
-   * ID of the user to add as a member
-   */
-  user_id: string;
 
-  /**
-   * Whether this is an invite to become a member
-   */
-  invite?: boolean;
 
-  /**
-   * ID of the membership level to assign to the member
-   */
-  membership_level?: string;
 
-  /**
-   * Role of the member in the feed
-   */
-  role?: string;
+    export interface DeleteCommentBookmarkResponse {
+    duration: string;
+    
 
-  /**
-   * Custom data for the member
-   */
-  custom?: Record<string, any>;
-}
+        
+    bookmark: BookmarkResponse;
+    
 
-export interface FeedMemberResponse {
-  /**
-   * When the membership was created
-   */
-  created_at: Date;
+        }
+    
 
-  /**
-   * Role of the member in the feed
-   */
-  role: string;
 
-  /**
-   * Status of the membership. One of: member, pending, rejected
-   */
 
-  status: 'member' | 'pending' | 'rejected';
 
-  /**
-   * When the membership was last updated
-   */
-  updated_at: Date;
+    export interface DeleteCommentReactionResponse {
+    duration: string;
+    
 
-  user: UserResponse;
+        
+    comment: CommentResponse;
+    
 
-  /**
-   * When the invite was accepted
-   */
-  invite_accepted_at?: Date;
+        
+    reaction: FeedsReactionResponse;
+    
 
-  /**
-   * When the invite was rejected
-   */
-  invite_rejected_at?: Date;
+        }
+    
 
-  /**
-   * Custom data for the membership
-   */
-  custom?: Record<string, any>;
 
-  membership_level?: MembershipLevelResponse;
-}
 
-export interface FeedMemberUpdatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  fid: string;
+    export interface DeleteCommentRequestPayload {
+    /**
+     * ID of the comment to delete (alternative to item_id)
+     */
+    entity_id?: string;
+    
 
-  custom: Record<string, any>;
+        
+    /**
+     * Type of the entity
+     */
+    entity_type?: string;
+    
 
-  member: FeedMemberResponse;
+        
+    /**
+     * Whether to permanently delete the comment
+     */
+    hard_delete?: boolean;
+    
 
-  /**
-   * The type of event: "feeds.feed_member.updated" in this case
-   */
-  type: string;
+        
+    /**
+     * Reason for deletion
+     */
+    reason?: string;
+    
 
-  feed_visibility?: string;
+        }
+    
 
-  received_at?: Date;
 
-  user?: UserResponseCommonFields;
-}
+
+
+    export interface DeleteCommentResponse {
+    duration: string;
+    
+
+        
+    activity: ActivityResponse;
+    
+
+        
+    comment: CommentResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface DeleteFeedResponse {
+    duration: string;
+    
+
+        
+    /**
+     * The ID of the async task that will handle feed cleanup and hard deletion
+     */
+    task_id: string;
+    
+
+        }
+    
+
+
+
+
+    export interface DeleteMessageRequestPayload {
+    /**
+     * ID of the message to delete (alternative to item_id)
+     */
+    entity_id?: string;
+    
+
+        
+    /**
+     * Type of the entity
+     */
+    entity_type?: string;
+    
+
+        
+    /**
+     * Whether to permanently delete the message
+     */
+    hard_delete?: boolean;
+    
+
+        
+    /**
+     * Reason for deletion
+     */
+    reason?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface DeleteModerationConfigResponse {
+    duration: string;
+    
+
+        }
+    
+
+
+
+
+    export interface DeleteReactionRequestPayload {
+    /**
+     * ID of the reaction to delete (alternative to item_id)
+     */
+    entity_id?: string;
+    
+
+        
+    /**
+     * Type of the entity
+     */
+    entity_type?: string;
+    
+
+        
+    /**
+     * Whether to permanently delete the reaction
+     */
+    hard_delete?: boolean;
+    
+
+        
+    /**
+     * Reason for deletion
+     */
+    reason?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface DeleteUserRequestPayload {
+    /**
+     * Also delete all user conversations
+     */
+    delete_conversation_channels?: boolean;
+    
+
+        
+    /**
+     * Delete flagged feeds content
+     */
+    delete_feeds_content?: boolean;
+    
+
+        
+    /**
+     * ID of the user to delete (alternative to item_id)
+     */
+    entity_id?: string;
+    
+
+        
+    /**
+     * Type of the entity
+     */
+    entity_type?: string;
+    
+
+        
+    /**
+     * Whether to permanently delete the user
+     */
+    hard_delete?: boolean;
+    
+
+        
+    /**
+     * Also delete all user messages
+     */
+    mark_messages_deleted?: boolean;
+    
+
+        
+    /**
+     * Reason for deletion
+     */
+    reason?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface DeliveryReceiptsResponse {
+    enabled: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface DeviceResponse {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * Device ID
+     */
+    id: string;
+    
+
+        
+    /**
+     * Push provider
+     */
+    push_provider: string;
+    
+
+        
+    /**
+     * User ID
+     */
+    user_id: string;
+    
+
+        
+    /**
+     * Whether device is disabled or not
+     */
+    disabled?: boolean;
+    
+
+        
+    /**
+     * Reason explaining why device had been disabled
+     */
+    disabled_reason?: string;
+    
+
+        
+    /**
+     * Push provider name
+     */
+    push_provider_name?: string;
+    
+
+        
+    /**
+     * When true the token is for Apple VoIP push notifications
+     */
+    voip?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface DraftPayloadResponse {
+    /**
+     * Message ID is unique string identifier of the message
+     */
+    id: string;
+    
+
+        
+    /**
+     * Text of the message
+     */
+    text: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    /**
+     * Contains HTML markup of the message
+     */
+    html?: string;
+    
+
+        
+    /**
+     * MML content of the message
+     */
+    mml?: string;
+    
+
+        
+    /**
+     * ID of parent message (thread)
+     */
+    parent_id?: string;
+    
+
+        
+    /**
+     * Identifier of the poll to include in the message
+     */
+    poll_id?: string;
+    
+
+        
+    quoted_message_id?: string;
+    
+
+        
+    /**
+     * Whether thread reply should be shown in the channel as well
+     */
+    show_in_channel?: boolean;
+    
+
+        
+    /**
+     * Whether message is silent or not
+     */
+    silent?: boolean;
+    
+
+        
+    /**
+     * Contains type of the message. One of: regular, system
+     */
+    type?: string;
+    
+
+        
+    /**
+     * Array of message attachments
+     */
+    attachments?: Array<Attachment>;
+    
+
+        
+    /**
+     * List of mentioned users
+     */
+    mentioned_users?: Array<UserResponse>;
+    
+
+        }
+    
+
+
+
+
+    export interface DraftResponse {
+    channel_cid: string;
+    
+
+        
+    created_at: Date;
+    
+
+        
+    message: DraftPayloadResponse;
+    
+
+        
+    parent_id?: string;
+    
+
+        
+    channel?: ChannelResponse;
+    
+
+        
+    parent_message?: MessageResponse;
+    
+
+        
+    quoted_message?: MessageResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface EnrichedActivity {
+    foreign_id?: string;
+    
+
+        
+    id?: string;
+    
+
+        
+    score?: number;
+    
+
+        
+    verb?: string;
+    
+
+        
+    to?: Array<string>;
+    
+
+        
+    actor?: Data;
+    
+
+        
+    latest_reactions?: Record<string, Array<EnrichedReaction>>;
+    
+
+        
+    object?: Data;
+    
+
+        
+    origin?: Data;
+    
+
+        
+    own_reactions?: Record<string, Array<EnrichedReaction>>;
+    
+
+        
+    reaction_counts?: Record<string, number>;
+    
+
+        
+    target?: Data;
+    
+
+        }
+    
+
+
+
+
+    export interface EnrichedCollectionResponse {
+    /**
+     * Unique identifier for the collection within its name
+     */
+    id: string;
+    
+
+        
+    /**
+     * Name/type of the collection
+     */
+    name: string;
+    
+
+        
+    /**
+     * Enrichment status of the collection. One of: ok, notfound
+     */
+    
+        status:| "ok" | "notfound" ;
+
+        
+    /**
+     * When the collection was created
+     */
+    created_at?: Date;
+    
+
+        
+    /**
+     * When the collection was last updated
+     */
+    updated_at?: Date;
+    
+
+        
+    /**
+     * ID of the user who owns this collection
+     */
+    user_id?: string;
+    
+
+        
+    /**
+     * Custom data for the collection
+     */
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface EnrichedReaction {
+    activity_id: string;
+    
+
+        
+    kind: string;
+    
+
+        
+    user_id: string;
+    
+
+        
+    id?: string;
+    
+
+        
+    parent?: string;
+    
+
+        
+    target_feeds?: Array<string>;
+    
+
+        
+    children_counts?: Record<string, number>;
+    
+
+        
+    created_at?: Time;
+    
+
+        
+    data?: Record<string, any>;
+    
+
+        
+    latest_children?: Record<string, Array<EnrichedReaction>>;
+    
+
+        
+    own_children?: Record<string, Array<EnrichedReaction>>;
+    
+
+        
+    updated_at?: Time;
+    
+
+        
+    user?: Data;
+    
+
+        }
+    
+
+
+
+
+    export interface EnrichmentOptions {
+    /**
+     * Default: false. When true, includes fetching and enriching own_followings (follows where activity author's feeds follow current user's feeds).
+     */
+    enrich_own_followings?: boolean;
+    
+
+        
+    /**
+     * Controls the top-level flat 'activities' array for aggregated feeds. For new apps, defaults to false (excluded); set to true to include. For older apps, defaults to true (included) for backward compatibility; set to false to exclude.
+     */
+    include_flat_activities?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, includes score_vars in activity responses containing variable values used at ranking time.
+     */
+    include_score_vars?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips all activity enrichments.
+     */
+    skip_activity?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips enriching collections on activities.
+     */
+    skip_activity_collections?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips enriching comments on activities.
+     */
+    skip_activity_comments?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips enriching current_feed on activities. Note: CurrentFeed is still computed for permission checks, but enrichment is skipped.
+     */
+    skip_activity_current_feed?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips enriching mentioned users on activities.
+     */
+    skip_activity_mentioned_users?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips enriching own bookmarks on activities.
+     */
+    skip_activity_own_bookmarks?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips enriching parent activities.
+     */
+    skip_activity_parents?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips enriching poll data on activities.
+     */
+    skip_activity_poll?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips fetching and enriching latest and own reactions on activities. Note: If reactions are already denormalized in the database, they will still be included.
+     */
+    skip_activity_reactions?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips refreshing image URLs on activities.
+     */
+    skip_activity_refresh_image_urls?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips all enrichments.
+     */
+    skip_all?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips enriching user data on feed members.
+     */
+    skip_feed_member_user?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips fetching and enriching followers. Note: If followers_pagination is explicitly provided, followers will be fetched regardless of this setting.
+     */
+    skip_followers?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips fetching and enriching following. Note: If following_pagination is explicitly provided, following will be fetched regardless of this setting.
+     */
+    skip_following?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips computing and including capabilities for feeds.
+     */
+    skip_own_capabilities?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips fetching and enriching own_follows (follows where user's feeds follow target feeds).
+     */
+    skip_own_follows?: boolean;
+    
+
+        
+    /**
+     * Default: false. When true, skips enriching pinned activities.
+     */
+    skip_pins?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface EntityCreatorResponse {
+    /**
+     * Number of minor actions performed on the user
+     */
+    ban_count: number;
+    
+
+        
+    banned: boolean;
+    
+
+        
+    created_at: Date;
+    
+
+        
+    /**
+     * Number of major actions performed on the user
+     */
+    deleted_content_count: number;
+    
+
+        
+    /**
+     * Number of flag actions performed on the user
+     */
+    flagged_count: number;
+    
+
+        
+    id: string;
+    
+
+        
+    language: string;
+    
+
+        
+    online: boolean;
+    
+
+        
+    role: string;
+    
+
+        
+    updated_at: Date;
+    
+
+        
+    blocked_user_ids: Array<string>;
+    
+
+        
+    teams: Array<string>;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    avg_response_time?: number;
+    
+
+        
+    deactivated_at?: Date;
+    
+
+        
+    deleted_at?: Date;
+    
+
+        
+    image?: string;
+    
+
+        
+    last_active?: Date;
+    
+
+        
+    name?: string;
+    
+
+        
+    revoke_tokens_issued_before?: Date;
+    
+
+        
+    teams_role?: Record<string, string>;
+    
+
+        }
+    
+
+
+
+
+    export interface EscalatePayload {
+    /**
+     * Additional context for the reviewer
+     */
+    notes?: string;
+    
+
+        
+    /**
+     * Priority of the escalation (low, medium, high)
+     */
+    priority?: string;
+    
+
+        
+    /**
+     * Reason for the escalation (from configured escalation_reasons)
+     */
+    reason?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface EscalationMetadata {
+    notes?: string;
+    
+
+        
+    priority?: string;
+    
+
+        
+    reason?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedCreatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    fid: string;
+    
+
+        
+    members: Array<FeedMemberResponse>;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    feed: FeedResponse;
+    
+
+        
+    user: UserResponseCommonFields;
+    
+
+        
+    /**
+     * The type of event: "feeds.feed.created" in this case
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedDeletedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    fid: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    /**
+     * The type of event: "feeds.feed.deleted" in this case
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    user?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedGroup {
+    aggregation_version: number;
+    
+
+        
+    app_pk: number;
+    
+
+        
+    created_at: Date;
+    
+
+        
+    default_visibility: string;
+    
+
+        
+    group_id: string;
+    
+
+        
+    updated_at: Date;
+    
+
+        
+    activity_processors: Array<ActivityProcessorConfig>;
+    
+
+        
+    activity_selectors: Array<ActivitySelectorConfig>;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    deleted_at?: Date;
+    
+
+        
+    last_feed_get_at?: Date;
+    
+
+        
+    activity_filter?: ActivityFilterConfig;
+    
+
+        
+    aggregation?: AggregationConfig;
+    
+
+        
+    notification?: NotificationConfig;
+    
+
+        
+    push_notification?: PushNotificationConfig;
+    
+
+        
+    ranking?: RankingConfig;
+    
+
+        
+    stories?: StoriesConfig;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedGroupChangedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    fid: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    /**
+     * The type of event: "feeds.feed_group.changed" in this case
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    feed_group?: FeedGroup;
+    
+
+        
+    user?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedGroupDeletedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    fid: string;
+    
+
+        
+    /**
+     * The ID of the feed group that was deleted
+     */
+    group_id: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    /**
+     * The type of event: "feeds.feed_group.deleted" in this case
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedGroupRestoredEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    fid: string;
+    
+
+        
+    /**
+     * The ID of the feed group that was restored
+     */
+    group_id: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    /**
+     * The type of event: "feeds.feed_group.restored" in this case
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedInput {
+    description?: string;
+    
+
+        
+    name?: string;
+    
+
+        
+    
+        visibility?:| "public" | "visible" | "followers" | "members" | "private" ;
+
+        
+    filter_tags?: Array<string>;
+    
+
+        
+    members?: Array<FeedMemberRequest>;
+    
+
+        
+    custom?: Record<string, any>;
+    
+
+        
+    location?: Location;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedMemberAddedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    fid: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    member: FeedMemberResponse;
+    
+
+        
+    /**
+     * The type of event: "feeds.feed_member.added" in this case
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    user?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedMemberRemovedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    fid: string;
+    
+
+        
+    member_id: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    /**
+     * The type of event: "feeds.feed_member.removed" in this case
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    user?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedMemberRequest {
+    /**
+     * ID of the user to add as a member
+     */
+    user_id: string;
+    
+
+        
+    /**
+     * Whether this is an invite to become a member
+     */
+    invite?: boolean;
+    
+
+        
+    /**
+     * ID of the membership level to assign to the member
+     */
+    membership_level?: string;
+    
+
+        
+    /**
+     * Role of the member in the feed
+     */
+    role?: string;
+    
+
+        
+    /**
+     * Custom data for the member
+     */
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedMemberResponse {
+    /**
+     * When the membership was created
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * Role of the member in the feed
+     */
+    role: string;
+    
+
+        
+    /**
+     * Status of the membership. One of: member, pending, rejected
+     */
+    
+        status:| "member" | "pending" | "rejected" ;
+
+        
+    /**
+     * When the membership was last updated
+     */
+    updated_at: Date;
+    
+
+        
+    user: UserResponse;
+    
+
+        
+    /**
+     * When the invite was accepted
+     */
+    invite_accepted_at?: Date;
+    
+
+        
+    /**
+     * When the invite was rejected
+     */
+    invite_rejected_at?: Date;
+    
+
+        
+    /**
+     * Custom data for the membership
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    membership_level?: MembershipLevelResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedMemberUpdatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    fid: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    member: FeedMemberResponse;
+    
+
+        
+    /**
+     * The type of event: "feeds.feed_member.updated" in this case
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    user?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
 
 export const FeedOwnCapability = {
-  ADD_ACTIVITY: 'add-activity',
-  ADD_ACTIVITY_BOOKMARK: 'add-activity-bookmark',
-  ADD_ACTIVITY_REACTION: 'add-activity-reaction',
-  ADD_COMMENT: 'add-comment',
-  ADD_COMMENT_REACTION: 'add-comment-reaction',
-  CREATE_FEED: 'create-feed',
-  DELETE_ANY_ACTIVITY: 'delete-any-activity',
-  DELETE_ANY_COMMENT: 'delete-any-comment',
-  DELETE_FEED: 'delete-feed',
-  DELETE_OWN_ACTIVITY: 'delete-own-activity',
-  DELETE_OWN_ACTIVITY_BOOKMARK: 'delete-own-activity-bookmark',
-  DELETE_OWN_ACTIVITY_REACTION: 'delete-own-activity-reaction',
-  DELETE_OWN_COMMENT: 'delete-own-comment',
-  DELETE_OWN_COMMENT_REACTION: 'delete-own-comment-reaction',
-  FOLLOW: 'follow',
-  PIN_ACTIVITY: 'pin-activity',
-  QUERY_FEED_MEMBERS: 'query-feed-members',
-  QUERY_FOLLOWS: 'query-follows',
-  READ_ACTIVITIES: 'read-activities',
-  READ_FEED: 'read-feed',
-  UNFOLLOW: 'unfollow',
-  UPDATE_ANY_ACTIVITY: 'update-any-activity',
-  UPDATE_ANY_COMMENT: 'update-any-comment',
-  UPDATE_FEED: 'update-feed',
-  UPDATE_FEED_FOLLOWERS: 'update-feed-followers',
-  UPDATE_FEED_MEMBERS: 'update-feed-members',
-  UPDATE_OWN_ACTIVITY: 'update-own-activity',
-  UPDATE_OWN_ACTIVITY_BOOKMARK: 'update-own-activity-bookmark',
-  UPDATE_OWN_COMMENT: 'update-own-comment',
+    ADD_ACTIVITY: 'add-activity',
+    ADD_ACTIVITY_BOOKMARK: 'add-activity-bookmark',
+    ADD_ACTIVITY_REACTION: 'add-activity-reaction',
+    ADD_COMMENT: 'add-comment',
+    ADD_COMMENT_REACTION: 'add-comment-reaction',
+    CREATE_FEED: 'create-feed',
+    DELETE_ANY_ACTIVITY: 'delete-any-activity',
+    DELETE_ANY_COMMENT: 'delete-any-comment',
+    DELETE_FEED: 'delete-feed',
+    DELETE_OWN_ACTIVITY: 'delete-own-activity',
+    DELETE_OWN_ACTIVITY_BOOKMARK: 'delete-own-activity-bookmark',
+    DELETE_OWN_ACTIVITY_REACTION: 'delete-own-activity-reaction',
+    DELETE_OWN_COMMENT: 'delete-own-comment',
+    DELETE_OWN_COMMENT_REACTION: 'delete-own-comment-reaction',
+    FOLLOW: 'follow',
+    PIN_ACTIVITY: 'pin-activity',
+    QUERY_FEED_MEMBERS: 'query-feed-members',
+    QUERY_FOLLOWS: 'query-follows',
+    READ_ACTIVITIES: 'read-activities',
+    READ_FEED: 'read-feed',
+    UNFOLLOW: 'unfollow',
+    UPDATE_ANY_ACTIVITY: 'update-any-activity',
+    UPDATE_ANY_COMMENT: 'update-any-comment',
+    UPDATE_FEED: 'update-feed',
+    UPDATE_FEED_FOLLOWERS: 'update-feed-followers',
+    UPDATE_FEED_MEMBERS: 'update-feed-members',
+    UPDATE_OWN_ACTIVITY: 'update-own-activity',
+    UPDATE_OWN_ACTIVITY_BOOKMARK: 'update-own-activity-bookmark',
+    UPDATE_OWN_COMMENT: 'update-own-comment',
 } as const;
 
-export type FeedOwnCapability =
-  (typeof FeedOwnCapability)[keyof typeof FeedOwnCapability];
-
-export interface FeedOwnData {
-  /**
-   * Capabilities the current user has for this feed
-   */
-  own_capabilities?: FeedOwnCapability[];
-
-  /**
-   * Follow relationships where the feed owner's feeds are following the current user's feeds (up to 5 total)
-   */
-  own_followings?: FollowResponse[];
-
-  /**
-   * Follow relationships where the current user's feeds are following this feed
-   */
-  own_follows?: FollowResponse[];
-
-  own_membership?: FeedMemberResponse;
-}
-
-export interface FeedRequest {
-  /**
-   * ID of the feed group
-   */
-  feed_group_id: string;
-
-  /**
-   * ID of the feed
-   */
-  feed_id: string;
-
-  /**
-   * ID of the feed creator
-   */
-  created_by_id?: string;
-
-  /**
-   * Description of the feed
-   */
-  description?: string;
-
-  /**
-   * Name of the feed
-   */
-  name?: string;
-
-  /**
-   * Visibility setting for the feed. One of: public, visible, followers, members, private
-   */
-
-  visibility?: 'public' | 'visible' | 'followers' | 'members' | 'private';
-
-  /**
-   * Tags used for filtering feeds
-   */
-  filter_tags?: string[];
-
-  /**
-   * Initial members for the feed
-   */
-  members?: FeedMemberRequest[];
-
-  /**
-   * Custom data for the feed
-   */
-  custom?: Record<string, any>;
-
-  location?: Location;
-}
-
-export interface FeedResponse {
-  activity_count: number;
-
-  /**
-   * When the feed was created
-   */
-  created_at: Date;
-
-  /**
-   * Description of the feed
-   */
-  description: string;
-
-  /**
-   * Fully qualified feed ID (group_id:id)
-   */
-  feed: string;
-
-  /**
-   * Number of followers of this feed
-   */
-  follower_count: number;
-
-  /**
-   * Number of feeds this feed follows
-   */
-  following_count: number;
-
-  /**
-   * Group this feed belongs to
-   */
-  group_id: string;
-
-  /**
-   * Unique identifier for the feed
-   */
-  id: string;
-
-  /**
-   * Number of members in this feed
-   */
-  member_count: number;
-
-  /**
-   * Name of the feed
-   */
-  name: string;
-
-  /**
-   * Number of pinned activities in this feed
-   */
-  pin_count: number;
-
-  /**
-   * When the feed was last updated
-   */
-  updated_at: Date;
-
-  created_by: UserResponse;
-
-  /**
-   * When the feed was deleted
-   */
-  deleted_at?: Date;
-
-  /**
-   * Visibility setting for the feed
-   */
-
-  visibility?: 'public' | 'visible' | 'followers' | 'members' | 'private';
-
-  /**
-   * Tags used for filtering feeds
-   */
-  filter_tags?: string[];
-
-  /**
-   * Capabilities the current user has for this feed
-   */
-  own_capabilities?: FeedOwnCapability[];
-
-  /**
-   * Follow relationships where the feed owner’s feeds are following the current user's feeds
-   */
-  own_followings?: FollowResponse[];
-
-  /**
-   * Follow relationships where the current user's feeds are following this feed
-   */
-  own_follows?: FollowResponse[];
-
-  /**
-   * Custom data for the feed
-   */
-  custom?: Record<string, any>;
-
-  location?: Location;
-
-  own_membership?: FeedMemberResponse;
-}
-
-export interface FeedSuggestionResponse {
-  activity_count: number;
-
-  /**
-   * When the feed was created
-   */
-  created_at: Date;
-
-  /**
-   * Description of the feed
-   */
-  description: string;
-
-  /**
-   * Fully qualified feed ID (group_id:id)
-   */
-  feed: string;
-
-  /**
-   * Number of followers of this feed
-   */
-  follower_count: number;
-
-  /**
-   * Number of feeds this feed follows
-   */
-  following_count: number;
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type FeedOwnCapability = typeof FeedOwnCapability[keyof typeof FeedOwnCapability]
+
+
+
+
+    export interface FeedOwnData {
+    /**
+     * Capabilities the current user has for this feed
+     */
+    own_capabilities?: Array<FeedOwnCapability>;
+    
+
+        
+    /**
+     * Follow relationships where the feed owner's feeds are following the current user's feeds (up to 5 total)
+     */
+    own_followings?: Array<FollowResponse>;
+    
+
+        
+    /**
+     * Follow relationships where the current user's feeds are following this feed
+     */
+    own_follows?: Array<FollowResponse>;
+    
+
+        
+    own_membership?: FeedMemberResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedRequest {
+    /**
+     * ID of the feed group
+     */
+    feed_group_id: string;
+    
+
+        
+    /**
+     * ID of the feed
+     */
+    feed_id: string;
+    
+
+        
+    /**
+     * ID of the feed creator
+     */
+    created_by_id?: string;
+    
+
+        
+    /**
+     * Description of the feed
+     */
+    description?: string;
+    
+
+        
+    /**
+     * Name of the feed
+     */
+    name?: string;
+    
+
+        
+    /**
+     * Visibility setting for the feed. One of: public, visible, followers, members, private
+     */
+    
+        visibility?:| "public" | "visible" | "followers" | "members" | "private" ;
+
+        
+    /**
+     * Tags used for filtering feeds
+     */
+    filter_tags?: Array<string>;
+    
+
+        
+    /**
+     * Initial members for the feed
+     */
+    members?: Array<FeedMemberRequest>;
+    
+
+        
+    /**
+     * Custom data for the feed
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    location?: Location;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedResponse {
+    activity_count: number;
+    
+
+        
+    /**
+     * When the feed was created
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * Description of the feed
+     */
+    description: string;
+    
+
+        
+    /**
+     * Fully qualified feed ID (group_id:id)
+     */
+    feed: string;
+    
+
+        
+    /**
+     * Number of followers of this feed
+     */
+    follower_count: number;
+    
+
+        
+    /**
+     * Number of feeds this feed follows
+     */
+    following_count: number;
+    
+
+        
+    /**
+     * Group this feed belongs to
+     */
+    group_id: string;
+    
+
+        
+    /**
+     * Unique identifier for the feed
+     */
+    id: string;
+    
+
+        
+    /**
+     * Number of members in this feed
+     */
+    member_count: number;
+    
+
+        
+    /**
+     * Name of the feed
+     */
+    name: string;
+    
+
+        
+    /**
+     * Number of pinned activities in this feed
+     */
+    pin_count: number;
+    
+
+        
+    /**
+     * When the feed was last updated
+     */
+    updated_at: Date;
+    
+
+        
+    created_by: UserResponse;
+    
+
+        
+    /**
+     * When the feed was deleted
+     */
+    deleted_at?: Date;
+    
+
+        
+    /**
+     * Visibility setting for the feed
+     */
+    
+        visibility?:| "public" | "visible" | "followers" | "members" | "private" ;
+
+        
+    /**
+     * Tags used for filtering feeds
+     */
+    filter_tags?: Array<string>;
+    
+
+        
+    /**
+     * Capabilities the current user has for this feed
+     */
+    own_capabilities?: Array<FeedOwnCapability>;
+    
+
+        
+    /**
+     * Follow relationships where the feed owner’s feeds are following the current user's feeds
+     */
+    own_followings?: Array<FollowResponse>;
+    
+
+        
+    /**
+     * Follow relationships where the current user's feeds are following this feed
+     */
+    own_follows?: Array<FollowResponse>;
+    
+
+        
+    /**
+     * Custom data for the feed
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    location?: Location;
+    
+
+        
+    own_membership?: FeedMemberResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedSuggestionResponse {
+    activity_count: number;
+    
+
+        
+    /**
+     * When the feed was created
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * Description of the feed
+     */
+    description: string;
+    
+
+        
+    /**
+     * Fully qualified feed ID (group_id:id)
+     */
+    feed: string;
+    
+
+        
+    /**
+     * Number of followers of this feed
+     */
+    follower_count: number;
+    
+
+        
+    /**
+     * Number of feeds this feed follows
+     */
+    following_count: number;
+    
+
+        
+    /**
+     * Group this feed belongs to
+     */
+    group_id: string;
+    
+
+        
+    /**
+     * Unique identifier for the feed
+     */
+    id: string;
+    
+
+        
+    /**
+     * Number of members in this feed
+     */
+    member_count: number;
+    
+
+        
+    /**
+     * Name of the feed
+     */
+    name: string;
+    
+
+        
+    /**
+     * Number of pinned activities in this feed
+     */
+    pin_count: number;
+    
+
+        
+    /**
+     * When the feed was last updated
+     */
+    updated_at: Date;
+    
+
+        
+    created_by: UserResponse;
+    
+
+        
+    /**
+     * When the feed was deleted
+     */
+    deleted_at?: Date;
+    
+
+        
+    reason?: string;
+    
+
+        
+    recommendation_score?: number;
+    
+
+        
+    /**
+     * Visibility setting for the feed
+     */
+    
+        visibility?:| "public" | "visible" | "followers" | "members" | "private" ;
+
+        
+    /**
+     * Tags used for filtering feeds
+     */
+    filter_tags?: Array<string>;
+    
+
+        
+    /**
+     * Capabilities the current user has for this feed
+     */
+    own_capabilities?: Array<FeedOwnCapability>;
+    
+
+        
+    /**
+     * Follow relationships where the feed owner’s feeds are following the current user's feeds
+     */
+    own_followings?: Array<FollowResponse>;
+    
+
+        
+    /**
+     * Follow relationships where the current user's feeds are following this feed
+     */
+    own_follows?: Array<FollowResponse>;
+    
+
+        
+    algorithm_scores?: Record<string, number>;
+    
+
+        
+    /**
+     * Custom data for the feed
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    location?: Location;
+    
+
+        
+    own_membership?: FeedMemberResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedUpdatedEvent {
+    created_at: Date;
+    
+
+        
+    fid: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    feed: FeedResponse;
+    
+
+        
+    /**
+     * The type of event: "feeds.feed.updated" in this case
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    user?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedsActivityLocation {
+    lat: number;
+    
+
+        
+    lng: number;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedsBookmarkResponse {
+    created_at: Date;
+    
+
+        
+    object_id: string;
+    
+
+        
+    object_type: string;
+    
+
+        
+    updated_at: Date;
+    
+
+        
+    user: UserResponse;
+    
+
+        
+    activity_id?: string;
+    
+
+        
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedsEnrichedCollectionResponse {
+    created_at: Date;
+    
+
+        
+    id: string;
+    
+
+        
+    name: string;
+    
+
+        
+    status: string;
+    
+
+        
+    updated_at: Date;
+    
+
+        
+    user_id: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedsFeedResponse {
+    activity_count: number;
+    
+
+        
+    created_at: Date;
+    
+
+        
+    description: string;
+    
+
+        
+    feed: string;
+    
+
+        
+    follower_count: number;
+    
+
+        
+    following_count: number;
+    
+
+        
+    group_id: string;
+    
+
+        
+    id: string;
+    
+
+        
+    member_count: number;
+    
+
+        
+    name: string;
+    
+
+        
+    pin_count: number;
+    
+
+        
+    updated_at: Date;
+    
+
+        
+    created_by: UserResponse;
+    
+
+        
+    deleted_at?: Date;
+    
+
+        
+    visibility?: string;
+    
+
+        
+    filter_tags?: Array<string>;
+    
+
+        
+    custom?: Record<string, any>;
+    
+
+        
+    location?: FeedsActivityLocation;
+    
+
+        }
+    
+
+
+
+
+    export interface FeedsNotificationComment {
+    comment: string;
+    
 
-  /**
-   * Group this feed belongs to
-   */
-  group_id: string;
-
-  /**
-   * Unique identifier for the feed
-   */
-  id: string;
+        
+    id: string;
+    
 
-  /**
-   * Number of members in this feed
-   */
-  member_count: number;
+        
+    user_id: string;
+    
 
-  /**
-   * Name of the feed
-   */
-  name: string;
+        
+    attachments?: Array<Attachment>;
+    
 
-  /**
-   * Number of pinned activities in this feed
-   */
-  pin_count: number;
+        }
+    
 
-  /**
-   * When the feed was last updated
-   */
-  updated_at: Date;
 
-  created_by: UserResponse;
 
-  /**
-   * When the feed was deleted
-   */
-  deleted_at?: Date;
 
-  reason?: string;
+    export interface FeedsNotificationContext {
+    target?: FeedsNotificationTarget;
+    
 
-  recommendation_score?: number;
+        
+    trigger?: FeedsNotificationTrigger;
+    
 
-  /**
-   * Visibility setting for the feed
-   */
+        }
+    
 
-  visibility?: 'public' | 'visible' | 'followers' | 'members' | 'private';
 
-  /**
-   * Tags used for filtering feeds
-   */
-  filter_tags?: string[];
 
-  /**
-   * Capabilities the current user has for this feed
-   */
-  own_capabilities?: FeedOwnCapability[];
 
-  /**
-   * Follow relationships where the feed owner’s feeds are following the current user's feeds
-   */
-  own_followings?: FollowResponse[];
+    export interface FeedsNotificationParentActivity {
+    id: string;
+    
 
-  /**
-   * Follow relationships where the current user's feeds are following this feed
-   */
-  own_follows?: FollowResponse[];
+        
+    text?: string;
+    
 
-  algorithm_scores?: Record<string, number>;
+        
+    type?: string;
+    
 
-  /**
-   * Custom data for the feed
-   */
-  custom?: Record<string, any>;
+        
+    user_id?: string;
+    
 
-  location?: Location;
+        
+    attachments?: Array<Attachment>;
+    
 
-  own_membership?: FeedMemberResponse;
-}
+        }
+    
 
-export interface FeedUpdatedEvent {
-  created_at: Date;
 
-  fid: string;
 
-  custom: Record<string, any>;
 
-  feed: FeedResponse;
+    export interface FeedsNotificationTarget {
+    id: string;
+    
 
-  /**
-   * The type of event: "feeds.feed.updated" in this case
-   */
-  type: string;
+        
+    name?: string;
+    
 
-  feed_visibility?: string;
+        
+    text?: string;
+    
+
+        
+    type?: string;
+    
+
+        
+    user_id?: string;
+    
+
+        
+    attachments?: Array<Attachment>;
+    
+
+        
+    comment?: FeedsNotificationComment;
+    
 
-  received_at?: Date;
+        
+    custom?: Record<string, any>;
+    
 
-  user?: UserResponseCommonFields;
-}
+        
+    parent_activity?: FeedsNotificationParentActivity;
+    
 
-export interface FeedsPreferences {
-  /**
-   * Push notification preference for comments on user's activities. One of: all, none
-   */
+        }
+    
 
-  comment?: 'all' | 'none';
 
-  /**
-   * Push notification preference for mentions in comments. One of: all, none
-   */
 
-  comment_mention?: 'all' | 'none';
 
-  /**
-   * Push notification preference for reactions on comments. One of: all, none
-   */
+    export interface FeedsNotificationTrigger {
+    text: string;
+    
 
-  comment_reaction?: 'all' | 'none';
+        
+    type: string;
+    
 
-  /**
-   * Push notification preference for replies to comments. One of: all, none
-   */
+        
+    comment?: FeedsNotificationComment;
+    
 
-  comment_reply?: 'all' | 'none';
+        
+    custom?: Record<string, any>;
+    
 
-  /**
-   * Push notification preference for new followers. One of: all, none
-   */
+        }
+    
 
-  follow?: 'all' | 'none';
 
-  /**
-   * Push notification preference for mentions in activities. One of: all, none
-   */
 
-  mention?: 'all' | 'none';
 
-  /**
-   * Push notification preference for reactions on user's activities or comments. One of: all, none
-   */
+    export interface FeedsPreferences {
+    /**
+     * Push notification preference for comments on user's activities. One of: all, none
+     */
+    
+        comment?:| "all" | "none" ;
 
-  reaction?: 'all' | 'none';
+        
+    /**
+     * Push notification preference for mentions in comments. One of: all, none
+     */
+    
+        comment_mention?:| "all" | "none" ;
 
-  /**
-   * Push notification preferences for custom activity types. Map of activity type to preference (all or none)
-   */
-  custom_activity_types?: Record<string, string>;
-}
+        
+    /**
+     * Push notification preference for reactions on comments. One of: all, none
+     */
+    
+        comment_reaction?:| "all" | "none" ;
 
-export interface FeedsPreferencesResponse {
-  comment?: string;
+        
+    /**
+     * Push notification preference for replies to comments. One of: all, none
+     */
+    
+        comment_reply?:| "all" | "none" ;
 
-  comment_mention?: string;
+        
+    /**
+     * Push notification preference for new followers. One of: all, none
+     */
+    
+        follow?:| "all" | "none" ;
 
-  comment_reaction?: string;
+        
+    /**
+     * Push notification preference for mentions in activities. One of: all, none
+     */
+    
+        mention?:| "all" | "none" ;
 
-  comment_reply?: string;
+        
+    /**
+     * Push notification preference for reactions on user's activities or comments. One of: all, none
+     */
+    
+        reaction?:| "all" | "none" ;
 
-  follow?: string;
+        
+    /**
+     * Push notification preferences for custom activity types. Map of activity type to preference (all or none)
+     */
+    custom_activity_types?: Record<string, string>;
+    
 
-  mention?: string;
+        }
+    
 
-  reaction?: string;
 
-  custom_activity_types?: Record<string, string>;
-}
 
-export interface FeedsReactionGroup {
-  count: number;
 
-  first_reaction_at: Date;
+    export interface FeedsPreferencesResponse {
+    comment?: string;
+    
 
-  last_reaction_at: Date;
-}
+        
+    comment_mention?: string;
+    
 
-export interface FeedsReactionGroupResponse {
-  /**
-   * Number of reactions in this group
-   */
-  count: number;
+        
+    comment_reaction?: string;
+    
 
-  /**
-   * Time of the first reaction
-   */
-  first_reaction_at: Date;
+        
+    comment_reply?: string;
+    
 
-  /**
-   * Time of the most recent reaction
-   */
-  last_reaction_at: Date;
-}
+        
+    follow?: string;
+    
 
-export interface FeedsReactionResponse {
-  /**
-   * ID of the activity that was reacted to
-   */
-  activity_id: string;
+        
+    mention?: string;
+    
 
-  /**
-   * When the reaction was created
-   */
-  created_at: Date;
+        
+    reaction?: string;
+    
 
-  /**
-   * Type of reaction
-   */
-  type: string;
+        
+    custom_activity_types?: Record<string, string>;
+    
 
-  /**
-   * When the reaction was last updated
-   */
-  updated_at: Date;
+        }
+    
 
-  user: UserResponse;
 
-  /**
-   * ID of the comment that was reacted to
-   */
-  comment_id?: string;
 
-  /**
-   * Custom data for the reaction
-   */
-  custom?: Record<string, any>;
-}
 
-export interface FeedsV3ActivityResponse {
-  bookmark_count: number;
+    export interface FeedsReactionGroupResponse {
+    count: number;
+    
 
-  comment_count: number;
+        
+    first_reaction_at: Date;
+    
 
-  created_at: Date;
+        
+    last_reaction_at: Date;
+    
 
-  hidden: boolean;
+        }
+    
 
-  id: string;
 
-  popularity: number;
 
-  preview: boolean;
 
-  reaction_count: number;
+    export interface FeedsReactionResponse {
+    activity_id: string;
+    
 
-  restrict_replies: string;
+        
+    created_at: Date;
+    
 
-  score: number;
+        
+    type: string;
+    
 
-  share_count: number;
+        
+    updated_at: Date;
+    
 
-  type: string;
+        
+    user: UserResponse;
+    
 
-  updated_at: Date;
+        
+    comment_id?: string;
+    
 
-  visibility: string;
+        
+    custom?: Record<string, any>;
+    
 
-  attachments: Attachment[];
+        }
+    
 
-  comments: FeedsV3CommentResponse[];
 
-  feeds: string[];
 
-  filter_tags: string[];
 
-  interest_tags: string[];
+    export interface FeedsV3ActivityResponse {
+    bookmark_count: number;
+    
 
-  latest_reactions: any[];
+        
+    comment_count: number;
+    
 
-  mentioned_users: UserResponse[];
+        
+    created_at: Date;
+    
 
-  own_bookmarks: any[];
+        
+    hidden: boolean;
+    
 
-  own_reactions: any[];
+        
+    id: string;
+    
 
-  collections: Record<string, EnrichedCollection>;
+        
+    popularity: number;
+    
 
-  custom: Record<string, any>;
+        
+    preview: boolean;
+    
 
-  reaction_groups: Record<string, FeedsReactionGroup>;
+        
+    reaction_count: number;
+    
 
-  search_data: Record<string, any>;
+        
+    restrict_replies: string;
+    
 
-  user: UserResponse;
+        
+    score: number;
+    
 
-  deleted_at?: Date;
+        
+    share_count: number;
+    
 
-  edited_at?: Date;
+        
+    type: string;
+    
 
-  expires_at?: Date;
+        
+    updated_at: Date;
+    
 
-  moderation_action?: string;
+        
+    visibility: string;
+    
 
-  text?: string;
+        
+    attachments: Array<Attachment>;
+    
 
-  visibility_tag?: string;
+        
+    comments: Array<FeedsV3CommentResponse>;
+    
 
-  metrics?: Record<string, number>;
+        
+    feeds: Array<string>;
+    
 
-  moderation?: ModerationV2Response;
-}
+        
+    filter_tags: Array<string>;
+    
 
-export interface FeedsV3CommentResponse {
-  confidence_score: number;
+        
+    interest_tags: Array<string>;
+    
 
-  created_at: Date;
+        
+    latest_reactions: Array<FeedsReactionResponse>;
+    
 
-  downvote_count: number;
+        
+    mentioned_users: Array<UserResponse>;
+    
 
-  id: string;
+        
+    own_bookmarks: Array<FeedsBookmarkResponse>;
+    
 
-  object_id: string;
+        
+    own_reactions: Array<FeedsReactionResponse>;
+    
 
-  object_type: string;
+        
+    collections: Record<string, FeedsEnrichedCollectionResponse>;
+    
 
-  reaction_count: number;
+        
+    custom: Record<string, any>;
+    
 
-  reply_count: number;
+        
+    reaction_groups: Record<string, FeedsReactionGroupResponse>;
+    
 
-  score: number;
+        
+    search_data: Record<string, any>;
+    
 
-  status: string;
+        
+    user: UserResponse;
+    
 
-  updated_at: Date;
+        
+    deleted_at?: Date;
+    
 
-  upvote_count: number;
+        
+    edited_at?: Date;
+    
 
-  mentioned_users: UserResponse[];
+        
+    expires_at?: Date;
+    
 
-  own_reactions: any[];
+        
+    friend_reaction_count?: number;
+    
 
-  user: UserResponse;
+        
+    is_read?: boolean;
+    
 
-  controversy_score?: number;
+        
+    is_seen?: boolean;
+    
 
-  deleted_at?: Date;
+        
+    is_watched?: boolean;
+    
 
-  edited_at?: Date;
+        
+    moderation_action?: string;
+    
 
-  parent_id?: string;
+        
+    selector_source?: string;
+    
 
-  text?: string;
+        
+    text?: string;
+    
 
-  attachments?: Attachment[];
+        
+    visibility_tag?: string;
+    
 
-  custom?: Record<string, any>;
+        
+    friend_reactions?: Array<FeedsReactionResponse>;
+    
 
-  moderation?: ModerationV2Response;
-}
+        
+    current_feed?: FeedsFeedResponse;
+    
 
-export interface Field {
-  short: boolean;
+        
+    location?: FeedsActivityLocation;
+    
 
-  title: string;
+        
+    metrics?: Record<string, number>;
+    
 
-  value: string;
-}
+        
+    moderation?: ModerationV2Response;
+    
 
-export interface FileUploadConfig {
-  size_limit: number;
+        
+    notification_context?: FeedsNotificationContext;
+    
 
-  allowed_file_extensions: string[];
+        
+    parent?: FeedsV3ActivityResponse;
+    
 
-  allowed_mime_types: string[];
+        
+    poll?: PollResponseData;
+    
 
-  blocked_file_extensions: string[];
+        
+    score_vars?: Record<string, any>;
+    
 
-  blocked_mime_types: string[];
-}
+        }
+    
 
-export interface FileUploadRequest {
-  /**
-   * file field
-   */
-  file?: string;
 
-  user?: OnlyUserID;
-}
 
-export interface FileUploadResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
 
-  /**
-   * URL to the uploaded asset. Should be used to put to `asset_url` attachment field
-   */
-  file?: string;
+    export interface FeedsV3CommentResponse {
+    bookmark_count: number;
+    
 
-  /**
-   * URL of the file thumbnail for supported file formats. Should be put to `thumb_url` attachment field
-   */
-  thumb_url?: string;
-}
+        
+    confidence_score: number;
+    
 
-export interface FilterConfigResponse {
-  llm_labels: string[];
+        
+    created_at: Date;
+    
 
-  ai_text_labels?: string[];
+        
+    downvote_count: number;
+    
 
-  config_keys?: string[];
-}
+        
+    id: string;
+    
 
-export interface FlagCountRuleParameters {
-  threshold?: number;
-}
+        
+    object_id: string;
+    
 
-export interface FlagRequest {
-  /**
-   * Unique identifier of the entity being flagged
-   */
-  entity_id: string;
+        
+    object_type: string;
+    
 
-  /**
-   * Type of entity being flagged (e.g., message, user)
-   */
-  entity_type: string;
+        
+    reaction_count: number;
+    
 
-  /**
-   * ID of the user who created the flagged entity
-   */
-  entity_creator_id?: string;
+        
+    reply_count: number;
+    
 
-  /**
-   * Optional explanation for why the content is being flagged
-   */
-  reason?: string;
+        
+    score: number;
+    
 
-  /**
-   * Additional metadata about the flag
-   */
-  custom?: Record<string, any>;
+        
+    status: string;
+    
 
-  moderation_payload?: ModerationPayload;
-}
+        
+    updated_at: Date;
+    
 
-export interface FlagResponse {
-  duration: string;
+        
+    upvote_count: number;
+    
 
-  /**
-   * Unique identifier of the created moderation item
-   */
-  item_id: string;
-}
+        
+    mentioned_users: Array<UserResponse>;
+    
 
-export interface FlagUserOptions {
-  reason?: string;
-}
+        
+    own_reactions: Array<FeedsReactionResponse>;
+    
 
-export interface FollowBatchRequest {
-  /**
-   * List of follow relationships to create
-   */
-  follows: FollowRequest[];
+        
+    user: UserResponse;
+    
 
-  /**
-   * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-   */
-  enrich_own_fields?: boolean;
-}
+        
+    controversy_score?: number;
+    
 
-export interface FollowBatchResponse {
-  duration: string;
+        
+    deleted_at?: Date;
+    
 
-  /**
-   * List of newly created follow relationships
-   */
-  created: FollowResponse[];
+        
+    edited_at?: Date;
+    
 
-  /**
-   * List of current follow relationships
-   */
-  follows: FollowResponse[];
-}
+        
+    parent_id?: string;
+    
 
-export interface FollowCreatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    text?: string;
+    
 
-  fid: string;
+        
+    attachments?: Array<Attachment>;
+    
 
-  custom: Record<string, any>;
+        
+    latest_reactions?: Array<FeedsReactionResponse>;
+    
 
-  follow: FollowResponse;
+        
+    custom?: Record<string, any>;
+    
 
-  /**
-   * The type of event: "feeds.follow.created" in this case
-   */
-  type: string;
+        
+    moderation?: ModerationV2Response;
+    
 
-  feed_visibility?: string;
+        
+    reaction_groups?: Record<string, FeedsReactionGroupResponse>;
+    
 
-  received_at?: Date;
-}
+        }
+    
 
-export interface FollowDeletedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  fid: string;
 
-  custom: Record<string, any>;
 
-  follow: FollowResponse;
+    export interface Field {
+    short: boolean;
+    
 
-  /**
-   * The type of event: "feeds.follow.deleted" in this case
-   */
-  type: string;
+        
+    title: string;
+    
 
-  feed_visibility?: string;
+        
+    value: string;
+    
 
-  received_at?: Date;
-}
+        }
+    
 
-export interface FollowRequest {
-  /**
-   * Fully qualified ID of the source feed
-   */
-  source: string;
 
-  /**
-   * Fully qualified ID of the target feed
-   */
-  target: string;
 
-  /**
-   * Maximum number of historical activities to copy from the target feed when the follow is first materialized. Not set = unlimited (default). 0 = copy nothing. Range: 0-1000.
-   */
-  activity_copy_limit?: number;
 
-  /**
-   * @deprecated
-   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-   */
-  copy_custom_to_notification?: boolean;
+    export interface FileUploadConfig {
+    size_limit: number;
+    
 
-  /**
-   * Whether to create a notification activity for this follow
-   */
-  create_notification_activity?: boolean;
+        
+    allowed_file_extensions: Array<string>;
+    
 
-  /**
-   * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-   */
-  enrich_own_fields?: boolean;
+        
+    allowed_mime_types: Array<string>;
+    
 
-  /**
-   * Push preference for the follow relationship
-   */
+        
+    blocked_file_extensions: Array<string>;
+    
 
-  push_preference?: 'all' | 'none';
+        
+    blocked_mime_types: Array<string>;
+    
 
-  /**
-   * Whether to skip push for this follow
-   */
-  skip_push?: boolean;
+        }
+    
 
-  /**
-   * Custom data for the follow relationship
-   */
-  custom?: Record<string, any>;
-}
 
-export interface FollowResponse {
-  /**
-   * When the follow relationship was created
-   */
-  created_at: Date;
 
-  /**
-   * Role of the follower (source user) in the follow relationship
-   */
-  follower_role: string;
 
-  /**
-   * Push preference for notifications. One of: all, none
-   */
+    export interface FileUploadRequest {
+    /**
+     * file field
+     */
+    file?: string;
+    
 
-  push_preference: 'all' | 'none';
+        
+    user?: OnlyUserID;
+    
 
-  /**
-   * Status of the follow relationship. One of: accepted, pending, rejected
-   */
+        }
+    
 
-  status: 'accepted' | 'pending' | 'rejected';
 
-  /**
-   * When the follow relationship was last updated
-   */
-  updated_at: Date;
 
-  source_feed: FeedResponse;
 
-  target_feed: FeedResponse;
+    export interface FileUploadResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  /**
-   * When the follow request was accepted
-   */
-  request_accepted_at?: Date;
+        
+    /**
+     * URL to the uploaded asset. Should be used to put to `asset_url` attachment field
+     */
+    file?: string;
+    
 
-  /**
-   * When the follow request was rejected
-   */
-  request_rejected_at?: Date;
+        
+    /**
+     * URL of the file thumbnail for supported file formats. Should be put to `thumb_url` attachment field
+     */
+    thumb_url?: string;
+    
 
-  /**
-   * Custom data for the follow relationship
-   */
-  custom?: Record<string, any>;
-}
+        }
+    
 
-export interface FollowUpdatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  fid: string;
 
-  custom: Record<string, any>;
 
-  follow: FollowResponse;
+    export interface FilterConfigResponse {
+    llm_labels: Array<string>;
+    
 
-  /**
-   * The type of event: "feeds.follow.updated" in this case
-   */
-  type: string;
+        
+    ai_text_labels?: Array<string>;
+    
 
-  feed_visibility?: string;
+        
+    config_keys?: Array<string>;
+    
 
-  received_at?: Date;
-}
+        }
+    
 
-export interface FrameRecordingResponse {
-  status: string;
-}
 
-export interface FrameRecordingSettingsResponse {
-  capture_interval_in_seconds: number;
 
-  mode: string;
 
-  quality?: string;
-}
+    export interface FlagCountRuleParameters {
+    threshold?: number;
+    
 
-export interface FriendReactionsOptions {
-  /**
-   * Default: false. When true, fetches friend reactions for activities.
-   */
-  enabled?: boolean;
+        }
+    
 
-  /**
-   * Default: 3, Max: 10. The maximum number of friend reactions to return per activity.
-   */
-  limit?: number;
 
-  /**
-   * Default: 'following'. The type of friend relationship to use. 'following' = users you follow, 'mutual' = users with mutual follows. One of: following, mutual
-   */
 
-  type?: 'following' | 'mutual';
-}
 
-export interface FullUserResponse {
-  banned: boolean;
+    export interface FlagRequest {
+    /**
+     * Unique identifier of the entity being flagged
+     */
+    entity_id: string;
+    
 
-  created_at: Date;
+        
+    /**
+     * Type of entity being flagged (e.g., message, user)
+     */
+    entity_type: string;
+    
 
-  id: string;
+        
+    /**
+     * ID of the user who created the flagged entity
+     */
+    entity_creator_id?: string;
+    
 
-  invisible: boolean;
+        
+    /**
+     * Optional explanation for why the content is being flagged
+     */
+    reason?: string;
+    
 
-  language: string;
+        
+    /**
+     * Additional metadata about the flag
+     */
+    custom?: Record<string, any>;
+    
 
-  online: boolean;
+        
+    moderation_payload?: ModerationPayload;
+    
 
-  role: string;
+        }
+    
 
-  shadow_banned: boolean;
 
-  total_unread_count: number;
 
-  unread_channels: number;
 
-  unread_count: number;
+    export interface FlagResponse {
+    duration: string;
+    
 
-  unread_threads: number;
+        
+    /**
+     * Unique identifier of the created moderation item
+     */
+    item_id: string;
+    
 
-  updated_at: Date;
+        }
+    
 
-  blocked_user_ids: string[];
 
-  channel_mutes: ChannelMute[];
 
-  devices: DeviceResponse[];
 
-  mutes: UserMuteResponse[];
+    export interface FlagUserOptions {
+    reason?: string;
+    
 
-  teams: string[];
+        }
+    
 
-  custom: Record<string, any>;
 
-  avg_response_time?: number;
 
-  ban_expires?: Date;
 
-  deactivated_at?: Date;
+    export interface FollowBatchRequest {
+    /**
+     * List of follow relationships to create
+     */
+    follows: Array<FollowRequest>;
+    
 
-  deleted_at?: Date;
+        
+    /**
+     * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+     */
+    enrich_own_fields?: boolean;
+    
 
-  image?: string;
+        }
+    
 
-  last_active?: Date;
 
-  name?: string;
 
-  revoke_tokens_issued_before?: Date;
 
-  latest_hidden_channels?: string[];
+    export interface FollowBatchResponse {
+    duration: string;
+    
 
-  privacy_settings?: PrivacySettingsResponse;
+        
+    /**
+     * List of newly created follow relationships
+     */
+    created: Array<FollowResponse>;
+    
 
-  teams_role?: Record<string, string>;
-}
+        
+    /**
+     * List of current follow relationships
+     */
+    follows: Array<FollowResponse>;
+    
 
-export interface GeofenceSettingsResponse {
-  names: string[];
-}
+        }
+    
 
-export interface GetActivityResponse {
-  duration: string;
 
-  activity: ActivityResponse;
-}
 
-export interface GetAppealResponse {
-  duration: string;
 
-  item?: AppealItemResponse;
-}
+    export interface FollowCreatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-export interface GetApplicationResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        
+    fid: string;
+    
 
-  app: AppResponseFields;
-}
+        
+    custom: Record<string, any>;
+    
 
-export interface GetBlockedUsersResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        
+    follow: FollowResponse;
+    
 
-  /**
-   * Array of blocked user object
-   */
-  blocks: BlockedUserResponse[];
-}
+        
+    /**
+     * The type of event: "feeds.follow.created" in this case
+     */
+    type: string;
+    
 
-export interface GetCommentRepliesResponse {
-  duration: string;
+        
+    feed_visibility?: string;
+    
 
-  /**
-   * Sort order used for the replies (first, last, top, best, controversial)
-   */
-  sort: string;
+        
+    received_at?: Date;
+    
 
-  /**
-   * Threaded listing of replies to the comment
-   */
-  comments: ThreadedCommentResponse[];
+        }
+    
 
-  next?: string;
 
-  prev?: string;
-}
 
-export interface GetCommentResponse {
-  duration: string;
 
-  comment: CommentResponse;
-}
+    export interface FollowDeletedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-export interface GetCommentsResponse {
-  duration: string;
+        
+    fid: string;
+    
 
-  /**
-   * Sort order used for the comments (first, last, top, best, controversial)
-   */
-  sort: string;
+        
+    custom: Record<string, any>;
+    
 
-  /**
-   * Threaded listing for the activity
-   */
-  comments: ThreadedCommentResponse[];
+        
+    follow: FollowResponse;
+    
 
-  next?: string;
+        
+    /**
+     * The type of event: "feeds.follow.deleted" in this case
+     */
+    type: string;
+    
 
-  prev?: string;
-}
+        
+    feed_visibility?: string;
+    
 
-export interface GetConfigResponse {
-  duration: string;
+        
+    received_at?: Date;
+    
 
-  config?: ConfigResponse;
-}
+        }
+    
 
-export interface GetFollowSuggestionsResponse {
-  duration: string;
 
-  /**
-   * List of suggested feeds to follow
-   */
-  suggestions: FeedSuggestionResponse[];
 
-  algorithm_used?: string;
-}
 
-export interface GetOGResponse {
-  duration: string;
+    export interface FollowRequest {
+    /**
+     * Fully qualified ID of the source feed
+     */
+    source: string;
+    
 
-  custom: Record<string, any>;
+        
+    /**
+     * Fully qualified ID of the target feed
+     */
+    target: string;
+    
 
-  /**
-   * URL of detected video or audio
-   */
-  asset_url?: string;
+        
+    /**
+     * Maximum number of historical activities to copy from the target feed when the follow is first materialized. Not set = unlimited (default). 0 = copy nothing. Range: 0-1000.
+     */
+    activity_copy_limit?: number;
+    
 
-  author_icon?: string;
+        
+    /**
+     * @deprecated
+     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+     */
+    copy_custom_to_notification?: boolean;
+    
 
-  /**
-   * og:site
-   */
-  author_link?: string;
+        
+    /**
+     * Whether to create a notification activity for this follow
+     */
+    create_notification_activity?: boolean;
+    
 
-  /**
-   * og:site_name
-   */
-  author_name?: string;
+        
+    /**
+     * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+     */
+    enrich_own_fields?: boolean;
+    
 
-  color?: string;
+        
+    /**
+     * Push preference for the follow relationship
+     */
+    
+        push_preference?:| "all" | "none" ;
 
-  fallback?: string;
+        
+    /**
+     * Whether to skip push for this follow
+     */
+    skip_push?: boolean;
+    
 
-  footer?: string;
+        
+    /**
+     * Custom data for the follow relationship
+     */
+    custom?: Record<string, any>;
+    
 
-  footer_icon?: string;
+        }
+    
 
-  /**
-   * URL of detected image
-   */
-  image_url?: string;
 
-  /**
-   * extracted url from the text
-   */
-  og_scrape_url?: string;
 
-  original_height?: number;
 
-  original_width?: number;
+    export interface FollowResponse {
+    /**
+     * When the follow relationship was created
+     */
+    created_at: Date;
+    
 
-  pretext?: string;
+        
+    /**
+     * Role of the follower (source user) in the follow relationship
+     */
+    follower_role: string;
+    
 
-  /**
-   * og:description
-   */
-  text?: string;
+        
+    /**
+     * Push preference for notifications. One of: all, none
+     */
+    
+        push_preference:| "all" | "none" ;
 
-  /**
-   * URL of detected thumb image
-   */
-  thumb_url?: string;
+        
+    /**
+     * Status of the follow relationship. One of: accepted, pending, rejected
+     */
+    
+        status:| "accepted" | "pending" | "rejected" ;
 
-  /**
-   * og:title
-   */
-  title?: string;
+        
+    /**
+     * When the follow relationship was last updated
+     */
+    updated_at: Date;
+    
 
-  /**
-   * og:url
-   */
-  title_link?: string;
+        
+    source_feed: FeedResponse;
+    
 
-  /**
-   * Attachment type, could be empty, image, audio or video
-   */
-  type?: string;
+        
+    target_feed: FeedResponse;
+    
 
-  actions?: Action[];
+        
+    /**
+     * When the follow request was accepted
+     */
+    request_accepted_at?: Date;
+    
 
-  fields?: Field[];
+        
+    /**
+     * When the follow request was rejected
+     */
+    request_rejected_at?: Date;
+    
 
-  giphy?: Images;
-}
+        
+    /**
+     * Custom data for the follow relationship
+     */
+    custom?: Record<string, any>;
+    
 
-export interface GetOrCreateFeedRequest {
-  id_around?: string;
+        }
+    
 
-  limit?: number;
 
-  next?: string;
 
-  prev?: string;
 
-  view?: string;
+    export interface FollowUpdatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  watch?: boolean;
+        
+    fid: string;
+    
 
-  data?: FeedInput;
+        
+    custom: Record<string, any>;
+    
 
-  enrichment_options?: EnrichmentOptions;
+        
+    follow: FollowResponse;
+    
 
-  external_ranking?: Record<string, any>;
+        
+    /**
+     * The type of event: "feeds.follow.updated" in this case
+     */
+    type: string;
+    
 
-  filter?: Record<string, any>;
+        
+    feed_visibility?: string;
+    
 
-  followers_pagination?: PagerRequest;
+        
+    received_at?: Date;
+    
 
-  following_pagination?: PagerRequest;
+        }
+    
 
-  friend_reactions_options?: FriendReactionsOptions;
 
-  interest_weights?: Record<string, number>;
 
-  member_pagination?: PagerRequest;
-}
 
-export interface GetOrCreateFeedResponse {
-  created: boolean;
+    export interface FriendReactionsOptions {
+    /**
+     * Default: false. When true, fetches friend reactions for activities.
+     */
+    enabled?: boolean;
+    
 
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        
+    /**
+     * Default: 3, Max: 10. The maximum number of friend reactions to return per activity.
+     */
+    limit?: number;
+    
 
-  activities: ActivityResponse[];
+        
+    /**
+     * Default: 'following'. The type of friend relationship to use. 'following' = users you follow, 'mutual' = users with mutual follows. One of: following, mutual
+     */
+    
+        type?:| "following" | "mutual" ;
 
-  aggregated_activities: AggregatedActivityResponse[];
+        }
+    
 
-  followers: FollowResponse[];
 
-  following: FollowResponse[];
 
-  members: FeedMemberResponse[];
 
-  pinned_activities: ActivityPinResponse[];
+    export interface FullUserResponse {
+    banned: boolean;
+    
 
-  feed: FeedResponse;
+        
+    created_at: Date;
+    
 
-  next?: string;
+        
+    id: string;
+    
 
-  prev?: string;
+        
+    invisible: boolean;
+    
 
-  followers_pagination?: PagerResponse;
+        
+    language: string;
+    
 
-  following_pagination?: PagerResponse;
+        
+    online: boolean;
+    
 
-  member_pagination?: PagerResponse;
+        
+    role: string;
+    
 
-  notification_status?: NotificationStatusResponse;
-}
+        
+    shadow_banned: boolean;
+    
 
-export interface GetUserGroupResponse {
-  duration: string;
+        
+    total_unread_count: number;
+    
 
-  user_group?: UserGroupResponse;
-}
+        
+    unread_channels: number;
+    
 
-export interface GoogleVisionConfig {
-  enabled?: boolean;
-}
+        
+    unread_count: number;
+    
 
-export interface HLSSettingsResponse {
-  auto_on: boolean;
+        
+    unread_threads: number;
+    
 
-  enabled: boolean;
+        
+    updated_at: Date;
+    
 
-  quality_tracks: string[];
+        
+    blocked_user_ids: Array<string>;
+    
 
-  layout: LayoutSettingsResponse;
-}
+        
+    channel_mutes: Array<ChannelMute>;
+    
 
-export interface HarmConfig {
-  cooldown_period: number;
+        
+    devices: Array<DeviceResponse>;
+    
 
-  severity: number;
+        
+    mutes: Array<UserMuteResponse>;
+    
 
-  threshold: number;
+        
+    teams: Array<string>;
+    
 
-  action_sequences: ActionSequence[];
+        
+    custom: Record<string, any>;
+    
 
-  harm_types: string[];
-}
+        
+    avg_response_time?: number;
+    
 
-export interface HealthCheckEvent {
-  connection_id: string;
+        
+    ban_expires?: Date;
+    
 
-  created_at: Date;
+        
+    deactivated_at?: Date;
+    
 
-  custom: Record<string, any>;
+        
+    deleted_at?: Date;
+    
 
-  type: string;
+        
+    image?: string;
+    
 
-  cid?: string;
+        
+    last_active?: Date;
+    
 
-  received_at?: Date;
+        
+    name?: string;
+    
 
-  me?: OwnUserResponse;
-}
+        
+    revoke_tokens_issued_before?: Date;
+    
 
-export interface ImageContentParameters {
-  label_operator?: string;
+        
+    latest_hidden_channels?: Array<string>;
+    
 
-  min_confidence?: number;
+        
+    privacy_settings?: PrivacySettingsResponse;
+    
 
-  harm_labels?: string[];
-}
+        
+    teams_role?: Record<string, string>;
+    
 
-export interface ImageData {
-  frames: string;
+        }
+    
 
-  height: string;
 
-  size: string;
 
-  url: string;
 
-  width: string;
-}
+    export interface GetActionConfigResponse {
+    duration: string;
+    
 
-export interface ImageRuleParameters {
-  min_confidence?: number;
+        
+    /**
+     * Moderation action configs grouped by entity type, sorted by order ascending
+     */
+    action_config: Record<string, Array<ModerationActionConfigResponse>>;
+    
 
-  threshold?: number;
+        }
+    
 
-  time_window?: string;
 
-  harm_labels?: string[];
-}
 
-export interface ImageSize {
-  /**
-   * Crop mode. One of: top, bottom, left, right, center
-   */
-  crop?: string;
 
-  /**
-   * Target image height
-   */
-  height?: number;
+    export interface GetActivityResponse {
+    duration: string;
+    
 
-  /**
-   * Resize method. One of: clip, crop, scale, fill
-   */
-  resize?: string;
+        
+    activity: ActivityResponse;
+    
 
-  /**
-   * Target image width
-   */
-  width?: number;
-}
+        }
+    
 
-export interface ImageUploadRequest {
-  file?: string;
 
-  /**
-   * field with JSON-encoded array of image size configurations
-   */
-  upload_sizes?: ImageSize[];
 
-  user?: OnlyUserID;
-}
 
-export interface ImageUploadResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+    export interface GetAppealResponse {
+    duration: string;
+    
 
-  file?: string;
+        
+    item?: AppealItemResponse;
+    
 
-  thumb_url?: string;
+        }
+    
 
-  /**
-   * Array of image size configurations
-   */
-  upload_sizes?: ImageSize[];
-}
 
-export interface Images {
-  fixed_height: ImageData;
 
-  fixed_height_downsampled: ImageData;
 
-  fixed_height_still: ImageData;
+    export interface GetApplicationResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  fixed_width: ImageData;
+        
+    app: AppResponseFields;
+    
 
-  fixed_width_downsampled: ImageData;
+        }
+    
 
-  fixed_width_still: ImageData;
 
-  original: ImageData;
-}
 
-export interface IndividualRecordingResponse {
-  status: string;
-}
 
-export interface IndividualRecordingSettingsResponse {
-  mode: string;
+    export interface GetBlockedUsersResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  output_types?: string[];
-}
+        
+    /**
+     * Array of blocked user object
+     */
+    blocks: Array<BlockedUserResponse>;
+    
 
-export interface IngressAudioEncodingResponse {
-  bitrate: number;
+        }
+    
 
-  channels: number;
 
-  enable_dtx: boolean;
-}
 
-export interface IngressSettingsResponse {
-  enabled: boolean;
 
-  audio_encoding_options?: IngressAudioEncodingResponse;
+    export interface GetCommentRepliesResponse {
+    duration: string;
+    
 
-  video_encoding_options?: Record<string, IngressVideoEncodingResponse>;
-}
+        
+    /**
+     * Sort order used for the replies (first, last, top, best, controversial)
+     */
+    sort: string;
+    
 
-export interface IngressSourceResponse {
-  fps: number;
+        
+    /**
+     * Threaded listing of replies to the comment
+     */
+    comments: Array<ThreadedCommentResponse>;
+    
 
-  height: number;
+        
+    next?: string;
+    
 
-  width: number;
-}
+        
+    prev?: string;
+    
 
-export interface IngressVideoEncodingResponse {
-  layers: IngressVideoLayerResponse[];
+        }
+    
 
-  source: IngressSourceResponse;
-}
 
-export interface IngressVideoLayerResponse {
-  bitrate: number;
 
-  codec: string;
 
-  frame_rate_limit: number;
+    export interface GetCommentResponse {
+    duration: string;
+    
 
-  max_dimension: number;
+        
+    comment: CommentResponse;
+    
 
-  min_dimension: number;
-}
+        }
+    
 
-export interface KeyframeRuleParameters {
-  min_confidence?: number;
 
-  threshold?: number;
 
-  harm_labels?: string[];
-}
 
-export interface LLMConfig {
-  enabled: boolean;
+    export interface GetCommentsResponse {
+    duration: string;
+    
 
-  rules: LLMRule[];
+        
+    /**
+     * Sort order used for the comments (first, last, top, best, controversial)
+     */
+    sort: string;
+    
 
-  app_context?: string;
+        
+    /**
+     * Threaded listing for the activity
+     */
+    comments: Array<ThreadedCommentResponse>;
+    
 
-  async?: boolean;
+        
+    next?: string;
+    
 
-  severity_descriptions?: Record<string, string>;
-}
+        
+    prev?: string;
+    
 
-export interface LLMRule {
-  action:
-    | 'flag'
-    | 'shadow'
-    | 'remove'
-    | 'bounce'
-    | 'bounce_flag'
-    | 'bounce_remove'
-    | 'keep';
+        }
+    
 
-  description: string;
 
-  label: string;
 
-  severity_rules: BodyguardSeverityRule[];
-}
 
-export interface LabelThresholds {
-  /**
-   * Threshold for automatic message block
-   */
-  block?: number;
+    export interface GetConfigResponse {
+    duration: string;
+    
 
-  /**
-   * Threshold for automatic message flag
-   */
-  flag?: number;
-}
+        
+    config?: ConfigResponse;
+    
 
-export interface LayoutSettingsResponse {
-  external_app_url: string;
+        }
+    
 
-  external_css_url: string;
 
-  name: string;
 
-  detect_orientation?: boolean;
 
-  options?: Record<string, any>;
-}
+    export interface GetFollowSuggestionsResponse {
+    duration: string;
+    
 
-export interface LimitsSettingsResponse {
-  max_participants_exclude_roles: string[];
+        
+    /**
+     * List of suggested feeds to follow
+     */
+    suggestions: Array<FeedSuggestionResponse>;
+    
 
-  max_duration_seconds?: number;
+        
+    algorithm_used?: string;
+    
 
-  max_participants?: number;
+        }
+    
 
-  max_participants_exclude_owner?: boolean;
-}
 
-export interface ListBlockListResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
 
-  blocklists: BlockListResponse[];
-}
 
-export interface ListDevicesResponse {
-  duration: string;
+    export interface GetOGResponse {
+    duration: string;
+    
 
-  /**
-   * List of devices
-   */
-  devices: DeviceResponse[];
-}
+        
+    custom: Record<string, any>;
+    
 
-export interface ListUserGroupsResponse {
-  duration: string;
+        
+    /**
+     * URL of detected video or audio
+     */
+    asset_url?: string;
+    
 
-  /**
-   * List of user groups
-   */
-  user_groups: UserGroupResponse[];
-}
+        
+    author_icon?: string;
+    
 
-export interface Location {
-  /**
-   * Latitude coordinate
-   */
-  lat: number;
+        
+    /**
+     * og:site
+     */
+    author_link?: string;
+    
 
-  /**
-   * Longitude coordinate
-   */
-  lng: number;
-}
+        
+    /**
+     * og:site_name
+     */
+    author_name?: string;
+    
 
-export interface MarkActivityRequest {
-  /**
-   * Whether to mark all activities as read
-   */
-  mark_all_read?: boolean;
+        
+    color?: string;
+    
 
-  /**
-   * Whether to mark all activities as seen
-   */
-  mark_all_seen?: boolean;
+        
+    fallback?: string;
+    
 
-  /**
-   * List of activity IDs to mark as read
-   */
-  mark_read?: string[];
+        
+    footer?: string;
+    
 
-  /**
-   * List of activity IDs to mark as seen
-   */
-  mark_seen?: string[];
+        
+    footer_icon?: string;
+    
 
-  /**
-   * List of activity IDs to mark as watched (for stories)
-   */
-  mark_watched?: string[];
-}
+        
+    /**
+     * URL of detected image
+     */
+    image_url?: string;
+    
 
-export interface MarkReviewedRequestPayload {
-  /**
-   * Maximum content items to mark as reviewed
-   */
-  content_to_mark_as_reviewed_limit?: number;
+        
+    /**
+     * extracted url from the text
+     */
+    og_scrape_url?: string;
+    
 
-  /**
-   * Reason for the appeal decision
-   */
-  decision_reason?: string;
+        
+    original_height?: number;
+    
 
-  /**
-   * Skip marking content as reviewed
-   */
-  disable_marking_content_as_reviewed?: boolean;
-}
+        
+    original_width?: number;
+    
 
-export interface MembershipLevelResponse {
-  /**
-   * When the membership level was created
-   */
-  created_at: Date;
+        
+    pretext?: string;
+    
 
-  /**
-   * Unique identifier for the membership level
-   */
-  id: string;
+        
+    /**
+     * og:description
+     */
+    text?: string;
+    
 
-  /**
-   * Display name for the membership level
-   */
-  name: string;
+        
+    /**
+     * URL of detected thumb image
+     */
+    thumb_url?: string;
+    
 
-  /**
-   * Priority level
-   */
-  priority: number;
+        
+    /**
+     * og:title
+     */
+    title?: string;
+    
 
-  /**
-   * When the membership level was last updated
-   */
-  updated_at: Date;
+        
+    /**
+     * og:url
+     */
+    title_link?: string;
+    
 
-  /**
-   * Activity tags this membership level gives access to
-   */
-  tags: string[];
+        
+    /**
+     * Attachment type, could be empty, image, audio or video
+     */
+    type?: string;
+    
 
-  /**
-   * Description of the membership level
-   */
-  description?: string;
+        
+    actions?: Array<Action>;
+    
 
-  /**
-   * Custom data for the membership level
-   */
-  custom?: Record<string, any>;
-}
+        
+    fields?: Array<Field>;
+    
 
-export interface MessageResponse {
-  /**
-   * Channel unique identifier in <type>:<id> format
-   */
-  cid: string;
+        
+    giphy?: Images;
+    
 
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        }
+    
 
-  deleted_reply_count: number;
 
-  /**
-   * Contains HTML markup of the message. Can only be set when using server-side API
-   */
-  html: string;
 
-  /**
-   * Message ID is unique string identifier of the message
-   */
-  id: string;
 
-  /**
-   * Whether the message mentioned the channel tag
-   */
-  mentioned_channel: boolean;
+    export interface GetOrCreateFeedRequest {
+    id_around?: string;
+    
 
-  /**
-   * Whether the message mentioned online users with @here tag
-   */
-  mentioned_here: boolean;
+        
+    limit?: number;
+    
 
-  /**
-   * Whether message is pinned or not
-   */
-  pinned: boolean;
+        
+    next?: string;
+    
 
-  /**
-   * Number of replies to this message
-   */
-  reply_count: number;
+        
+    prev?: string;
+    
 
-  /**
-   * Whether the message was shadowed or not
-   */
-  shadowed: boolean;
+        
+    view?: string;
+    
 
-  /**
-   * Whether message is silent or not
-   */
-  silent: boolean;
+        
+    watch?: boolean;
+    
 
-  /**
-   * Text of the message. Should be empty if `mml` is provided
-   */
-  text: string;
+        
+    data?: FeedInput;
+    
 
-  /**
-   * Contains type of the message. One of: regular, ephemeral, error, reply, system, deleted
-   */
-  type: string;
+        
+    enrichment_options?: EnrichmentOptions;
+    
 
-  /**
-   * Date/time of the last update
-   */
-  updated_at: Date;
+        
+    external_ranking?: Record<string, any>;
+    
 
-  /**
-   * Array of message attachments
-   */
-  attachments: Attachment[];
+        
+    filter?: Record<string, any>;
+    
 
-  /**
-   * List of 10 latest reactions to this message
-   */
-  latest_reactions: ReactionResponse[];
+        
+    followers_pagination?: PagerRequest;
+    
 
-  /**
-   * List of mentioned users
-   */
-  mentioned_users: UserResponse[];
+        
+    following_pagination?: PagerRequest;
+    
 
-  /**
-   * List of 10 latest reactions of authenticated user to this message
-   */
-  own_reactions: ReactionResponse[];
+        
+    friend_reactions_options?: FriendReactionsOptions;
+    
 
-  /**
-   * A list of user ids that have restricted visibility to the message, if the list is not empty, the message is only visible to the users in the list
-   */
-  restricted_visibility: string[];
+        
+    interest_weights?: Record<string, number>;
+    
 
-  custom: Record<string, any>;
+        
+    member_pagination?: PagerRequest;
+    
 
-  /**
-   * An object containing number of reactions of each type. Key: reaction type (string), value: number of reactions (int)
-   */
-  reaction_counts: Record<string, number>;
+        }
+    
 
-  /**
-   * An object containing scores of reactions of each type. Key: reaction type (string), value: total score of reactions (int)
-   */
-  reaction_scores: Record<string, number>;
 
-  user: UserResponse;
 
-  /**
-   * Contains provided slash command
-   */
-  command?: string;
 
-  /**
-   * Date/time of deletion
-   */
-  deleted_at?: Date;
+    export interface GetOrCreateFeedResponse {
+    created: boolean;
+    
 
-  deleted_for_me?: boolean;
+        
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  message_text_updated_at?: Date;
+        
+    activities: Array<ActivityResponse>;
+    
 
-  /**
-   * Should be empty if `text` is provided. Can only be set when using server-side API
-   */
-  mml?: string;
+        
+    aggregated_activities: Array<AggregatedActivityResponse>;
+    
 
-  /**
-   * ID of parent message (thread)
-   */
-  parent_id?: string;
+        
+    followers: Array<FollowResponse>;
+    
 
-  /**
-   * Date when pinned message expires
-   */
-  pin_expires?: Date;
+        
+    following: Array<FollowResponse>;
+    
 
-  /**
-   * Date when message got pinned
-   */
-  pinned_at?: Date;
+        
+    members: Array<FeedMemberResponse>;
+    
 
-  /**
-   * Identifier of the poll to include in the message
-   */
-  poll_id?: string;
+        
+    pinned_activities: Array<ActivityPinResponse>;
+    
 
-  quoted_message_id?: string;
+        
+    feed: FeedResponse;
+    
 
-  /**
-   * Whether thread reply should be shown in the channel as well
-   */
-  show_in_channel?: boolean;
+        
+    next?: string;
+    
 
-  /**
-   * List of user group IDs mentioned in the message. Group members who are also channel members will receive push notifications based on their push preferences. Max 10 groups
-   */
-  mentioned_group_ids?: string[];
+        
+    prev?: string;
+    
 
-  /**
-   * List of roles mentioned in the message (e.g. admin, channel_moderator, custom roles). Members with matching roles will receive push notifications based on their push preferences. Max 10 roles
-   */
-  mentioned_roles?: string[];
+        
+    followers_pagination?: PagerResponse;
+    
 
-  /**
-   * List of users who participate in thread
-   */
-  thread_participants?: UserResponse[];
+        
+    following_pagination?: PagerResponse;
+    
 
-  draft?: DraftResponse;
+        
+    member_pagination?: PagerResponse;
+    
 
-  /**
-   * Object with translations. Key `language` contains the original language key. Other keys contain translations
-   */
-  i18n?: Record<string, string>;
+        
+    notification_status?: NotificationStatusResponse;
+    
 
-  /**
-   * Contains image moderation information
-   */
-  image_labels?: Record<string, string[]>;
+        }
+    
 
-  member?: ChannelMemberResponse;
 
-  moderation?: ModerationV2Response;
 
-  pinned_by?: UserResponse;
 
-  poll?: PollResponseData;
+    export interface GetUserGroupResponse {
+    duration: string;
+    
 
-  quoted_message?: MessageResponse;
+        
+    user_group?: UserGroupResponse;
+    
 
-  reaction_groups?: Record<string, ReactionGroupResponse>;
+        }
+    
 
-  reminder?: ReminderResponseData;
 
-  shared_location?: SharedLocationResponseData;
-}
 
-export interface ModerationActionConfigResponse {
-  /**
-   * The action to take
-   */
-  action: string;
 
-  /**
-   * Description of what this action does
-   */
-  description: string;
+    export interface GoogleVisionConfig {
+    enabled?: boolean;
+    
 
-  /**
-   * Type of entity this action applies to
-   */
-  entity_type: string;
+        }
+    
 
-  /**
-   * Icon for the dashboard
-   */
-  icon: string;
 
-  /**
-   * Display order (lower numbers shown first)
-   */
-  order: number;
 
-  /**
-   * Queue type this action config belongs to
-   */
-  queue_type?: string;
 
-  /**
-   * Custom data for the action
-   */
-  custom?: Record<string, any>;
-}
+    export interface HarmConfig {
+    cooldown_period: number;
+    
 
-export interface ModerationCustomActionEvent {
-  /**
-   * The ID of the custom action that was executed
-   */
-  action_id: string;
+        
+    severity: number;
+    
 
-  created_at: Date;
+        
+    threshold: number;
+    
 
-  custom: Record<string, any>;
+        
+    action_sequences: Array<ActionSequence>;
+    
 
-  review_queue_item: ReviewQueueItemResponse;
+        
+    harm_types: Array<string>;
+    
 
-  type: string;
+        }
+    
 
-  received_at?: Date;
 
-  /**
-   * Additional options passed to the custom action
-   */
-  action_options?: Record<string, any>;
 
-  message?: MessageResponse;
-}
 
-export interface ModerationFlagResponse {
-  created_at: Date;
+    export interface HealthCheckEvent {
+    connection_id: string;
+    
 
-  entity_id: string;
+        
+    created_at: Date;
+    
 
-  entity_type: string;
+        
+    custom: Record<string, any>;
+    
 
-  type: string;
+        
+    type: string;
+    
 
-  updated_at: Date;
+        
+    cid?: string;
+    
 
-  user_id: string;
+        
+    received_at?: Date;
+    
 
-  result: Array<Record<string, any>>;
+        
+    me?: OwnUserResponse;
+    
 
-  entity_creator_id?: string;
+        }
+    
 
-  reason?: string;
 
-  review_queue_item_id?: string;
 
-  labels?: string[];
 
-  custom?: Record<string, any>;
+    export interface ImageContentParameters {
+    label_operator?: string;
+    
 
-  moderation_payload?: ModerationPayloadResponse;
+        
+    min_confidence?: number;
+    
 
-  review_queue_item?: ReviewQueueItemResponse;
+        
+    harm_labels?: Array<string>;
+    
 
-  user?: UserResponse;
-}
+        }
+    
 
-export interface ModerationFlaggedEvent {
-  /**
-   * The type of content that was flagged
-   */
-  content_type: string;
 
-  created_at: Date;
 
-  /**
-   * The ID of the flagged content
-   */
-  object_id: string;
 
-  custom: Record<string, any>;
+    export interface ImageData {
+    frames: string;
+    
 
-  type: string;
+        
+    height: string;
+    
 
-  received_at?: Date;
-}
+        
+    size: string;
+    
 
-export interface ModerationMarkReviewedEvent {
-  created_at: Date;
+        
+    url: string;
+    
 
-  custom: Record<string, any>;
+        
+    width: string;
+    
 
-  item: ReviewQueueItemResponse;
+        }
+    
 
-  type: string;
 
-  received_at?: Date;
 
-  message?: MessageResponse;
-}
 
-export interface ModerationPayload {
-  images?: string[];
+    export interface ImageRuleParameters {
+    min_confidence?: number;
+    
 
-  texts?: string[];
+        
+    threshold?: number;
+    
 
-  videos?: string[];
+        
+    time_window?: string;
+    
 
-  custom?: Record<string, any>;
-}
+        
+    harm_labels?: Array<string>;
+    
 
-export interface ModerationPayloadResponse {
-  /**
-   * Image URLs to moderate
-   */
-  images?: string[];
+        }
+    
 
-  /**
-   * Text content to moderate
-   */
-  texts?: string[];
 
-  /**
-   * Video URLs to moderate
-   */
-  videos?: string[];
 
-  /**
-   * Custom data for moderation
-   */
-  custom?: Record<string, any>;
-}
 
-export interface ModerationV2Response {
-  action: string;
+    export interface ImageSize {
+    /**
+     * Crop mode. One of: top, bottom, left, right, center
+     */
+    crop?: string;
+    
 
-  original_text: string;
+        
+    /**
+     * Target image height
+     */
+    height?: number;
+    
 
-  blocklist_matched?: string;
+        
+    /**
+     * Resize method. One of: clip, crop, scale, fill
+     */
+    resize?: string;
+    
 
-  platform_circumvented?: boolean;
+        
+    /**
+     * Target image width
+     */
+    width?: number;
+    
 
-  semantic_filter_matched?: string;
+        }
+    
 
-  blocklists_matched?: string[];
 
-  image_harms?: string[];
 
-  text_harms?: string[];
-}
 
-export interface MuteRequest {
-  /**
-   * User IDs to mute (if multiple users)
-   */
-  target_ids: string[];
+    export interface ImageUploadRequest {
+    file?: string;
+    
 
-  /**
-   * Duration of mute in minutes
-   */
-  timeout?: number;
-}
+        
+    /**
+     * field with JSON-encoded array of image size configurations
+     */
+    upload_sizes?: Array<ImageSize>;
+    
 
-export interface MuteResponse {
-  duration: string;
+        
+    user?: OnlyUserID;
+    
 
-  /**
-   * Object with mutes (if multiple users were muted)
-   */
-  mutes?: UserMuteResponse[];
+        }
+    
 
-  /**
-   * A list of users that can't be found. Common cause for this is deleted users
-   */
-  non_existing_users?: string[];
 
-  own_user?: OwnUserResponse;
-}
 
-export interface NoiseCancellationSettings {
-  mode: string;
-}
 
-export interface NotificationComment {
-  comment: string;
+    export interface ImageUploadResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  id: string;
+        
+    file?: string;
+    
 
-  user_id: string;
+        
+    thumb_url?: string;
+    
 
-  attachments?: Attachment[];
-}
+        
+    /**
+     * Array of image size configurations
+     */
+    upload_sizes?: Array<ImageSize>;
+    
 
-export interface NotificationConfig {
-  deduplication_window?: string;
+        }
+    
 
-  track_read?: boolean;
 
-  track_seen?: boolean;
-}
 
-export interface NotificationContext {
-  target?: NotificationTarget;
 
-  trigger?: NotificationTrigger;
-}
+    export interface Images {
+    fixed_height: ImageData;
+    
 
-export interface NotificationFeedUpdatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    fixed_height_downsampled: ImageData;
+    
 
-  /**
-   * The ID of the feed
-   */
-  fid: string;
+        
+    fixed_height_still: ImageData;
+    
 
-  custom: Record<string, any>;
+        
+    fixed_width: ImageData;
+    
 
-  /**
-   * The type of event: "feeds.notification_feed.updated" in this case
-   */
-  type: string;
+        
+    fixed_width_downsampled: ImageData;
+    
 
-  feed_visibility?: string;
+        
+    fixed_width_still: ImageData;
+    
 
-  received_at?: Date;
+        
+    original: ImageData;
+    
 
-  /**
-   * Aggregated activities for notification feeds
-   */
-  aggregated_activities?: AggregatedActivityResponse[];
+        }
+    
 
-  notification_status?: NotificationStatusResponse;
 
-  user?: UserResponseCommonFields;
-}
 
-export interface NotificationParentActivity {
-  id: string;
 
-  text?: string;
+    export interface KeyframeRuleParameters {
+    min_confidence?: number;
+    
 
-  type?: string;
+        
+    threshold?: number;
+    
 
-  user_id?: string;
+        
+    harm_labels?: Array<string>;
+    
 
-  attachments?: Attachment[];
-}
+        }
+    
 
-export interface NotificationStatusResponse {
-  /**
-   * Number of unread notifications
-   */
-  unread: number;
 
-  /**
-   * Number of unseen notifications
-   */
-  unseen: number;
 
-  /**
-   * When notifications were last read
-   */
-  last_read_at?: Date;
 
-  /**
-   * When notifications were last seen
-   */
-  last_seen_at?: Date;
+    export interface LLMConfig {
+    enabled: boolean;
+    
 
-  /**
-   * Deprecated: use is_read on each activity/group instead. IDs of activities that have been read. Capped at ~101 entries for aggregated feeds.
-   */
-  read_activities?: string[];
+        
+    rules: Array<LLMRule>;
+    
 
-  /**
-   * Deprecated: use is_seen on each activity/group instead. IDs of activities that have been seen. Capped at ~101 entries for aggregated feeds.
-   */
-  seen_activities?: string[];
-}
+        
+    app_context?: string;
+    
 
-export interface NotificationTarget {
-  /**
-   * The ID of the target (activity ID or user ID)
-   */
-  id: string;
+        
+    async?: boolean;
+    
 
-  /**
-   * The name of the target user (for user targets like follows)
-   */
-  name?: string;
+        
+    severity_descriptions?: Record<string, string>;
+    
 
-  /**
-   * The text content of the target activity (for activity targets)
-   */
-  text?: string;
+        }
+    
 
-  /**
-   * The type of the target activity (for activity targets)
-   */
-  type?: string;
 
-  /**
-   * The ID of the user who created the target activity (for activity targets)
-   */
-  user_id?: string;
 
-  /**
-   * Attachments on the target activity (for activity targets)
-   */
-  attachments?: Attachment[];
 
-  comment?: NotificationComment;
+    export interface LLMRule {
+    
+        action:| "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" | "keep" ;
 
-  /**
-   * Custom data from the target activity
-   */
-  custom?: Record<string, any>;
+        
+    description: string;
+    
 
-  parent_activity?: NotificationParentActivity;
-}
+        
+    label: string;
+    
 
-export interface NotificationTrigger {
-  /**
-   * Human-readable text describing the notification
-   */
-  text: string;
+        
+    severity_rules: Array<BodyguardSeverityRule>;
+    
 
-  /**
-   * The type of notification (mention, reaction, comment, follow, etc.)
-   */
-  type: string;
+        }
+    
 
-  comment?: NotificationComment;
 
-  /**
-   * Custom data from the trigger object (comment, reaction, etc.)
-   */
-  custom?: Record<string, any>;
-}
 
-export interface OCRRule {
-  action:
-    | 'flag'
-    | 'shadow'
-    | 'remove'
-    | 'bounce'
-    | 'bounce_flag'
-    | 'bounce_remove';
 
-  label: string;
-}
+    export interface LabelThresholds {
+    /**
+     * Threshold for automatic message block
+     */
+    block?: number;
+    
 
-export interface OnlyUserID {
-  id: string;
-}
+        
+    /**
+     * Threshold for automatic message flag
+     */
+    flag?: number;
+    
 
-export interface OwnBatchRequest {
-  /**
-   * List of feed IDs to get own fields for
-   */
-  feeds: string[];
+        }
+    
 
-  /**
-   * Optional list of specific fields to return. If not specified, all fields (own_follows, own_followings, own_capabilities, own_membership) are returned
-   */
-  fields?: string[];
-}
 
-export interface OwnBatchResponse {
-  duration: string;
 
-  /**
-   * Map of feed ID to own fields data
-   */
-  data: Record<string, FeedOwnData>;
-}
 
-export interface OwnUserResponse {
-  banned: boolean;
+    export interface ListBlockListResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  created_at: Date;
+        
+    blocklists: Array<BlockListResponse>;
+    
 
-  id: string;
+        }
+    
 
-  invisible: boolean;
 
-  language: string;
 
-  online: boolean;
 
-  role: string;
+    export interface ListDevicesResponse {
+    duration: string;
+    
 
-  total_unread_count: number;
+        
+    /**
+     * List of devices
+     */
+    devices: Array<DeviceResponse>;
+    
 
-  unread_channels: number;
+        }
+    
 
-  unread_count: number;
 
-  unread_threads: number;
 
-  updated_at: Date;
 
-  channel_mutes: ChannelMute[];
+    export interface ListUserGroupsResponse {
+    duration: string;
+    
 
-  devices: DeviceResponse[];
+        
+    /**
+     * List of user groups
+     */
+    user_groups: Array<UserGroupResponse>;
+    
 
-  mutes: UserMuteResponse[];
+        }
+    
 
-  teams: string[];
 
-  custom: Record<string, any>;
 
-  avg_response_time?: number;
 
-  deactivated_at?: Date;
+    export interface Location {
+    /**
+     * Latitude coordinate
+     */
+    lat: number;
+    
 
-  deleted_at?: Date;
+        
+    /**
+     * Longitude coordinate
+     */
+    lng: number;
+    
 
-  image?: string;
+        }
+    
 
-  last_active?: Date;
 
-  name?: string;
 
-  revoke_tokens_issued_before?: Date;
 
-  blocked_user_ids?: string[];
+    export interface MarkActivityRequest {
+    /**
+     * Whether to mark all activities as read
+     */
+    mark_all_read?: boolean;
+    
 
-  latest_hidden_channels?: string[];
+        
+    /**
+     * Whether to mark all activities as seen
+     */
+    mark_all_seen?: boolean;
+    
 
-  privacy_settings?: PrivacySettingsResponse;
+        
+    /**
+     * List of activity IDs to mark as read
+     */
+    mark_read?: Array<string>;
+    
 
-  push_preferences?: PushPreferencesResponse;
+        
+    /**
+     * List of activity IDs to mark as seen
+     */
+    mark_seen?: Array<string>;
+    
 
-  teams_role?: Record<string, string>;
+        
+    /**
+     * List of activity IDs to mark as watched (for stories)
+     */
+    mark_watched?: Array<string>;
+    
 
-  total_unread_count_by_team?: Record<string, number>;
-}
+        }
+    
 
-export interface PagerRequest {
-  limit?: number;
 
-  next?: string;
 
-  prev?: string;
-}
 
-export interface PagerResponse {
-  next?: string;
+    export interface MarkReviewedRequestPayload {
+    /**
+     * Maximum content items to mark as reviewed
+     */
+    content_to_mark_as_reviewed_limit?: number;
+    
 
-  prev?: string;
-}
+        
+    /**
+     * Reason for the appeal decision
+     */
+    decision_reason?: string;
+    
 
-export interface PinActivityRequest {
-  /**
-   * If true, enriches the activity's current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-   */
-  enrich_own_fields?: boolean;
-}
+        
+    /**
+     * Skip marking content as reviewed
+     */
+    disable_marking_content_as_reviewed?: boolean;
+    
 
-export interface PinActivityResponse {
-  /**
-   * When the activity was pinned
-   */
-  created_at: Date;
+        }
+    
 
-  duration: string;
 
-  /**
-   * Fully qualified ID of the feed the activity was pinned to
-   */
-  feed: string;
 
-  /**
-   * ID of the user who pinned the activity
-   */
-  user_id: string;
 
-  activity: ActivityResponse;
-}
+    export interface MembershipLevelResponse {
+    /**
+     * When the membership level was created
+     */
+    created_at: Date;
+    
 
-export interface PollClosedFeedEvent {
-  created_at: Date;
+        
+    /**
+     * Unique identifier for the membership level
+     */
+    id: string;
+    
 
-  fid: string;
+        
+    /**
+     * Display name for the membership level
+     */
+    name: string;
+    
 
-  custom: Record<string, any>;
+        
+    /**
+     * Priority level
+     */
+    priority: number;
+    
 
-  poll: PollResponseData;
+        
+    /**
+     * When the membership level was last updated
+     */
+    updated_at: Date;
+    
 
-  type: string;
+        
+    /**
+     * Activity tags this membership level gives access to
+     */
+    tags: Array<string>;
+    
 
-  feed_visibility?: string;
+        
+    /**
+     * Description of the membership level
+     */
+    description?: string;
+    
 
-  received_at?: Date;
-}
+        
+    /**
+     * Custom data for the membership level
+     */
+    custom?: Record<string, any>;
+    
 
-export interface PollDeletedFeedEvent {
-  created_at: Date;
+        }
+    
 
-  fid: string;
 
-  custom: Record<string, any>;
 
-  poll: PollResponseData;
 
-  type: string;
+    export interface MessageResponse {
+    /**
+     * Channel unique identifier in <type>:<id> format
+     */
+    cid: string;
+    
 
-  feed_visibility?: string;
+        
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  received_at?: Date;
-}
+        
+    deleted_reply_count: number;
+    
 
-export interface PollOptionInput {
-  text?: string;
+        
+    /**
+     * Contains HTML markup of the message. Can only be set when using server-side API
+     */
+    html: string;
+    
 
-  custom?: Record<string, any>;
-}
+        
+    /**
+     * Message ID is unique string identifier of the message
+     */
+    id: string;
+    
 
-export interface PollOptionRequest {
-  id: string;
+        
+    /**
+     * Whether the message mentioned the channel tag
+     */
+    mentioned_channel: boolean;
+    
 
-  text?: string;
+        
+    /**
+     * Whether the message mentioned online users with @here tag
+     */
+    mentioned_here: boolean;
+    
 
-  custom?: Record<string, any>;
-}
+        
+    /**
+     * Whether message is pinned or not
+     */
+    pinned: boolean;
+    
 
-export interface PollOptionResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        
+    /**
+     * Number of replies to this message
+     */
+    reply_count: number;
+    
 
-  poll_option: PollOptionResponseData;
-}
+        
+    /**
+     * Whether the message was shadowed or not
+     */
+    shadowed: boolean;
+    
 
-export interface PollOptionResponseData {
-  id: string;
+        
+    /**
+     * Whether message is silent or not
+     */
+    silent: boolean;
+    
 
-  text: string;
+        
+    /**
+     * Text of the message. Should be empty if `mml` is provided
+     */
+    text: string;
+    
 
-  custom: Record<string, any>;
-}
+        
+    /**
+     * Contains type of the message. One of: regular, ephemeral, error, reply, system, deleted
+     */
+    type: string;
+    
 
-export interface PollResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        
+    /**
+     * Date/time of the last update
+     */
+    updated_at: Date;
+    
 
-  poll: PollResponseData;
-}
+        
+    /**
+     * Array of message attachments
+     */
+    attachments: Array<Attachment>;
+    
 
-export interface PollResponseData {
-  allow_answers: boolean;
+        
+    /**
+     * List of 10 latest reactions to this message
+     */
+    latest_reactions: Array<ReactionResponse>;
+    
 
-  allow_user_suggested_options: boolean;
+        
+    /**
+     * List of mentioned users
+     */
+    mentioned_users: Array<UserResponse>;
+    
 
-  answers_count: number;
+        
+    /**
+     * List of 10 latest reactions of authenticated user to this message
+     */
+    own_reactions: Array<ReactionResponse>;
+    
 
-  created_at: Date;
+        
+    /**
+     * A list of user ids that have restricted visibility to the message, if the list is not empty, the message is only visible to the users in the list
+     */
+    restricted_visibility: Array<string>;
+    
 
-  created_by_id: string;
+        
+    custom: Record<string, any>;
+    
 
-  description: string;
+        
+    /**
+     * An object containing number of reactions of each type. Key: reaction type (string), value: number of reactions (int)
+     */
+    reaction_counts: Record<string, number>;
+    
 
-  enforce_unique_vote: boolean;
+        
+    /**
+     * An object containing scores of reactions of each type. Key: reaction type (string), value: total score of reactions (int)
+     */
+    reaction_scores: Record<string, number>;
+    
 
-  id: string;
+        
+    user: UserResponse;
+    
 
-  name: string;
+        
+    /**
+     * Contains provided slash command
+     */
+    command?: string;
+    
 
-  updated_at: Date;
+        
+    /**
+     * Date/time of deletion
+     */
+    deleted_at?: Date;
+    
 
-  vote_count: number;
+        
+    deleted_for_me?: boolean;
+    
 
-  voting_visibility: string;
+        
+    message_text_updated_at?: Date;
+    
 
-  latest_answers: PollVoteResponseData[];
+        
+    /**
+     * Should be empty if `text` is provided. Can only be set when using server-side API
+     */
+    mml?: string;
+    
 
-  options: PollOptionResponseData[];
+        
+    /**
+     * ID of parent message (thread)
+     */
+    parent_id?: string;
+    
 
-  own_votes: PollVoteResponseData[];
+        
+    /**
+     * Date when pinned message expires
+     */
+    pin_expires?: Date;
+    
 
-  custom: Record<string, any>;
+        
+    /**
+     * Date when message got pinned
+     */
+    pinned_at?: Date;
+    
 
-  latest_votes_by_option: Record<string, PollVoteResponseData[]>;
+        
+    /**
+     * Identifier of the poll to include in the message
+     */
+    poll_id?: string;
+    
 
-  vote_counts_by_option: Record<string, number>;
+        
+    quoted_message_id?: string;
+    
 
-  is_closed?: boolean;
+        
+    /**
+     * Whether thread reply should be shown in the channel as well
+     */
+    show_in_channel?: boolean;
+    
 
-  max_votes_allowed?: number;
+        
+    /**
+     * List of user group IDs mentioned in the message. Group members who are also channel members will receive push notifications based on their push preferences. Max 10 groups
+     */
+    mentioned_group_ids?: Array<string>;
+    
 
-  created_by?: UserResponse;
-}
+        
+    /**
+     * List of roles mentioned in the message (e.g. admin, channel_moderator, custom roles). Members with matching roles will receive push notifications based on their push preferences. Max 10 roles
+     */
+    mentioned_roles?: Array<string>;
+    
 
-export interface PollUpdatedFeedEvent {
-  created_at: Date;
+        
+    /**
+     * List of users who participate in thread
+     */
+    thread_participants?: Array<UserResponse>;
+    
 
-  fid: string;
+        
+    draft?: DraftResponse;
+    
 
-  custom: Record<string, any>;
+        
+    /**
+     * Object with translations. Key `language` contains the original language key. Other keys contain translations
+     */
+    i18n?: Record<string, string>;
+    
 
-  poll: PollResponseData;
+        
+    /**
+     * Contains image moderation information
+     */
+    image_labels?: Record<string, Array<string>>;
+    
 
-  type: string;
+        
+    member?: ChannelMemberResponse;
+    
 
-  feed_visibility?: string;
+        
+    moderation?: ModerationV2Response;
+    
 
-  received_at?: Date;
-}
+        
+    pinned_by?: UserResponse;
+    
 
-export interface PollVoteCastedFeedEvent {
-  created_at: Date;
+        
+    poll?: PollResponseData;
+    
 
-  fid: string;
+        
+    quoted_message?: MessageResponse;
+    
 
-  custom: Record<string, any>;
+        
+    reaction_groups?: Record<string, ReactionGroupResponse>;
+    
 
-  poll: PollResponseData;
+        
+    reminder?: ReminderResponseData;
+    
 
-  poll_vote: PollVoteResponseData;
+        
+    shared_location?: SharedLocationResponseData;
+    
 
-  type: string;
+        }
+    
 
-  feed_visibility?: string;
 
-  received_at?: Date;
-}
 
-export interface PollVoteChangedFeedEvent {
-  created_at: Date;
 
-  fid: string;
+    export interface ModerationActionConfigResponse {
+    /**
+     * The action to take
+     */
+    action: string;
+    
 
-  custom: Record<string, any>;
+        
+    /**
+     * Description of what this action does
+     */
+    description: string;
+    
 
-  poll: PollResponseData;
+        
+    /**
+     * Type of entity this action applies to
+     */
+    entity_type: string;
+    
 
-  poll_vote: PollVoteResponseData;
+        
+    /**
+     * Icon for the dashboard
+     */
+    icon: string;
+    
 
-  type: string;
+        
+    /**
+     * Display order (lower numbers shown first)
+     */
+    order: number;
+    
 
-  feed_visibility?: string;
+        
+    id?: string;
+    
 
-  received_at?: Date;
-}
+        
+    /**
+     * Queue type this action config belongs to
+     */
+    queue_type?: string;
+    
 
-export interface PollVoteRemovedFeedEvent {
-  created_at: Date;
+        
+    /**
+     * Custom data for the action
+     */
+    custom?: Record<string, any>;
+    
 
-  fid: string;
+        }
+    
 
-  custom: Record<string, any>;
 
-  poll: PollResponseData;
 
-  poll_vote: PollVoteResponseData;
 
-  type: string;
+    export interface ModerationCustomActionEvent {
+    /**
+     * The ID of the custom action that was executed
+     */
+    action_id: string;
+    
 
-  feed_visibility?: string;
+        
+    created_at: Date;
+    
 
-  received_at?: Date;
-}
+        
+    custom: Record<string, any>;
+    
 
-export interface PollVoteResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        
+    review_queue_item: ReviewQueueItemResponse;
+    
 
-  poll?: PollResponseData;
+        
+    type: string;
+    
 
-  vote?: PollVoteResponseData;
-}
+        
+    received_at?: Date;
+    
 
-export interface PollVoteResponseData {
-  created_at: Date;
+        
+    /**
+     * Additional options passed to the custom action
+     */
+    action_options?: Record<string, any>;
+    
 
-  id: string;
+        
+    message?: MessageResponse;
+    
 
-  option_id: string;
+        }
+    
 
-  poll_id: string;
 
-  updated_at: Date;
 
-  answer_text?: string;
 
-  is_answer?: boolean;
+    export interface ModerationFlagResponse {
+    created_at: Date;
+    
 
-  user_id?: string;
+        
+    entity_id: string;
+    
 
-  user?: UserResponse;
-}
+        
+    entity_type: string;
+    
 
-export interface PollVotesResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        
+    type: string;
+    
 
-  /**
-   * Poll votes
-   */
-  votes: PollVoteResponseData[];
+        
+    updated_at: Date;
+    
 
-  next?: string;
+        
+    user_id: string;
+    
 
-  prev?: string;
-}
+        
+    result: Array<Record<string, any>>;
+    
 
-export interface PrivacySettingsResponse {
-  delivery_receipts?: DeliveryReceiptsResponse;
+        
+    entity_creator_id?: string;
+    
 
-  read_receipts?: ReadReceiptsResponse;
+        
+    reason?: string;
+    
 
-  typing_indicators?: TypingIndicatorsResponse;
-}
+        
+    review_queue_item_id?: string;
+    
 
-export interface PushNotificationConfig {
-  enable_push?: boolean;
+        
+    labels?: Array<string>;
+    
 
-  push_types?: string[];
-}
+        
+    custom?: Record<string, any>;
+    
 
-export interface PushPreferenceInput {
-  /**
-   * Set the level of call push notifications for the user. One of: all, none, default
-   */
+        
+    moderation_payload?: ModerationPayloadResponse;
+    
 
-  call_level?: 'all' | 'none' | 'default';
+        
+    review_queue_item?: ReviewQueueItemResponse;
+    
 
-  /**
-   * Set the push preferences for a specific channel. If empty it sets the default for the user
-   */
-  channel_cid?: string;
+        
+    user?: UserResponse;
+    
 
-  /**
-   * Set the level of chat push notifications for the user. Note: "mentions" is deprecated in favor of "direct_mentions". One of: all, mentions, direct_mentions, all_mentions, none, default
-   */
+        }
+    
 
-  chat_level?:
-    | 'all'
-    | 'mentions'
-    | 'direct_mentions'
-    | 'all_mentions'
-    | 'none'
-    | 'default';
 
-  /**
-   * Disable push notifications till a certain time
-   */
-  disabled_until?: Date;
 
-  /**
-   * Set the level of feeds push notifications for the user. One of: all, none, default
-   */
 
-  feeds_level?: 'all' | 'none' | 'default';
+    export interface ModerationFlaggedEvent {
+    /**
+     * The type of content that was flagged
+     */
+    content_type: string;
+    
 
-  /**
-   * Remove the disabled until time. (IE stop snoozing notifications)
-   */
-  remove_disable?: boolean;
+        
+    created_at: Date;
+    
 
-  /**
-   * The user id for which to set the push preferences. Required when using server side auths, defaults to current user with client side auth.
-   */
-  user_id?: string;
+        
+    /**
+     * The ID of the flagged content
+     */
+    object_id: string;
+    
 
-  chat_preferences?: ChatPreferencesInput;
+        
+    custom: Record<string, any>;
+    
 
-  feeds_preferences?: FeedsPreferences;
-}
+        
+    type: string;
+    
 
-export interface PushPreferencesResponse {
-  call_level?: string;
+        
+    received_at?: Date;
+    
 
-  chat_level?: string;
+        }
+    
 
-  disabled_until?: Date;
 
-  feeds_level?: string;
 
-  chat_preferences?: ChatPreferencesResponse;
 
-  feeds_preferences?: FeedsPreferencesResponse;
-}
+    export interface ModerationMarkReviewedEvent {
+    created_at: Date;
+    
 
-export interface QueryActivitiesRequest {
-  enrich_own_fields?: boolean;
+        
+    custom: Record<string, any>;
+    
 
-  /**
-   * When true, include soft-deleted activities in the result.
-   */
-  include_soft_deleted_activities?: boolean;
+        
+    item: ReviewQueueItemResponse;
+    
 
-  limit?: number;
+        
+    type: string;
+    
 
-  next?: string;
+        
+    received_at?: Date;
+    
 
-  prev?: string;
+        
+    message?: MessageResponse;
+    
 
-  /**
-   * Sorting parameters for the query
-   */
-  sort?: SortParamRequest[];
+        }
+    
 
-  /**
-   * Filters to apply to the query. Supports location-based queries with 'near' and 'within_bounds' operators.
-   */
-  filter?: Record<string, any>;
-}
 
-export interface QueryActivitiesResponse {
-  duration: string;
 
-  /**
-   * List of activities matching the query
-   */
-  activities: ActivityResponse[];
 
-  /**
-   * Cursor for next page
-   */
-  next?: string;
+    export interface ModerationPayload {
+    images?: Array<string>;
+    
 
-  /**
-   * Cursor for previous page
-   */
-  prev?: string;
-}
+        
+    texts?: Array<string>;
+    
 
-export interface QueryActivityReactionsRequest {
-  limit?: number;
+        
+    videos?: Array<string>;
+    
 
-  next?: string;
+        
+    custom?: Record<string, any>;
+    
 
-  prev?: string;
+        }
+    
 
-  sort?: SortParamRequest[];
 
-  filter?: Record<string, any>;
-}
 
-export interface QueryActivityReactionsResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
 
-  reactions: FeedsReactionResponse[];
+    export interface ModerationPayloadResponse {
+    /**
+     * Image URLs to moderate
+     */
+    images?: Array<string>;
+    
 
-  next?: string;
+        
+    /**
+     * Text content to moderate
+     */
+    texts?: Array<string>;
+    
 
-  prev?: string;
-}
+        
+    /**
+     * Video URLs to moderate
+     */
+    videos?: Array<string>;
+    
 
-export interface QueryAppealsRequest {
-  limit?: number;
+        
+    /**
+     * Custom data for moderation
+     */
+    custom?: Record<string, any>;
+    
 
-  next?: string;
+        }
+    
 
-  prev?: string;
 
-  /**
-   * Sorting parameters for appeals
-   */
-  sort?: SortParamRequest[];
 
-  /**
-   * Filter conditions for appeals
-   */
-  filter?: Record<string, any>;
-}
 
-export interface QueryAppealsResponse {
-  duration: string;
+    export interface ModerationV2Response {
+    action: string;
+    
 
-  /**
-   * List of Appeal Items
-   */
-  items: AppealItemResponse[];
+        
+    original_text: string;
+    
 
-  next?: string;
+        
+    blocklist_matched?: string;
+    
 
-  prev?: string;
-}
+        
+    platform_circumvented?: boolean;
+    
 
-export interface QueryBookmarkFoldersRequest {
-  limit?: number;
+        
+    semantic_filter_matched?: string;
+    
 
-  next?: string;
+        
+    blocklists_matched?: Array<string>;
+    
 
-  prev?: string;
+        
+    image_harms?: Array<string>;
+    
 
-  /**
-   * Sorting parameters for the query
-   */
-  sort?: SortParamRequest[];
+        
+    text_harms?: Array<string>;
+    
 
-  /**
-   * Filters to apply to the query
-   */
-  filter?: Record<string, any>;
-}
+        }
+    
 
-export interface QueryBookmarkFoldersResponse {
-  duration: string;
 
-  /**
-   * List of bookmark folders matching the query
-   */
-  bookmark_folders: BookmarkFolderResponse[];
 
-  /**
-   * Cursor for next page
-   */
-  next?: string;
 
-  /**
-   * Cursor for previous page
-   */
-  prev?: string;
-}
+    export interface MuteRequest {
+    /**
+     * User IDs to mute (if multiple users)
+     */
+    target_ids: Array<string>;
+    
 
-export interface QueryBookmarksRequest {
-  enrich_own_fields?: boolean;
+        
+    /**
+     * Duration of mute in minutes
+     */
+    timeout?: number;
+    
 
-  limit?: number;
+        }
+    
 
-  next?: string;
 
-  prev?: string;
 
-  /**
-   * Sorting parameters for the query
-   */
-  sort?: SortParamRequest[];
 
-  /**
-   * Filters to apply to the query
-   */
-  filter?: Record<string, any>;
-}
+    export interface MuteResponse {
+    duration: string;
+    
 
-export interface QueryBookmarksResponse {
-  duration: string;
+        
+    /**
+     * Object with mutes (if multiple users were muted)
+     */
+    mutes?: Array<UserMuteResponse>;
+    
 
-  /**
-   * List of bookmarks matching the query
-   */
-  bookmarks: BookmarkResponse[];
+        
+    /**
+     * A list of users that can't be found. Common cause for this is deleted users
+     */
+    non_existing_users?: Array<string>;
+    
 
-  /**
-   * Cursor for next page
-   */
-  next?: string;
+        
+    own_user?: OwnUserResponse;
+    
 
-  /**
-   * Cursor for previous page
-   */
-  prev?: string;
-}
+        }
+    
 
-export interface QueryCollectionsRequest {
-  limit?: number;
 
-  next?: string;
 
-  prev?: string;
 
-  /**
-   * Sorting parameters for the query
-   */
-  sort?: SortParamRequest[];
+    export interface NotificationComment {
+    comment: string;
+    
 
-  /**
-   * Filters to apply to the query
-   */
-  filter?: Record<string, any>;
-}
+        
+    id: string;
+    
 
-export interface QueryCollectionsResponse {
-  duration: string;
+        
+    user_id: string;
+    
 
-  /**
-   * List of collections matching the query
-   */
-  collections: CollectionResponse[];
+        
+    attachments?: Array<Attachment>;
+    
 
-  /**
-   * Cursor for next page
-   */
-  next?: string;
+        }
+    
 
-  /**
-   * Cursor for previous page
-   */
-  prev?: string;
-}
 
-export interface QueryCommentReactionsRequest {
-  limit?: number;
 
-  next?: string;
 
-  prev?: string;
+    export interface NotificationConfig {
+    deduplication_window?: string;
+    
 
-  sort?: SortParamRequest[];
+        
+    track_read?: boolean;
+    
 
-  filter?: Record<string, any>;
-}
+        
+    track_seen?: boolean;
+    
 
-export interface QueryCommentReactionsResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        }
+    
 
-  reactions: FeedsReactionResponse[];
 
-  next?: string;
 
-  prev?: string;
-}
 
-export interface QueryCommentsRequest {
-  /**
-   * Filter to apply to the query
-   */
-  filter: Record<string, any>;
+    export interface NotificationContext {
+    target?: NotificationTarget;
+    
 
-  /**
-   * Returns the comment with the specified ID along with surrounding comments for context
-   */
-  id_around?: string;
+        
+    trigger?: NotificationTrigger;
+    
 
-  /**
-   * Maximum number of comments to return
-   */
-  limit?: number;
+        }
+    
 
-  next?: string;
 
-  prev?: string;
 
-  /**
-   * Array of sort parameters
-   */
 
-  sort?: 'first' | 'last' | 'top' | 'best' | 'controversial';
-}
+    export interface NotificationFeedUpdatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-export interface QueryCommentsResponse {
-  duration: string;
+        
+    /**
+     * The ID of the feed
+     */
+    fid: string;
+    
 
-  /**
-   * List of comments matching the query
-   */
-  comments: CommentResponse[];
+        
+    custom: Record<string, any>;
+    
 
-  /**
-   * Cursor for next page
-   */
-  next?: string;
+        
+    /**
+     * The type of event: "feeds.notification_feed.updated" in this case
+     */
+    type: string;
+    
 
-  /**
-   * Cursor for previous page
-   */
-  prev?: string;
-}
+        
+    feed_visibility?: string;
+    
 
-export interface QueryFeedMembersRequest {
-  limit?: number;
+        
+    received_at?: Date;
+    
 
-  next?: string;
+        
+    /**
+     * Aggregated activities for notification feeds
+     */
+    aggregated_activities?: Array<AggregatedActivityResponse>;
+    
 
-  prev?: string;
+        
+    notification_status?: NotificationStatusResponse;
+    
 
-  /**
-   * Sort parameters for the query
-   */
-  sort?: SortParamRequest[];
+        
+    user?: UserResponseCommonFields;
+    
 
-  /**
-   * Filter parameters for the query
-   */
-  filter?: Record<string, any>;
-}
+        }
+    
 
-export interface QueryFeedMembersResponse {
-  duration: string;
 
-  /**
-   * List of feed members
-   */
-  members: FeedMemberResponse[];
 
-  /**
-   * Cursor for next page
-   */
-  next?: string;
 
-  /**
-   * Cursor for previous page
-   */
-  prev?: string;
-}
+    export interface NotificationParentActivity {
+    id: string;
+    
 
-export interface QueryFeedsRequest {
-  enrich_own_fields?: boolean;
+        
+    text?: string;
+    
 
-  limit?: number;
+        
+    type?: string;
+    
 
-  next?: string;
+        
+    user_id?: string;
+    
 
-  prev?: string;
+        
+    attachments?: Array<Attachment>;
+    
 
-  /**
-   * Whether to subscribe to realtime updates
-   */
-  watch?: boolean;
+        }
+    
 
-  /**
-   * Sorting parameters for the query
-   */
-  sort?: SortParamRequest[];
 
-  /**
-   * Filters to apply to the query
-   */
-  filter?: Record<string, any>;
-}
 
-export interface QueryFeedsResponse {
-  duration: string;
 
-  /**
-   * List of feeds matching the query
-   */
-  feeds: FeedResponse[];
+    export interface NotificationStatusResponse {
+    /**
+     * Number of unread notifications
+     */
+    unread: number;
+    
 
-  /**
-   * Cursor for next page
-   */
-  next?: string;
+        
+    /**
+     * Number of unseen notifications
+     */
+    unseen: number;
+    
 
-  /**
-   * Cursor for previous page
-   */
-  prev?: string;
-}
+        
+    /**
+     * When notifications were last read
+     */
+    last_read_at?: Date;
+    
 
-export interface QueryFollowsRequest {
-  limit?: number;
+        
+    /**
+     * When notifications were last seen
+     */
+    last_seen_at?: Date;
+    
 
-  next?: string;
+        
+    /**
+     * Deprecated: use is_read on each activity/group instead. IDs of activities that have been read. Capped at ~101 entries for aggregated feeds.
+     */
+    read_activities?: Array<string>;
+    
 
-  prev?: string;
+        
+    /**
+     * Deprecated: use is_seen on each activity/group instead. IDs of activities that have been seen. Capped at ~101 entries for aggregated feeds.
+     */
+    seen_activities?: Array<string>;
+    
 
-  /**
-   * Sorting parameters for the query
-   */
-  sort?: SortParamRequest[];
+        }
+    
 
-  /**
-   * Filters to apply to the query
-   */
-  filter?: Record<string, any>;
-}
 
-export interface QueryFollowsResponse {
-  duration: string;
 
-  /**
-   * List of follow relationships matching the query
-   */
-  follows: FollowResponse[];
 
-  /**
-   * Cursor for next page
-   */
-  next?: string;
+    export interface NotificationTarget {
+    /**
+     * The ID of the target (activity ID or user ID)
+     */
+    id: string;
+    
 
-  /**
-   * Cursor for previous page
-   */
-  prev?: string;
-}
+        
+    /**
+     * The name of the target user (for user targets like follows)
+     */
+    name?: string;
+    
 
-export interface QueryModerationConfigsRequest {
-  limit?: number;
+        
+    /**
+     * The text content of the target activity (for activity targets)
+     */
+    text?: string;
+    
 
-  next?: string;
+        
+    /**
+     * The type of the target activity (for activity targets)
+     */
+    type?: string;
+    
 
-  prev?: string;
+        
+    /**
+     * The ID of the user who created the target activity (for activity targets)
+     */
+    user_id?: string;
+    
 
-  /**
-   * Sorting parameters for the results
-   */
-  sort?: SortParamRequest[];
+        
+    /**
+     * Attachments on the target activity (for activity targets)
+     */
+    attachments?: Array<Attachment>;
+    
 
-  /**
-   * Filter conditions for moderation configs
-   */
-  filter?: Record<string, any>;
-}
+        
+    comment?: NotificationComment;
+    
 
-export interface QueryModerationConfigsResponse {
-  duration: string;
+        
+    /**
+     * Custom data from the target activity
+     */
+    custom?: Record<string, any>;
+    
 
-  /**
-   * List of moderation configurations
-   */
-  configs: ConfigResponse[];
+        
+    parent_activity?: NotificationParentActivity;
+    
 
-  next?: string;
+        }
+    
 
-  prev?: string;
-}
 
-export interface QueryPinnedActivitiesRequest {
-  enrich_own_fields?: boolean;
 
-  limit?: number;
 
-  next?: string;
+    export interface NotificationTrigger {
+    /**
+     * Human-readable text describing the notification
+     */
+    text: string;
+    
 
-  prev?: string;
+        
+    /**
+     * The type of notification (mention, reaction, comment, follow, etc.)
+     */
+    type: string;
+    
 
-  /**
-   * Sorting parameters for the query
-   */
-  sort?: SortParamRequest[];
+        
+    comment?: NotificationComment;
+    
 
-  /**
-   * Filters to apply to the query
-   */
-  filter?: Record<string, any>;
-}
+        
+    /**
+     * Custom data from the trigger object (comment, reaction, etc.)
+     */
+    custom?: Record<string, any>;
+    
 
-export interface QueryPinnedActivitiesResponse {
-  duration: string;
+        }
+    
 
-  /**
-   * List of pinned activities matching the query
-   */
-  pinned_activities: ActivityPinResponse[];
 
-  /**
-   * Cursor for next page
-   */
-  next?: string;
 
-  /**
-   * Cursor for previous page
-   */
-  prev?: string;
-}
 
-export interface QueryPollVotesRequest {
-  limit?: number;
+    export interface OCRRule {
+    
+        action:| "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
 
-  next?: string;
+        
+    label: string;
+    
 
-  prev?: string;
+        }
+    
 
-  /**
-   * Array of sort parameters
-   */
-  sort?: SortParamRequest[];
 
-  /**
-   * Filter to apply to the query
-   */
-  filter?: Record<string, any>;
-}
 
-export interface QueryPollsRequest {
-  limit?: number;
 
-  next?: string;
+    export interface OnlyUserID {
+    id: string;
+    
 
-  prev?: string;
+        }
+    
 
-  /**
-   * Array of sort parameters
-   */
-  sort?: SortParamRequest[];
 
-  /**
-   * Filter to apply to the query
-   */
-  filter?: Record<string, any>;
-}
 
-export interface QueryPollsResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
 
-  /**
-   * Polls data returned by the query
-   */
-  polls: PollResponseData[];
+    export interface OwnBatchRequest {
+    /**
+     * List of feed IDs to get own fields for
+     */
+    feeds: Array<string>;
+    
 
-  next?: string;
+        
+    /**
+     * Optional list of specific fields to return. If not specified, all fields (own_follows, own_followings, own_capabilities, own_membership) are returned
+     */
+    fields?: Array<string>;
+    
 
-  prev?: string;
-}
+        }
+    
 
-export interface QueryReviewQueueRequest {
-  limit?: number;
 
-  /**
-   * Number of items to lock (1-25)
-   */
-  lock_count?: number;
 
-  /**
-   * Duration for which items should be locked
-   */
-  lock_duration?: number;
 
-  /**
-   * Whether to lock items for review (true), unlock items (false), or just fetch (nil)
-   */
-  lock_items?: boolean;
+    export interface OwnBatchResponse {
+    duration: string;
+    
 
-  next?: string;
+        
+    /**
+     * Map of feed ID to own fields data
+     */
+    data: Record<string, FeedOwnData>;
+    
 
-  prev?: string;
+        }
+    
 
-  /**
-   * Whether to return only statistics
-   */
-  stats_only?: boolean;
 
-  /**
-   * Sorting parameters for the results
-   */
-  sort?: SortParamRequest[];
 
-  /**
-   * Filter conditions for review queue items
-   */
-  filter?: Record<string, any>;
-}
 
-export interface QueryReviewQueueResponse {
-  duration: string;
+    export interface OwnUserResponse {
+    banned: boolean;
+    
 
-  /**
-   * List of review queue items
-   */
-  items: ReviewQueueItemResponse[];
+        
+    created_at: Date;
+    
 
-  /**
-   * Configuration for moderation actions
-   */
-  action_config: Record<string, ModerationActionConfigResponse[]>;
+        
+    id: string;
+    
 
-  /**
-   * Statistics about the review queue
-   */
-  stats: Record<string, any>;
+        
+    invisible: boolean;
+    
 
-  next?: string;
+        
+    language: string;
+    
 
-  prev?: string;
+        
+    online: boolean;
+    
 
-  filter_config?: FilterConfigResponse;
-}
+        
+    role: string;
+    
 
-export interface QueryUsersPayload {
-  /**
-   * Filter conditions to apply to the query
-   */
-  filter_conditions: Record<string, any>;
+        
+    total_unread_count: number;
+    
 
-  include_deactivated_users?: boolean;
+        
+    unread_channels: number;
+    
 
-  limit?: number;
+        
+    unread_count: number;
+    
 
-  offset?: number;
+        
+    unread_threads: number;
+    
 
-  presence?: boolean;
+        
+    updated_at: Date;
+    
 
-  /**
-   * Array of sort parameters
-   */
-  sort?: SortParamRequest[];
-}
+        
+    channel_mutes: Array<ChannelMute>;
+    
 
-export interface QueryUsersResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        
+    devices: Array<DeviceResponse>;
+    
 
-  /**
-   * Array of users as result of filters applied.
-   */
-  users: FullUserResponse[];
-}
+        
+    mutes: Array<UserMuteResponse>;
+    
 
-export interface RTMPIngress {
-  address: string;
-}
+        
+    teams: Array<string>;
+    
 
-export interface RTMPSettingsResponse {
-  enabled: boolean;
+        
+    custom: Record<string, any>;
+    
 
-  quality: string;
+        
+    avg_response_time?: number;
+    
 
-  layout: LayoutSettingsResponse;
-}
+        
+    deactivated_at?: Date;
+    
 
-export interface RankingConfig {
-  score?: string;
+        
+    deleted_at?: Date;
+    
 
-  type?: string;
+        
+    image?: string;
+    
 
-  defaults?: Record<string, any>;
+        
+    last_active?: Date;
+    
 
-  functions?: Record<string, DecayFunctionConfig>;
-}
+        
+    name?: string;
+    
 
-export interface RawRecordingResponse {
-  status: string;
-}
+        
+    revoke_tokens_issued_before?: Date;
+    
 
-export interface RawRecordingSettingsResponse {
-  mode: string;
-}
+        
+    blocked_user_ids?: Array<string>;
+    
 
-export interface Reaction {
-  activity_id: string;
+        
+    latest_hidden_channels?: Array<string>;
+    
 
-  created_at: Date;
+        
+    privacy_settings?: PrivacySettingsResponse;
+    
 
-  kind: string;
+        
+    push_preferences?: PushPreferencesResponse;
+    
 
-  updated_at: Date;
+        
+    teams_role?: Record<string, string>;
+    
 
-  user_id: string;
+        
+    total_unread_count_by_team?: Record<string, number>;
+    
 
-  deleted_at?: Date;
+        }
+    
 
-  id?: string;
 
-  parent?: string;
 
-  score?: number;
 
-  target_feeds?: string[];
+    export interface PagerRequest {
+    limit?: number;
+    
 
-  children_counts?: Record<string, any>;
+        
+    next?: string;
+    
 
-  data?: Record<string, any>;
+        
+    prev?: string;
+    
 
-  latest_children?: Record<string, Reaction[]>;
+        }
+    
 
-  moderation?: Record<string, any>;
 
-  own_children?: Record<string, Reaction[]>;
 
-  target_feeds_extra_data?: Record<string, any>;
 
-  user?: User;
-}
+    export interface PagerResponse {
+    next?: string;
+    
 
-export interface ReactionGroupResponse {
-  /**
-   * Count is the number of reactions of this type.
-   */
-  count: number;
+        
+    prev?: string;
+    
 
-  /**
-   * FirstReactionAt is the time of the first reaction of this type. This is the same also if all reaction of this type are deleted, because if someone will react again with the same type, will be preserved the sorting.
-   */
-  first_reaction_at: Date;
+        }
+    
 
-  /**
-   * LastReactionAt is the time of the last reaction of this type.
-   */
-  last_reaction_at: Date;
 
-  /**
-   * SumScores is the sum of all scores of reactions of this type. Medium allows you to clap articles more than once and shows the sum of all claps from all users. For example, you can send `clap` x5 using `score: 5`.
-   */
-  sum_scores: number;
 
-  /**
-   * The most recent users who reacted with this type, ordered by most recent first.
-   */
-  latest_reactions_by: ReactionGroupUserResponse[];
-}
 
-export interface ReactionGroupUserResponse {
-  /**
-   * The time when the user reacted.
-   */
-  created_at: Date;
+    export interface PinActivityRequest {
+    /**
+     * If true, enriches the activity's current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+     */
+    enrich_own_fields?: boolean;
+    
 
-  /**
-   * The ID of the user who reacted.
-   */
-  user_id: string;
+        }
+    
 
-  user?: UserResponse;
-}
 
-export interface ReactionResponse {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  /**
-   * Message ID
-   */
-  message_id: string;
 
-  /**
-   * Score of the reaction
-   */
-  score: number;
+    export interface PinActivityResponse {
+    /**
+     * When the activity was pinned
+     */
+    created_at: Date;
+    
 
-  /**
-   * Type of reaction
-   */
-  type: string;
+        
+    duration: string;
+    
 
-  /**
-   * Date/time of the last update
-   */
-  updated_at: Date;
+        
+    /**
+     * Fully qualified ID of the feed the activity was pinned to
+     */
+    feed: string;
+    
 
-  /**
-   * User ID
-   */
-  user_id: string;
+        
+    /**
+     * ID of the user who pinned the activity
+     */
+    user_id: string;
+    
 
-  /**
-   * Custom data for this object
-   */
-  custom: Record<string, any>;
+        
+    activity: ActivityResponse;
+    
 
-  user: UserResponse;
-}
+        }
+    
 
-export interface ReadCollectionsResponse {
-  duration: string;
 
-  /**
-   * List of collections matching the references
-   */
-  collections: CollectionResponse[];
-}
 
-export interface ReadReceiptsResponse {
-  enabled: boolean;
-}
 
-export interface RecordSettingsResponse {
-  audio_only: boolean;
+    export interface PollClosedFeedEvent {
+    created_at: Date;
+    
 
-  mode: string;
+        
+    fid: string;
+    
 
-  quality: string;
+        
+    custom: Record<string, any>;
+    
 
-  layout: LayoutSettingsResponse;
-}
+        
+    poll: PollResponseData;
+    
 
-export interface RejectAppealRequestPayload {
-  /**
-   * Reason for rejecting the appeal
-   */
-  decision_reason: string;
-}
+        
+    type: string;
+    
 
-export interface RejectFeedMemberInviteRequest {}
+        
+    feed_visibility?: string;
+    
 
-export interface RejectFeedMemberInviteResponse {
-  duration: string;
+        
+    received_at?: Date;
+    
 
-  member: FeedMemberResponse;
-}
+        }
+    
 
-export interface RejectFollowRequest {
-  /**
-   * Fully qualified ID of the source feed
-   */
-  source: string;
 
-  /**
-   * Fully qualified ID of the target feed
-   */
-  target: string;
-}
 
-export interface RejectFollowResponse {
-  duration: string;
 
-  follow: FollowResponse;
-}
+    export interface PollDeletedFeedEvent {
+    created_at: Date;
+    
 
-export interface ReminderResponseData {
-  channel_cid: string;
+        
+    fid: string;
+    
 
-  created_at: Date;
+        
+    custom: Record<string, any>;
+    
 
-  message_id: string;
+        
+    poll: PollResponseData;
+    
 
-  updated_at: Date;
+        
+    type: string;
+    
 
-  user_id: string;
+        
+    feed_visibility?: string;
+    
 
-  remind_at?: Date;
+        
+    received_at?: Date;
+    
 
-  channel?: ChannelResponse;
+        }
+    
 
-  message?: MessageResponse;
 
-  user?: UserResponse;
-}
 
-export interface RemoveUserGroupMembersRequest {
-  /**
-   * List of user IDs to remove
-   */
-  member_ids: string[];
 
-  team_id?: string;
-}
+    export interface PollOptionInput {
+    text?: string;
+    
 
-export interface RemoveUserGroupMembersResponse {
-  duration: string;
+        
+    custom?: Record<string, any>;
+    
 
-  user_group?: UserGroupResponse;
-}
+        }
+    
 
-export interface RepliesMeta {
-  /**
-   * True if the subtree was cut because the requested depth was reached.
-   */
-  depth_truncated: boolean;
 
-  /**
-   * True if more siblings exist in the database.
-   */
-  has_more: boolean;
 
-  /**
-   * Number of unread siblings that match current filters.
-   */
-  remaining: number;
 
-  /**
-   * Opaque cursor to request the next page of siblings.
-   */
-  next_cursor?: string;
-}
+    export interface PollOptionRequest {
+    id: string;
+    
 
-export interface Response {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
-}
+        
+    text?: string;
+    
 
-export interface RestoreActionRequestPayload {
-  /**
-   * Reason for the appeal decision
-   */
-  decision_reason?: string;
-}
+        
+    custom?: Record<string, any>;
+    
 
-export interface RestoreActivityRequest {}
+        }
+    
 
-export interface RestoreActivityResponse {
-  duration: string;
 
-  activity: ActivityResponse;
-}
 
-export interface RestoreCommentRequest {}
 
-export interface RestoreCommentResponse {
-  duration: string;
+    export interface PollOptionResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  activity: ActivityResponse;
+        
+    poll_option: PollOptionResponseData;
+    
 
-  comment: CommentResponse;
-}
+        }
+    
 
-export interface ReviewQueueItemResponse {
-  /**
-   * AI-determined text severity
-   */
-  ai_text_severity: string;
 
-  /**
-   * When the item was created
-   */
-  created_at: Date;
 
-  /**
-   * ID of the entity being reviewed
-   */
-  entity_id: string;
 
-  /**
-   * Type of entity being reviewed
-   */
-  entity_type: string;
+    export interface PollOptionResponseData {
+    id: string;
+    
 
-  /**
-   * Whether the item has been escalated
-   */
-  escalated: boolean;
+        
+    text: string;
+    
 
-  flags_count: number;
+        
+    custom: Record<string, any>;
+    
 
-  /**
-   * Unique identifier of the review queue item
-   */
-  id: string;
+        }
+    
 
-  latest_moderator_action: string;
 
-  /**
-   * Suggested moderation action
-   */
-  recommended_action: string;
 
-  /**
-   * ID of the moderator who reviewed the item
-   */
-  reviewed_by: string;
 
-  /**
-   * Severity level of the content
-   */
-  severity: number;
+    export interface PollResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  /**
-   * Current status of the review
-   */
-  status: string;
+        
+    poll: PollResponseData;
+    
 
-  /**
-   * When the item was last updated
-   */
-  updated_at: Date;
+        }
+    
 
-  /**
-   * Moderation actions taken
-   */
-  actions: ActionLogResponse[];
 
-  /**
-   * Associated ban records
-   */
-  bans: BanInfoResponse[];
 
-  /**
-   * Associated flag records
-   */
-  flags: ModerationFlagResponse[];
 
-  /**
-   * Detected languages in the content
-   */
-  languages: string[];
+    export interface PollResponseData {
+    allow_answers: boolean;
+    
 
-  /**
-   * When the review was completed
-   */
-  completed_at?: Date;
+        
+    allow_user_suggested_options: boolean;
+    
 
-  config_key?: string;
+        
+    answers_count: number;
+    
 
-  /**
-   * ID of who created the entity
-   */
-  entity_creator_id?: string;
+        
+    created_at: Date;
+    
 
-  /**
-   * When the item was escalated
-   */
-  escalated_at?: Date;
+        
+    created_by_id: string;
+    
 
-  /**
-   * ID of the moderator who escalated the item
-   */
-  escalated_by?: string;
+        
+    description: string;
+    
 
-  /**
-   * When the item was reviewed
-   */
-  reviewed_at?: Date;
+        
+    enforce_unique_vote: boolean;
+    
 
-  /**
-   * Teams associated with this item
-   */
-  teams?: string[];
+        
+    id: string;
+    
 
-  activity?: EnrichedActivity;
+        
+    name: string;
+    
 
-  appeal?: AppealItemResponse;
+        
+    updated_at: Date;
+    
 
-  assigned_to?: UserResponse;
+        
+    vote_count: number;
+    
 
-  call?: CallResponse;
+        
+    voting_visibility: string;
+    
 
-  entity_creator?: EntityCreatorResponse;
+        
+    latest_answers: Array<PollVoteResponseData>;
+    
 
-  escalation_metadata?: EscalationMetadata;
+        
+    options: Array<PollOptionResponseData>;
+    
 
-  feeds_v2_activity?: EnrichedActivity;
+        
+    own_votes: Array<PollVoteResponseData>;
+    
 
-  feeds_v2_reaction?: Reaction;
+        
+    custom: Record<string, any>;
+    
 
-  feeds_v3_activity?: FeedsV3ActivityResponse;
+        
+    latest_votes_by_option: Record<string, Array<PollVoteResponseData>>;
+    
 
-  feeds_v3_comment?: FeedsV3CommentResponse;
+        
+    vote_counts_by_option: Record<string, number>;
+    
 
-  message?: MessageResponse;
+        
+    is_closed?: boolean;
+    
 
-  moderation_payload?: ModerationPayloadResponse;
+        
+    max_votes_allowed?: number;
+    
 
-  reaction?: Reaction;
-}
+        
+    created_by?: UserResponse;
+    
 
-export interface RingSettingsResponse {
-  auto_cancel_timeout_ms: number;
+        }
+    
 
-  incoming_call_timeout_ms: number;
 
-  missed_call_timeout_ms: number;
-}
 
-export interface RuleBuilderAction {
-  skip_inbox?: boolean;
 
-  type?:
-    | 'ban_user'
-    | 'flag_user'
-    | 'flag_content'
-    | 'block_content'
-    | 'shadow_content'
-    | 'bounce_flag_content'
-    | 'bounce_content'
-    | 'bounce_remove_content'
-    | 'mute_video'
-    | 'mute_audio'
-    | 'blur'
-    | 'call_blur'
-    | 'end_call'
-    | 'kick_user'
-    | 'warning'
-    | 'call_warning'
-    | 'webhook_only';
+    export interface PollUpdatedFeedEvent {
+    created_at: Date;
+    
 
-  ban_options?: BanOptions;
+        
+    fid: string;
+    
 
-  call_options?: CallActionOptions;
+        
+    custom: Record<string, any>;
+    
 
-  flag_user_options?: FlagUserOptions;
-}
+        
+    poll: PollResponseData;
+    
 
-export interface RuleBuilderCondition {
-  confidence?: number;
+        
+    type: string;
+    
 
-  type?: string;
+        
+    feed_visibility?: string;
+    
 
-  call_custom_property_params?: CallCustomPropertyParameters;
+        
+    received_at?: Date;
+    
 
-  call_type_rule_params?: CallTypeRuleParameters;
+        }
+    
 
-  call_violation_count_params?: CallViolationCountParameters;
 
-  closed_caption_rule_params?: ClosedCaptionRuleParameters;
 
-  content_count_rule_params?: ContentCountRuleParameters;
 
-  content_flag_count_rule_params?: FlagCountRuleParameters;
+    export interface PollVoteCastedFeedEvent {
+    created_at: Date;
+    
 
-  image_content_params?: ImageContentParameters;
+        
+    fid: string;
+    
 
-  image_rule_params?: ImageRuleParameters;
+        
+    custom: Record<string, any>;
+    
 
-  keyframe_rule_params?: KeyframeRuleParameters;
+        
+    poll: PollResponseData;
+    
 
-  text_content_params?: TextContentParameters;
+        
+    poll_vote: PollVoteResponseData;
+    
 
-  text_rule_params?: TextRuleParameters;
+        
+    type: string;
+    
 
-  user_created_within_params?: UserCreatedWithinParameters;
+        
+    feed_visibility?: string;
+    
 
-  user_custom_property_params?: UserCustomPropertyParameters;
+        
+    received_at?: Date;
+    
 
-  user_flag_count_rule_params?: FlagCountRuleParameters;
+        }
+    
 
-  user_identical_content_count_params?: UserIdenticalContentCountParameters;
 
-  user_role_params?: UserRoleParameters;
 
-  user_rule_params?: UserRuleParameters;
 
-  video_content_params?: VideoContentParameters;
+    export interface PollVoteChangedFeedEvent {
+    created_at: Date;
+    
 
-  video_rule_params?: VideoRuleParameters;
-}
+        
+    fid: string;
+    
 
-export interface RuleBuilderConditionGroup {
-  logic?: string;
+        
+    custom: Record<string, any>;
+    
 
-  conditions?: RuleBuilderCondition[];
-}
+        
+    poll: PollResponseData;
+    
 
-export interface RuleBuilderConfig {
-  async?: boolean;
+        
+    poll_vote: PollVoteResponseData;
+    
 
-  rules?: RuleBuilderRule[];
-}
+        
+    type: string;
+    
 
-export interface RuleBuilderRule {
-  rule_type: string;
+        
+    feed_visibility?: string;
+    
 
-  cooldown_period?: string;
+        
+    received_at?: Date;
+    
 
-  id?: string;
+        }
+    
 
-  logic?: string;
 
-  action_sequences?: CallRuleActionSequence[];
 
-  conditions?: RuleBuilderCondition[];
 
-  groups?: RuleBuilderConditionGroup[];
+    export interface PollVoteRemovedFeedEvent {
+    created_at: Date;
+    
 
-  action?: RuleBuilderAction;
-}
+        
+    fid: string;
+    
 
-export interface SRTIngress {
-  address: string;
-}
+        
+    custom: Record<string, any>;
+    
 
-export interface ScreensharingSettingsResponse {
-  access_request_enabled: boolean;
+        
+    poll: PollResponseData;
+    
 
-  enabled: boolean;
+        
+    poll_vote: PollVoteResponseData;
+    
 
-  target_resolution?: TargetResolution;
-}
+        
+    type: string;
+    
 
-export interface SearchUserGroupsResponse {
-  duration: string;
+        
+    feed_visibility?: string;
+    
 
-  /**
-   * List of matching user groups
-   */
-  user_groups: UserGroupResponse[];
-}
+        
+    received_at?: Date;
+    
 
-export interface SessionSettingsResponse {
-  inactivity_timeout_seconds: number;
-}
+        }
+    
 
-export interface ShadowBlockActionRequestPayload {
-  /**
-   * Reason for shadow blocking
-   */
-  reason?: string;
-}
 
-export interface SharedLocationResponse {
-  /**
-   * Channel CID
-   */
-  channel_cid: string;
 
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  /**
-   * Device ID that created the live location
-   */
-  created_by_device_id: string;
+    export interface PollVoteResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  duration: string;
+        
+    poll?: PollResponseData;
+    
 
-  /**
-   * Latitude coordinate
-   */
-  latitude: number;
+        
+    vote?: PollVoteResponseData;
+    
 
-  /**
-   * Longitude coordinate
-   */
-  longitude: number;
+        }
+    
 
-  /**
-   * Message ID
-   */
-  message_id: string;
 
-  /**
-   * Date/time of the last update
-   */
-  updated_at: Date;
 
-  /**
-   * User ID
-   */
-  user_id: string;
 
-  /**
-   * Time when the live location expires
-   */
-  end_at?: Date;
+    export interface PollVoteResponseData {
+    created_at: Date;
+    
 
-  channel?: ChannelResponse;
+        
+    id: string;
+    
 
-  message?: MessageResponse;
-}
+        
+    option_id: string;
+    
 
-export interface SharedLocationResponseData {
-  channel_cid: string;
+        
+    poll_id: string;
+    
 
-  created_at: Date;
+        
+    updated_at: Date;
+    
 
-  created_by_device_id: string;
+        
+    answer_text?: string;
+    
 
-  latitude: number;
+        
+    is_answer?: boolean;
+    
 
-  longitude: number;
+        
+    user_id?: string;
+    
 
-  message_id: string;
+        
+    user?: UserResponse;
+    
 
-  updated_at: Date;
+        }
+    
 
-  user_id: string;
 
-  end_at?: Date;
 
-  channel?: ChannelResponse;
 
-  message?: MessageResponse;
-}
+    export interface PollVotesResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-export interface SharedLocationsResponse {
-  duration: string;
+        
+    /**
+     * Poll votes
+     */
+    votes: Array<PollVoteResponseData>;
+    
 
-  active_live_locations: SharedLocationResponseData[];
-}
+        
+    next?: string;
+    
 
-export interface SingleFollowResponse {
-  duration: string;
+        
+    prev?: string;
+    
 
-  follow: FollowResponse;
+        }
+    
 
-  /**
-   * Whether a notification activity was successfully created
-   */
-  notification_created?: boolean;
-}
 
-export interface SortParam {
-  direction: number;
 
-  field: string;
 
-  type: string;
-}
+    export interface PrivacySettingsResponse {
+    delivery_receipts?: DeliveryReceiptsResponse;
+    
 
-export interface SortParamRequest {
-  /**
-   * Direction of sorting, 1 for Ascending, -1 for Descending, default is 1. One of: -1, 1
-   */
-  direction?: number;
+        
+    read_receipts?: ReadReceiptsResponse;
+    
 
-  /**
-   * Name of field to sort by
-   */
-  field?: string;
+        
+    typing_indicators?: TypingIndicatorsResponse;
+    
 
-  /**
-   * Type of field to sort by. Empty string or omitted means string type (default). One of: number, boolean
-   */
-  type?: string;
-}
+        }
+    
 
-export interface SpeechSegmentConfig {
-  max_speech_caption_ms?: number;
 
-  silence_duration_ms?: number;
-}
 
-export interface StoriesConfig {
-  skip_watched?: boolean;
 
-  track_watched?: boolean;
-}
+    export interface PushNotificationConfig {
+    enable_push?: boolean;
+    
 
-export interface StoriesFeedUpdatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    push_types?: Array<string>;
+    
 
-  /**
-   * The ID of the feed
-   */
-  fid: string;
+        }
+    
 
-  custom: Record<string, any>;
 
-  /**
-   * The type of event: "feeds.stories_feed.updated" in this case
-   */
-  type: string;
 
-  feed_visibility?: string;
 
-  received_at?: Date;
+    export interface PushPreferenceInput {
+    /**
+     * Set the level of call push notifications for the user. One of: all, none, default
+     */
+    
+        call_level?:| "all" | "none" | "default" ;
 
-  /**
-   * Individual activities for stories feeds
-   */
-  activities?: ActivityResponse[];
+        
+    /**
+     * Set the push preferences for a specific channel. If empty it sets the default for the user
+     */
+    channel_cid?: string;
+    
 
-  /**
-   * Aggregated activities for stories feeds
-   */
-  aggregated_activities?: AggregatedActivityResponse[];
+        
+    /**
+     * Set the level of chat push notifications for the user. Note: "mentions" is deprecated in favor of "direct_mentions". One of: all, mentions, direct_mentions, all_mentions, none, default
+     */
+    
+        chat_level?:| "all" | "mentions" | "direct_mentions" | "all_mentions" | "none" | "default" ;
 
-  user?: UserResponseCommonFields;
-}
+        
+    /**
+     * Disable push notifications till a certain time
+     */
+    disabled_until?: Date;
+    
 
-export interface SubmitActionRequest {
-  /**
-   * Type of moderation action to perform. One of: mark_reviewed, delete_message, delete_activity, delete_comment, delete_reaction, ban, custom, unban, restore, delete_user, unblock, block, shadow_block, unmask, kick_user, end_call, escalate, de_escalate
-   */
+        
+    /**
+     * Set the level of feeds push notifications for the user. One of: all, none, default
+     */
+    
+        feeds_level?:| "all" | "none" | "default" ;
 
-  action_type:
-    | 'flag'
-    | 'mark_reviewed'
-    | 'delete_message'
-    | 'delete_activity'
-    | 'delete_comment'
-    | 'delete_reaction'
-    | 'ban'
-    | 'custom'
-    | 'unban'
-    | 'restore'
-    | 'delete_user'
-    | 'unblock'
-    | 'block'
-    | 'shadow_block'
-    | 'unmask'
-    | 'kick_user'
-    | 'end_call'
-    | 'reject_appeal'
-    | 'escalate'
-    | 'de_escalate'
-    | 'bypass';
+        
+    /**
+     * Remove the disabled until time. (IE stop snoozing notifications)
+     */
+    remove_disable?: boolean;
+    
 
-  /**
-   * UUID of the appeal to act on (required for reject_appeal, optional for other actions)
-   */
-  appeal_id?: string;
+        
+    /**
+     * The user id for which to set the push preferences. Required when using server side auths, defaults to current user with client side auth.
+     */
+    user_id?: string;
+    
 
-  /**
-   * UUID of the review queue item to act on
-   */
-  item_id?: string;
+        
+    chat_preferences?: ChatPreferencesInput;
+    
 
-  ban?: BanActionRequestPayload;
+        
+    feeds_preferences?: FeedsPreferences;
+    
 
-  block?: BlockActionRequestPayload;
+        }
+    
 
-  bypass?: BypassActionRequest;
 
-  custom?: CustomActionRequestPayload;
 
-  delete_activity?: DeleteActivityRequestPayload;
 
-  delete_comment?: DeleteCommentRequestPayload;
+    export interface PushPreferencesResponse {
+    call_level?: string;
+    
 
-  delete_message?: DeleteMessageRequestPayload;
+        
+    chat_level?: string;
+    
 
-  delete_reaction?: DeleteReactionRequestPayload;
+        
+    disabled_until?: Date;
+    
 
-  delete_user?: DeleteUserRequestPayload;
+        
+    feeds_level?: string;
+    
 
-  escalate?: EscalatePayload;
+        
+    chat_preferences?: ChatPreferencesResponse;
+    
 
-  flag?: FlagRequest;
+        
+    feeds_preferences?: FeedsPreferencesResponse;
+    
 
-  mark_reviewed?: MarkReviewedRequestPayload;
+        }
+    
 
-  reject_appeal?: RejectAppealRequestPayload;
 
-  restore?: RestoreActionRequestPayload;
 
-  shadow_block?: ShadowBlockActionRequestPayload;
 
-  unban?: UnbanActionRequestPayload;
+    export interface QueryActivitiesRequest {
+    enrich_own_fields?: boolean;
+    
 
-  unblock?: UnblockActionRequestPayload;
-}
+        
+    /**
+     * When true, include soft-deleted activities in the result.
+     */
+    include_soft_deleted_activities?: boolean;
+    
 
-export interface SubmitActionResponse {
-  duration: string;
+        
+    limit?: number;
+    
 
-  appeal_item?: AppealItemResponse;
+        
+    next?: string;
+    
 
-  item?: ReviewQueueItemResponse;
-}
+        
+    prev?: string;
+    
 
-export interface TargetResolution {
-  bitrate: number;
+        
+    /**
+     * Sorting parameters for the query
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-  height: number;
+        
+    /**
+     * Filters to apply to the query. Supports location-based queries with 'near' and 'within_bounds' operators.
+     */
+    filter?: Record<string, any>;
+    
 
-  width: number;
-}
+        }
+    
 
-export interface TextContentParameters {
-  contains_url?: boolean;
 
-  label_operator?: string;
 
-  severity?: string;
 
-  blocklist_match?: string[];
+    export interface QueryActivitiesResponse {
+    duration: string;
+    
 
-  harm_labels?: string[];
+        
+    /**
+     * List of activities matching the query
+     */
+    activities: Array<ActivityResponse>;
+    
 
-  llm_harm_labels?: Record<string, string>;
-}
+        
+    /**
+     * Cursor for next page
+     */
+    next?: string;
+    
 
-export interface TextRuleParameters {
-  contains_url?: boolean;
+        
+    /**
+     * Cursor for previous page
+     */
+    prev?: string;
+    
 
-  semantic_filter_min_threshold?: number;
+        }
+    
 
-  severity?: string;
 
-  threshold?: number;
 
-  time_window?: string;
 
-  blocklist_match?: string[];
+    export interface QueryActivityReactionsRequest {
+    limit?: number;
+    
 
-  harm_labels?: string[];
+        
+    next?: string;
+    
 
-  semantic_filter_names?: string[];
+        
+    prev?: string;
+    
 
-  llm_harm_labels?: Record<string, string>;
-}
+        
+    sort?: Array<SortParamRequest>;
+    
 
-export interface ThreadedCommentResponse {
-  bookmark_count: number;
+        
+    filter?: Record<string, any>;
+    
 
-  confidence_score: number;
+        }
+    
 
-  created_at: Date;
 
-  downvote_count: number;
 
-  id: string;
 
-  object_id: string;
+    export interface QueryActivityReactionsResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  object_type: string;
+        
+    reactions: Array<FeedsReactionResponse>;
+    
 
-  reaction_count: number;
+        
+    next?: string;
+    
 
-  reply_count: number;
+        
+    prev?: string;
+    
 
-  score: number;
+        }
+    
 
-  /**
-   * Status of the comment. One of: active, deleted, removed, hidden
-   */
 
-  status: 'active' | 'deleted' | 'removed' | 'hidden' | 'shadow_blocked';
 
-  updated_at: Date;
 
-  upvote_count: number;
+    export interface QueryAppealsRequest {
+    limit?: number;
+    
 
-  mentioned_users: UserResponse[];
+        
+    next?: string;
+    
 
-  own_reactions: FeedsReactionResponse[];
+        
+    prev?: string;
+    
 
-  user: UserResponse;
+        
+    /**
+     * Sorting parameters for appeals
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-  controversy_score?: number;
+        
+    /**
+     * Filter conditions for appeals
+     */
+    filter?: Record<string, any>;
+    
 
-  deleted_at?: Date;
+        }
+    
 
-  edited_at?: Date;
 
-  parent_id?: string;
 
-  text?: string;
 
-  attachments?: Attachment[];
+    export interface QueryAppealsResponse {
+    duration: string;
+    
 
-  latest_reactions?: FeedsReactionResponse[];
+        
+    /**
+     * List of Appeal Items
+     */
+    items: Array<AppealItemResponse>;
+    
 
-  /**
-   * Slice of nested comments (may be empty).
-   */
-  replies?: ThreadedCommentResponse[];
+        
+    next?: string;
+    
 
-  custom?: Record<string, any>;
+        
+    prev?: string;
+    
 
-  meta?: RepliesMeta;
+        }
+    
 
-  moderation?: ModerationV2Response;
 
-  reaction_groups?: Record<string, FeedsReactionGroupResponse>;
-}
 
-export interface Thresholds {
-  explicit?: LabelThresholds;
 
-  spam?: LabelThresholds;
+    export interface QueryBookmarkFoldersRequest {
+    limit?: number;
+    
 
-  toxic?: LabelThresholds;
-}
+        
+    next?: string;
+    
 
-export interface ThumbnailResponse {
-  image_url: string;
-}
+        
+    prev?: string;
+    
 
-export interface ThumbnailsSettingsResponse {
-  enabled: boolean;
-}
+        
+    /**
+     * Sorting parameters for the query
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-export interface Time {}
+        
+    /**
+     * Filters to apply to the query
+     */
+    filter?: Record<string, any>;
+    
 
-export interface Timestamp {
-  time?: Date;
-}
+        }
+    
 
-export interface TrackActivityMetricsEvent {
-  /**
-   * The ID of the activity to track the metric for
-   */
-  activity_id: string;
 
-  /**
-   * The metric name (e.g. views, clicks, impressions). Alphanumeric and underscores only.
-   */
-  metric: string;
 
-  /**
-   * The amount to increment (positive) or decrement (negative). Defaults to 1. The absolute value counts against rate limits.
-   */
-  delta?: number;
-}
 
-export interface TrackActivityMetricsEventResult {
-  /**
-   * The activity ID from the request
-   */
-  activity_id: string;
+    export interface QueryBookmarkFoldersResponse {
+    duration: string;
+    
 
-  /**
-   * Whether the metric was counted (false if rate-limited)
-   */
-  allowed: boolean;
+        
+    /**
+     * List of bookmark folders matching the query
+     */
+    bookmark_folders: Array<BookmarkFolderResponse>;
+    
 
-  /**
-   * The metric name from the request
-   */
-  metric: string;
+        
+    /**
+     * Cursor for next page
+     */
+    next?: string;
+    
 
-  /**
-   * Error message if processing failed
-   */
-  error?: string;
-}
+        
+    /**
+     * Cursor for previous page
+     */
+    prev?: string;
+    
 
-export interface TrackActivityMetricsRequest {
-  /**
-   * List of metric events to track (max 100 per request)
-   */
-  events: TrackActivityMetricsEvent[];
-}
+        }
+    
 
-export interface TrackActivityMetricsResponse {
-  duration: string;
 
-  /**
-   * Results for each event in the request, in the same order
-   */
-  results: TrackActivityMetricsEventResult[];
-}
 
-export interface TranscriptionSettingsResponse {
-  closed_caption_mode: string;
 
-  language: string;
+    export interface QueryBookmarksRequest {
+    enrich_own_fields?: boolean;
+    
 
-  mode: string;
+        
+    limit?: number;
+    
 
-  speech_segment_config?: SpeechSegmentConfig;
+        
+    next?: string;
+    
 
-  translation?: TranslationSettings;
-}
+        
+    prev?: string;
+    
 
-export interface TranslationSettings {
-  enabled: boolean;
+        
+    /**
+     * Sorting parameters for the query
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-  languages: string[];
-}
+        
+    /**
+     * Filters to apply to the query
+     */
+    filter?: Record<string, any>;
+    
 
-export interface TypingIndicatorsResponse {
-  enabled: boolean;
-}
+        }
+    
 
-export interface UnbanActionRequestPayload {
-  /**
-   * Channel CID for channel-specific unban
-   */
-  channel_cid?: string;
 
-  /**
-   * Reason for the appeal decision
-   */
-  decision_reason?: string;
 
-  /**
-   * Also remove the future channels ban for this user
-   */
-  remove_future_channels_ban?: boolean;
-}
 
-export interface UnblockActionRequestPayload {
-  /**
-   * Reason for the appeal decision
-   */
-  decision_reason?: string;
-}
+    export interface QueryBookmarksResponse {
+    duration: string;
+    
 
-export interface UnblockUsersRequest {
-  blocked_user_id: string;
-}
+        
+    /**
+     * List of bookmarks matching the query
+     */
+    bookmarks: Array<BookmarkResponse>;
+    
 
-export interface UnblockUsersResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
-}
+        
+    /**
+     * Cursor for next page
+     */
+    next?: string;
+    
 
-export interface UnfollowBatchRequest {
-  /**
-   * List of follow relationships to remove, each with optional keep_history
-   */
-  follows: UnfollowPair[];
+        
+    /**
+     * Cursor for previous page
+     */
+    prev?: string;
+    
 
-  /**
-   * Whether to delete the corresponding notification activity (default: false)
-   */
-  delete_notification_activity?: boolean;
+        }
+    
 
-  /**
-   * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-   */
-  enrich_own_fields?: boolean;
-}
 
-export interface UnfollowBatchResponse {
-  duration: string;
 
-  /**
-   * List of follow relationships that were removed
-   */
-  follows: FollowResponse[];
-}
 
-export interface UnfollowPair {
-  /**
-   * Fully qualified ID of the source feed
-   */
-  source: string;
+    export interface QueryCollectionsRequest {
+    limit?: number;
+    
 
-  /**
-   * Fully qualified ID of the target feed
-   */
-  target: string;
+        
+    next?: string;
+    
 
-  /**
-   * When true, activities from the unfollowed feed will remain in the source feed's timeline (default: false)
-   */
-  keep_history?: boolean;
-}
+        
+    prev?: string;
+    
 
-export interface UnfollowResponse {
-  duration: string;
+        
+    /**
+     * Sorting parameters for the query
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-  follow: FollowResponse;
-}
+        
+    /**
+     * Filters to apply to the query
+     */
+    filter?: Record<string, any>;
+    
 
-export interface UnpinActivityResponse {
-  duration: string;
+        }
+    
 
-  /**
-   * Fully qualified ID of the feed the activity was unpinned from
-   */
-  feed: string;
 
-  /**
-   * ID of the user who unpinned the activity
-   */
-  user_id: string;
 
-  activity: ActivityResponse;
-}
 
-export interface UpdateActivityPartialRequest {
-  /**
-   * @deprecated
-   * Whether to copy custom data to the notification activity (only applies when handle_mention_notifications creates notifications) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-   */
-  copy_custom_to_notification?: boolean;
+    export interface QueryCollectionsResponse {
+    duration: string;
+    
 
-  /**
-   * If true, enriches the activity's current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-   */
-  enrich_own_fields?: boolean;
+        
+    /**
+     * List of collections matching the query
+     */
+    collections: Array<CollectionResponse>;
+    
 
-  /**
-   * If true, creates notification activities for newly mentioned users and deletes notifications for users no longer mentioned
-   */
-  handle_mention_notifications?: boolean;
+        
+    /**
+     * Cursor for next page
+     */
+    next?: string;
+    
 
-  /**
-   * If true, runs activity processors on the updated activity. Processors will only run if the activity text and/or attachments are changed. Defaults to false.
-   */
-  run_activity_processors?: boolean;
+        
+    /**
+     * Cursor for previous page
+     */
+    prev?: string;
+    
 
-  /**
-   * List of field names to remove. Supported fields: 'custom', 'visibility_tag', 'location', 'expires_at', 'filter_tags', 'interest_tags', 'attachments', 'poll_id', 'mentioned_user_ids', 'search_data'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
-   */
-  unset?: string[];
+        }
+    
 
-  /**
-   * Map of field names to new values. Supported fields: 'text', 'attachments', 'custom', 'visibility', 'visibility_tag', 'restrict_replies' (values: 'everyone', 'people_i_follow', 'nobody'), 'location', 'expires_at', 'filter_tags', 'interest_tags', 'poll_id', 'feeds', 'mentioned_user_ids', 'search_data'. For custom fields, use dot-notation (e.g., 'custom.field_name')
-   */
-  set?: Record<string, any>;
-}
 
-export interface UpdateActivityPartialResponse {
-  duration: string;
 
-  activity: ActivityResponse;
-}
 
-export interface UpdateActivityRequest {
-  /**
-   * @deprecated
-   * Whether to copy custom data to the notification activity (only applies when handle_mention_notifications creates notifications) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-   */
-  copy_custom_to_notification?: boolean;
+    export interface QueryCommentReactionsRequest {
+    limit?: number;
+    
 
-  /**
-   * If true, enriches the activity's current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-   */
-  enrich_own_fields?: boolean;
+        
+    next?: string;
+    
 
-  /**
-   * Time when the activity will expire
-   */
-  expires_at?: Date;
+        
+    prev?: string;
+    
 
-  /**
-   * If true, creates notification activities for newly mentioned users and deletes notifications for users no longer mentioned
-   */
-  handle_mention_notifications?: boolean;
+        
+    sort?: Array<SortParamRequest>;
+    
 
-  /**
-   * Poll ID
-   */
-  poll_id?: string;
+        
+    filter?: Record<string, any>;
+    
 
-  /**
-   * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
-   */
+        }
+    
 
-  restrict_replies?: 'everyone' | 'people_i_follow' | 'nobody';
 
-  /**
-   * If true, runs activity processors on the updated activity. Processors will only run if the activity text and/or attachments are changed. Defaults to false.
-   */
-  run_activity_processors?: boolean;
 
-  /**
-   * Whether to skip URL enrichment for the activity
-   */
-  skip_enrich_url?: boolean;
 
-  /**
-   * The text content of the activity
-   */
-  text?: string;
+    export interface QueryCommentReactionsResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  /**
-   * Visibility setting for the activity
-   */
+        
+    reactions: Array<FeedsReactionResponse>;
+    
 
-  visibility?: 'public' | 'private' | 'tag';
+        
+    next?: string;
+    
 
-  /**
-   * If visibility is 'tag', this is the tag name and is required
-   */
-  visibility_tag?: string;
+        
+    prev?: string;
+    
 
-  /**
-   * List of attachments for the activity
-   */
-  attachments?: Attachment[];
+        }
+    
 
-  /**
-   * Collections that this activity references
-   */
-  collection_refs?: string[];
 
-  /**
-   * List of feeds the activity is present in
-   */
-  feeds?: string[];
 
-  /**
-   * Tags used for filtering the activity
-   */
-  filter_tags?: string[];
 
-  /**
-   * Tags indicating interest categories
-   */
-  interest_tags?: string[];
+    export interface QueryCommentsRequest {
+    /**
+     * Filter to apply to the query
+     */
+    filter: Record<string, any>;
+    
 
-  /**
-   * List of user IDs mentioned in the activity
-   */
-  mentioned_user_ids?: string[];
+        
+    /**
+     * Returns the comment with the specified ID along with surrounding comments for context
+     */
+    id_around?: string;
+    
 
-  /**
-   * Custom data for the activity
-   */
-  custom?: Record<string, any>;
+        
+    /**
+     * Maximum number of comments to return
+     */
+    limit?: number;
+    
 
-  location?: Location;
+        
+    next?: string;
+    
 
-  /**
-   * Additional data for search indexing
-   */
-  search_data?: Record<string, any>;
-}
+        
+    prev?: string;
+    
 
-export interface UpdateActivityResponse {
-  duration: string;
+        
+    /**
+     * Array of sort parameters
+     */
+    
+        sort?:| "first" | "last" | "top" | "best" | "controversial" ;
 
-  activity: ActivityResponse;
-}
+        }
+    
 
-export interface UpdateBlockListRequest {
-  is_leet_check_enabled?: boolean;
 
-  is_plural_check_enabled?: boolean;
 
-  team?: string;
 
-  /**
-   * List of words to block
-   */
-  words?: string[];
-}
+    export interface QueryCommentsResponse {
+    duration: string;
+    
 
-export interface UpdateBlockListResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        
+    /**
+     * List of comments matching the query
+     */
+    comments: Array<CommentResponse>;
+    
 
-  blocklist?: BlockListResponse;
-}
+        
+    /**
+     * Cursor for next page
+     */
+    next?: string;
+    
 
-export interface UpdateBookmarkFolderRequest {
-  /**
-   * Name of the folder
-   */
-  name?: string;
+        
+    /**
+     * Cursor for previous page
+     */
+    prev?: string;
+    
 
-  /**
-   * Custom data for the folder
-   */
-  custom?: Record<string, any>;
-}
+        }
+    
 
-export interface UpdateBookmarkFolderResponse {
-  duration: string;
 
-  bookmark_folder: BookmarkFolderResponse;
-}
 
-export interface UpdateBookmarkRequest {
-  /**
-   * ID of the folder containing the bookmark
-   */
-  folder_id?: string;
 
-  /**
-   * Move the bookmark to this folder (empty string removes the folder)
-   */
-  new_folder_id?: string;
+    export interface QueryFeedMembersRequest {
+    limit?: number;
+    
 
-  /**
-   * Custom data for the bookmark
-   */
-  custom?: Record<string, any>;
+        
+    next?: string;
+    
 
-  new_folder?: AddFolderRequest;
-}
+        
+    prev?: string;
+    
 
-export interface UpdateBookmarkResponse {
-  duration: string;
+        
+    /**
+     * Sort parameters for the query
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-  bookmark: BookmarkResponse;
-}
+        
+    /**
+     * Filter parameters for the query
+     */
+    filter?: Record<string, any>;
+    
 
-export interface UpdateCollectionRequest {
-  /**
-   * Unique identifier for the collection within its name
-   */
-  id: string;
+        }
+    
 
-  /**
-   * Name/type of the collection
-   */
-  name: string;
 
-  /**
-   * Custom data for the collection (required, must contain at least one key)
-   */
-  custom: Record<string, any>;
-}
 
-export interface UpdateCollectionsRequest {
-  /**
-   * List of collections to update (only custom data is updatable)
-   */
-  collections: UpdateCollectionRequest[];
-}
 
-export interface UpdateCollectionsResponse {
-  duration: string;
+    export interface QueryFeedMembersResponse {
+    duration: string;
+    
 
-  /**
-   * List of updated collections
-   */
-  collections: CollectionResponse[];
-}
+        
+    /**
+     * List of feed members
+     */
+    members: Array<FeedMemberResponse>;
+    
 
-export interface UpdateCommentBookmarkRequest {
-  /**
-   * ID of the folder containing the bookmark
-   */
-  folder_id?: string;
+        
+    /**
+     * Cursor for next page
+     */
+    next?: string;
+    
 
-  /**
-   * Move the bookmark to this folder (empty string removes the folder)
-   */
-  new_folder_id?: string;
+        
+    /**
+     * Cursor for previous page
+     */
+    prev?: string;
+    
 
-  /**
-   * Custom data for the bookmark
-   */
-  custom?: Record<string, any>;
+        }
+    
 
-  new_folder?: AddFolderRequest;
-}
 
-export interface UpdateCommentBookmarkResponse {
-  duration: string;
 
-  bookmark: BookmarkResponse;
-}
 
-export interface UpdateCommentPartialRequest {
-  /**
-   * @deprecated
-   * Whether to copy custom data to notification activities Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-   */
-  copy_custom_to_notification?: boolean;
+    export interface QueryFeedsRequest {
+    enrich_own_fields?: boolean;
+    
 
-  /**
-   * Whether to handle mention notification changes
-   */
-  handle_mention_notifications?: boolean;
+        
+    limit?: number;
+    
 
-  /**
-   * Whether to skip URL enrichment
-   */
-  skip_enrich_url?: boolean;
+        
+    next?: string;
+    
 
-  /**
-   * Whether to skip push notifications
-   */
-  skip_push?: boolean;
+        
+    prev?: string;
+    
 
-  /**
-   * List of field names to remove. Supported fields: 'custom', 'attachments', 'mentioned_user_ids', 'status'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
-   */
-  unset?: string[];
+        
+    /**
+     * Whether to subscribe to realtime updates
+     */
+    watch?: boolean;
+    
 
-  /**
-   * Map of field names to new values. Supported fields: 'text', 'attachments', 'custom', 'mentioned_user_ids', 'status'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
-   */
-  set?: Record<string, any>;
-}
+        
+    /**
+     * Sorting parameters for the query
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-export interface UpdateCommentPartialResponse {
-  duration: string;
+        
+    /**
+     * Filters to apply to the query
+     */
+    filter?: Record<string, any>;
+    
 
-  comment: CommentResponse;
-}
+        }
+    
 
-export interface UpdateCommentRequest {
-  /**
-   * Updated text content of the comment
-   */
-  comment?: string;
 
-  /**
-   * @deprecated
-   * Whether to copy custom data to the notification activity (only applies when handle_mention_notifications creates notifications) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-   */
-  copy_custom_to_notification?: boolean;
 
-  /**
-   * If true, creates notification activities for newly mentioned users and deletes notifications for users no longer mentioned
-   */
-  handle_mention_notifications?: boolean;
 
-  /**
-   * Whether to skip URL enrichment for this comment
-   */
-  skip_enrich_url?: boolean;
+    export interface QueryFeedsResponse {
+    duration: string;
+    
 
-  skip_push?: boolean;
+        
+    /**
+     * List of feeds matching the query
+     */
+    feeds: Array<FeedResponse>;
+    
 
-  /**
-   * Updated media attachments for the comment. Providing this field will replace all existing attachments.
-   */
-  attachments?: Attachment[];
+        
+    /**
+     * Cursor for next page
+     */
+    next?: string;
+    
 
-  /**
-   * List of user IDs mentioned in the comment
-   */
-  mentioned_user_ids?: string[];
+        
+    /**
+     * Cursor for previous page
+     */
+    prev?: string;
+    
 
-  /**
-   * Updated custom data for the comment
-   */
-  custom?: Record<string, any>;
-}
+        }
+    
 
-export interface UpdateCommentResponse {
-  duration: string;
 
-  comment: CommentResponse;
-}
 
-export interface UpdateFeedMembersRequest {
-  /**
-   * Type of update operation to perform. One of: upsert, remove, set
-   */
 
-  operation: 'upsert' | 'remove' | 'set';
+    export interface QueryFollowsRequest {
+    limit?: number;
+    
 
-  limit?: number;
+        
+    next?: string;
+    
 
-  next?: string;
+        
+    prev?: string;
+    
 
-  prev?: string;
+        
+    /**
+     * Sorting parameters for the query
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-  /**
-   * List of members to upsert, remove, or set
-   */
-  members?: FeedMemberRequest[];
-}
+        
+    /**
+     * Filters to apply to the query
+     */
+    filter?: Record<string, any>;
+    
 
-export interface UpdateFeedMembersResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        }
+    
 
-  added: FeedMemberResponse[];
 
-  removed_ids: string[];
 
-  updated: FeedMemberResponse[];
-}
 
-export interface UpdateFeedRequest {
-  /**
-   * If true, removes the geographic location from the feed
-   */
-  clear_location?: boolean;
+    export interface QueryFollowsResponse {
+    duration: string;
+    
 
-  /**
-   * Description of the feed
-   */
-  description?: string;
+        
+    /**
+     * List of follow relationships matching the query
+     */
+    follows: Array<FollowResponse>;
+    
 
-  /**
-   * If true, enriches the feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-   */
-  enrich_own_fields?: boolean;
+        
+    /**
+     * Cursor for next page
+     */
+    next?: string;
+    
 
-  /**
-   * Name of the feed
-   */
-  name?: string;
+        
+    /**
+     * Cursor for previous page
+     */
+    prev?: string;
+    
 
-  /**
-   * Tags used for filtering feeds
-   */
-  filter_tags?: string[];
+        }
+    
 
-  /**
-   * Custom data for the feed
-   */
-  custom?: Record<string, any>;
 
-  location?: Location;
-}
 
-export interface UpdateFeedResponse {
-  duration: string;
 
-  feed: FeedResponse;
-}
+    export interface QueryModerationConfigsRequest {
+    limit?: number;
+    
 
-export interface UpdateFollowRequest {
-  /**
-   * Fully qualified ID of the source feed
-   */
-  source: string;
+        
+    next?: string;
+    
 
-  /**
-   * Fully qualified ID of the target feed
-   */
-  target: string;
+        
+    prev?: string;
+    
 
-  /**
-   * Maximum number of historical activities to copy from the target feed when the follow is first materialized. Not set = unlimited (default). 0 = copy nothing. Range: 0-1000.
-   */
-  activity_copy_limit?: number;
+        
+    /**
+     * Sorting parameters for the results
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-  /**
-   * @deprecated
-   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-   */
-  copy_custom_to_notification?: boolean;
+        
+    /**
+     * Filter conditions for moderation configs
+     */
+    filter?: Record<string, any>;
+    
 
-  /**
-   * Whether to create a notification activity for this follow
-   */
-  create_notification_activity?: boolean;
+        }
+    
 
-  /**
-   * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-   */
-  enrich_own_fields?: boolean;
 
-  follower_role?: string;
 
-  /**
-   * Push preference for the follow relationship
-   */
 
-  push_preference?: 'all' | 'none';
+    export interface QueryModerationConfigsResponse {
+    duration: string;
+    
 
-  /**
-   * Whether to skip push for this follow
-   */
-  skip_push?: boolean;
+        
+    /**
+     * List of moderation configurations
+     */
+    configs: Array<ConfigResponse>;
+    
 
-  /**
-   * Custom data for the follow relationship
-   */
-  custom?: Record<string, any>;
-}
+        
+    next?: string;
+    
 
-export interface UpdateFollowResponse {
-  duration: string;
+        
+    prev?: string;
+    
 
-  follow: FollowResponse;
-}
+        }
+    
 
-export interface UpdateLiveLocationRequest {
-  /**
-   * Live location ID
-   */
-  message_id: string;
 
-  /**
-   * Time when the live location expires
-   */
-  end_at?: Date;
 
-  /**
-   * Latitude coordinate
-   */
-  latitude?: number;
 
-  /**
-   * Longitude coordinate
-   */
-  longitude?: number;
-}
+    export interface QueryPinnedActivitiesRequest {
+    enrich_own_fields?: boolean;
+    
 
-export interface UpdatePollOptionRequest {
-  /**
-   * Option ID
-   */
-  id: string;
+        
+    limit?: number;
+    
 
-  /**
-   * Option text
-   */
-  text: string;
+        
+    next?: string;
+    
 
-  custom?: Record<string, any>;
-}
+        
+    prev?: string;
+    
 
-export interface UpdatePollPartialRequest {
-  /**
-   * Array of field names to unset
-   */
-  unset?: string[];
+        
+    /**
+     * Sorting parameters for the query
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-  /**
-   * Sets new field values
-   */
-  set?: Record<string, any>;
-}
+        
+    /**
+     * Filters to apply to the query
+     */
+    filter?: Record<string, any>;
+    
 
-export interface UpdatePollRequest {
-  /**
-   * Poll ID
-   */
-  id: string;
+        }
+    
 
-  /**
-   * Poll name
-   */
-  name: string;
 
-  /**
-   * Allow answers
-   */
-  allow_answers?: boolean;
 
-  /**
-   * Allow user suggested options
-   */
-  allow_user_suggested_options?: boolean;
 
-  /**
-   * Poll description
-   */
-  description?: string;
+    export interface QueryPinnedActivitiesResponse {
+    duration: string;
+    
 
-  /**
-   * Enforce unique vote
-   */
-  enforce_unique_vote?: boolean;
+        
+    /**
+     * List of pinned activities matching the query
+     */
+    pinned_activities: Array<ActivityPinResponse>;
+    
 
-  /**
-   * Is closed
-   */
-  is_closed?: boolean;
+        
+    /**
+     * Cursor for next page
+     */
+    next?: string;
+    
 
-  /**
-   * Max votes allowed
-   */
-  max_votes_allowed?: number;
+        
+    /**
+     * Cursor for previous page
+     */
+    prev?: string;
+    
 
-  /**
-   * Voting visibility
-   */
+        }
+    
 
-  voting_visibility?: 'anonymous' | 'public';
 
-  /**
-   * Poll options
-   */
-  options?: PollOptionRequest[];
 
-  custom?: Record<string, any>;
-}
 
-export interface UpdateUserGroupRequest {
-  /**
-   * The new description for the group
-   */
-  description?: string;
+    export interface QueryPollVotesRequest {
+    limit?: number;
+    
 
-  /**
-   * The new name of the user group
-   */
-  name?: string;
+        
+    next?: string;
+    
 
-  team_id?: string;
-}
+        
+    prev?: string;
+    
 
-export interface UpdateUserGroupResponse {
-  duration: string;
+        
+    /**
+     * Array of sort parameters
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-  user_group?: UserGroupResponse;
-}
+        
+    /**
+     * Filter to apply to the query
+     */
+    filter?: Record<string, any>;
+    
 
-export interface UpdateUserPartialRequest {
-  /**
-   * User ID to update
-   */
-  id: string;
+        }
+    
 
-  unset?: string[];
 
-  set?: Record<string, any>;
-}
 
-export interface UpdateUsersPartialRequest {
-  users: UpdateUserPartialRequest[];
-}
 
-export interface UpdateUsersRequest {
-  /**
-   * Object containing users
-   */
-  users: Record<string, UserRequest>;
-}
+    export interface QueryPollsRequest {
+    limit?: number;
+    
 
-export interface UpdateUsersResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
+        
+    next?: string;
+    
 
-  membership_deletion_task_id: string;
+        
+    prev?: string;
+    
 
-  /**
-   * Object containing users
-   */
-  users: Record<string, FullUserResponse>;
-}
+        
+    /**
+     * Array of sort parameters
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-export interface UpsertActivitiesRequest {
-  /**
-   * List of activities to create or update
-   */
-  activities: ActivityRequest[];
+        
+    /**
+     * Filter to apply to the query
+     */
+    filter?: Record<string, any>;
+    
 
-  /**
-   * If true, enriches the activities' current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-   */
-  enrich_own_fields?: boolean;
-}
+        }
+    
 
-export interface UpsertActivitiesResponse {
-  duration: string;
 
-  /**
-   * List of created or updated activities
-   */
-  activities: ActivityResponse[];
 
-  /**
-   * Total number of mention notification activities created for mentioned users across all activities
-   */
-  mention_notifications_created?: number;
-}
 
-export interface UpsertConfigRequest {
-  /**
-   * Unique identifier for the moderation configuration
-   */
-  key: string;
+    export interface QueryPollsResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  /**
-   * Whether moderation should be performed asynchronously
-   */
-  async?: boolean;
+        
+    /**
+     * Polls data returned by the query
+     */
+    polls: Array<PollResponseData>;
+    
 
-  /**
-   * Team associated with the configuration
-   */
-  team?: string;
+        
+    next?: string;
+    
 
-  ai_image_config?: AIImageConfig;
+        
+    prev?: string;
+    
 
-  ai_text_config?: AITextConfig;
+        }
+    
 
-  ai_video_config?: AIVideoConfig;
 
-  automod_platform_circumvention_config?: AutomodPlatformCircumventionConfig;
 
-  automod_semantic_filters_config?: AutomodSemanticFiltersConfig;
 
-  automod_toxicity_config?: AutomodToxicityConfig;
+    export interface QueryReviewQueueRequest {
+    exclude_default_action_config?: boolean;
+    
 
-  aws_rekognition_config?: AIImageConfig;
+        
+    limit?: number;
+    
 
-  block_list_config?: BlockListConfig;
+        
+    /**
+     * Number of items to lock (1-25)
+     */
+    lock_count?: number;
+    
 
-  bodyguard_config?: AITextConfig;
+        
+    /**
+     * Duration for which items should be locked
+     */
+    lock_duration?: number;
+    
 
-  google_vision_config?: GoogleVisionConfig;
+        
+    /**
+     * Whether to lock items for review (true), unlock items (false), or just fetch (nil)
+     */
+    lock_items?: boolean;
+    
 
-  llm_config?: LLMConfig;
+        
+    next?: string;
+    
 
-  rule_builder_config?: RuleBuilderConfig;
+        
+    prev?: string;
+    
 
-  velocity_filter_config?: VelocityFilterConfig;
+        
+    /**
+     * Whether to return only statistics
+     */
+    stats_only?: boolean;
+    
 
-  video_call_rule_config?: VideoCallRuleConfig;
-}
+        
+    /**
+     * Sorting parameters for the results
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-export interface UpsertConfigResponse {
-  duration: string;
+        
+    /**
+     * Filter conditions for review queue items
+     */
+    filter?: Record<string, any>;
+    
 
-  config?: ConfigResponse;
-}
+        }
+    
 
-export interface UpsertPushPreferencesRequest {
-  /**
-   * A list of push preferences for channels, calls, or the user.
-   */
-  preferences: PushPreferenceInput[];
-}
 
-export interface UpsertPushPreferencesResponse {
-  /**
-   * Duration of the request in milliseconds
-   */
-  duration: string;
 
-  /**
-   * The channel specific push notification preferences, only returned for channels you've edited.
-   */
-  user_channel_preferences: Record<
-    string,
-    Record<string, ChannelPushPreferencesResponse | null>
-  >;
 
-  /**
-   * The user preferences, always returned regardless if you edited it
-   */
-  user_preferences: Record<string, PushPreferencesResponse>;
-}
+    export interface QueryReviewQueueResponse {
+    duration: string;
+    
 
-export interface User {
-  id: string;
+        
+    /**
+     * List of review queue items
+     */
+    items: Array<ReviewQueueItemResponse>;
+    
 
-  data?: Record<string, any>;
-}
+        
+    /**
+     * Configuration for moderation actions
+     */
+    action_config: Record<string, Array<ModerationActionConfigResponse>>;
+    
 
-export interface UserBannedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    /**
+     * Statistics about the review queue
+     */
+    stats: Record<string, any>;
+    
 
-  custom: Record<string, any>;
+        
+    next?: string;
+    
 
-  user: UserResponseCommonFields;
+        
+    prev?: string;
+    
 
-  /**
-   * The type of event: "user.banned" in this case
-   */
-  type: string;
+        
+    default_action_config?: Record<string, Array<ModerationActionConfigResponse>>;
+    
 
-  /**
-   * The ID of the channel where the target user was banned
-   */
-  channel_id?: string;
+        
+    filter_config?: FilterConfigResponse;
+    
 
-  channel_member_count?: number;
+        }
+    
 
-  channel_message_count?: number;
 
-  /**
-   * The type of the channel where the target user was banned
-   */
-  channel_type?: string;
 
-  /**
-   * The CID of the channel where the target user was banned
-   */
-  cid?: string;
 
-  /**
-   * The expiration date of the ban
-   */
-  expiration?: Date;
+    export interface QueryUsersPayload {
+    /**
+     * Filter conditions to apply to the query
+     */
+    filter_conditions: Record<string, any>;
+    
 
-  /**
-   * The reason for the ban
-   */
-  reason?: string;
+        
+    include_deactivated_users?: boolean;
+    
 
-  received_at?: Date;
+        
+    limit?: number;
+    
 
-  /**
-   * Whether the user was shadow banned
-   */
-  shadow?: boolean;
+        
+    offset?: number;
+    
 
-  /**
-   * The team of the channel where the target user was banned
-   */
-  team?: string;
+        
+    presence?: boolean;
+    
 
-  total_bans?: number;
+        
+    /**
+     * Array of sort parameters
+     */
+    sort?: Array<SortParamRequest>;
+    
 
-  channel_custom?: Record<string, any>;
+        }
+    
 
-  created_by?: UserResponseCommonFields;
-}
 
-export interface UserCreatedWithinParameters {
-  max_age?: string;
-}
 
-export interface UserCustomPropertyParameters {
-  operator?: string;
 
-  property_key?: string;
-}
+    export interface QueryUsersResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-export interface UserDeactivatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    /**
+     * Array of users as result of filters applied.
+     */
+    users: Array<FullUserResponse>;
+    
 
-  custom: Record<string, any>;
+        }
+    
 
-  user: UserResponseCommonFields;
 
-  /**
-   * The type of event: "user.deactivated" in this case
-   */
-  type: string;
 
-  received_at?: Date;
 
-  created_by?: UserResponseCommonFields;
-}
+    export interface RankingConfig {
+    score?: string;
+    
 
-export interface UserGroupMember {
-  app_pk: number;
+        
+    type?: string;
+    
 
-  created_at: Date;
+        
+    defaults?: Record<string, any>;
+    
 
-  group_id: string;
+        
+    functions?: Record<string, DecayFunctionConfig>;
+    
 
-  is_admin: boolean;
+        }
+    
 
-  user_id: string;
-}
 
-export interface UserGroupResponse {
-  created_at: Date;
 
-  id: string;
 
-  name: string;
+    export interface Reaction {
+    activity_id: string;
+    
 
-  updated_at: Date;
+        
+    created_at: Date;
+    
 
-  created_by?: string;
+        
+    kind: string;
+    
 
-  description?: string;
+        
+    updated_at: Date;
+    
 
-  team_id?: string;
+        
+    user_id: string;
+    
 
-  members?: UserGroupMember[];
-}
+        
+    deleted_at?: Date;
+    
 
-export interface UserIdenticalContentCountParameters {
-  threshold?: number;
+        
+    id?: string;
+    
 
-  time_window?: string;
-}
+        
+    parent?: string;
+    
 
-export interface UserMuteResponse {
-  created_at: Date;
+        
+    score?: number;
+    
 
-  updated_at: Date;
+        
+    target_feeds?: Array<string>;
+    
 
-  expires?: Date;
+        
+    children_counts?: Record<string, any>;
+    
 
-  target?: UserResponse;
+        
+    data?: Record<string, any>;
+    
 
-  user?: UserResponse;
-}
+        
+    latest_children?: Record<string, Array<Reaction>>;
+    
 
-export interface UserReactivatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
+        
+    moderation?: Record<string, any>;
+    
 
-  custom: Record<string, any>;
+        
+    own_children?: Record<string, Array<Reaction>>;
+    
 
-  user: UserResponseCommonFields;
+        
+    target_feeds_extra_data?: Record<string, any>;
+    
 
-  /**
-   * The type of event: "user.reactivated" in this case
-   */
-  type: string;
+        
+    user?: User;
+    
 
-  received_at?: Date;
+        }
+    
 
-  created_by?: UserResponseCommonFields;
-}
 
-export interface UserRequest {
-  /**
-   * User ID
-   */
-  id: string;
 
-  /**
-   * User's profile image URL
-   */
-  image?: string;
 
-  invisible?: boolean;
+    export interface ReactionGroupResponse {
+    /**
+     * Count is the number of reactions of this type.
+     */
+    count: number;
+    
 
-  language?: string;
+        
+    /**
+     * FirstReactionAt is the time of the first reaction of this type. This is the same also if all reaction of this type are deleted, because if someone will react again with the same type, will be preserved the sorting.
+     */
+    first_reaction_at: Date;
+    
 
-  /**
-   * Optional name of user
-   */
-  name?: string;
+        
+    /**
+     * LastReactionAt is the time of the last reaction of this type.
+     */
+    last_reaction_at: Date;
+    
 
-  /**
-   * Custom user data
-   */
-  custom?: Record<string, any>;
+        
+    /**
+     * SumScores is the sum of all scores of reactions of this type. Medium allows you to clap articles more than once and shows the sum of all claps from all users. For example, you can send `clap` x5 using `score: 5`.
+     */
+    sum_scores: number;
+    
 
-  privacy_settings?: PrivacySettingsResponse;
-}
+        
+    /**
+     * The most recent users who reacted with this type, ordered by most recent first.
+     */
+    latest_reactions_by: Array<ReactionGroupUserResponse>;
+    
 
-export interface UserResponse {
-  /**
-   * Whether a user is banned or not
-   */
-  banned: boolean;
+        }
+    
 
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  /**
-   * Unique user identifier
-   */
-  id: string;
 
-  /**
-   * Preferred language of a user
-   */
-  language: string;
 
-  /**
-   * Whether a user online or not
-   */
-  online: boolean;
+    export interface ReactionGroupUserResponse {
+    /**
+     * The time when the user reacted.
+     */
+    created_at: Date;
+    
 
-  /**
-   * Determines the set of user permissions
-   */
-  role: string;
+        
+    /**
+     * The ID of the user who reacted.
+     */
+    user_id: string;
+    
 
-  /**
-   * Date/time of the last update
-   */
-  updated_at: Date;
+        
+    user?: UserResponse;
+    
 
-  blocked_user_ids: string[];
+        }
+    
 
-  /**
-   * List of teams user is a part of
-   */
-  teams: string[];
 
-  /**
-   * Custom data for this object
-   */
-  custom: Record<string, any>;
 
-  avg_response_time?: number;
 
-  /**
-   * Date of deactivation
-   */
-  deactivated_at?: Date;
+    export interface ReactionResponse {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
 
-  /**
-   * Date/time of deletion
-   */
-  deleted_at?: Date;
+        
+    /**
+     * Message ID
+     */
+    message_id: string;
+    
 
-  image?: string;
+        
+    /**
+     * Score of the reaction
+     */
+    score: number;
+    
 
-  /**
-   * Date of last activity
-   */
-  last_active?: Date;
+        
+    /**
+     * Type of reaction
+     */
+    type: string;
+    
 
-  /**
-   * Optional name of user
-   */
-  name?: string;
+        
+    /**
+     * Date/time of the last update
+     */
+    updated_at: Date;
+    
 
-  /**
-   * Revocation date for tokens
-   */
-  revoke_tokens_issued_before?: Date;
+        
+    /**
+     * User ID
+     */
+    user_id: string;
+    
 
-  teams_role?: Record<string, string>;
-}
+        
+    /**
+     * Custom data for this object
+     */
+    custom: Record<string, any>;
+    
 
-export interface UserResponseCommonFields {
-  banned: boolean;
+        
+    user: UserResponse;
+    
 
-  created_at: Date;
+        }
+    
 
-  id: string;
 
-  language: string;
 
-  online: boolean;
 
-  role: string;
+    export interface ReadCollectionsResponse {
+    duration: string;
+    
 
-  updated_at: Date;
+        
+    /**
+     * List of collections matching the references
+     */
+    collections: Array<CollectionResponse>;
+    
 
-  blocked_user_ids: string[];
+        }
+    
 
-  teams: string[];
 
-  custom: Record<string, any>;
 
-  avg_response_time?: number;
 
-  deactivated_at?: Date;
+    export interface ReadReceiptsResponse {
+    enabled: boolean;
+    
 
-  deleted_at?: Date;
+        }
+    
 
-  image?: string;
 
-  last_active?: Date;
 
-  name?: string;
 
-  revoke_tokens_issued_before?: Date;
+    export interface RejectAppealRequestPayload {
+    /**
+     * Reason for rejecting the appeal
+     */
+    decision_reason: string;
+    
 
-  teams_role?: Record<string, string>;
-}
+        }
+    
 
-export interface UserResponsePrivacyFields {
-  banned: boolean;
 
-  created_at: Date;
 
-  id: string;
 
-  language: string;
+    export interface RejectFeedMemberInviteRequest {}
+    
 
-  online: boolean;
 
-  role: string;
 
-  updated_at: Date;
 
-  blocked_user_ids: string[];
+    export interface RejectFeedMemberInviteResponse {
+    duration: string;
+    
 
-  teams: string[];
+        
+    member: FeedMemberResponse;
+    
 
-  custom: Record<string, any>;
+        }
+    
 
-  avg_response_time?: number;
 
-  deactivated_at?: Date;
 
-  deleted_at?: Date;
 
-  image?: string;
+    export interface RejectFollowRequest {
+    /**
+     * Fully qualified ID of the source feed
+     */
+    source: string;
+    
 
-  invisible?: boolean;
+        
+    /**
+     * Fully qualified ID of the target feed
+     */
+    target: string;
+    
 
-  last_active?: Date;
+        }
+    
 
-  name?: string;
 
-  revoke_tokens_issued_before?: Date;
 
-  privacy_settings?: PrivacySettingsResponse;
 
-  teams_role?: Record<string, string>;
-}
+    export interface RejectFollowResponse {
+    duration: string;
+    
 
-export interface UserRoleParameters {
-  operator?: string;
+        
+    follow: FollowResponse;
+    
 
-  role?: string;
-}
+        }
+    
 
-export interface UserRuleParameters {
-  max_age?: string;
-}
 
-export interface UserUnbannedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  custom: Record<string, any>;
 
-  user: UserResponseCommonFields;
+    export interface ReminderResponseData {
+    channel_cid: string;
+    
 
-  /**
-   * The type of event: "user.unbanned" in this case
-   */
-  type: string;
+        
+    created_at: Date;
+    
 
-  /**
-   * The ID of the channel where the target user was unbanned
-   */
-  channel_id?: string;
+        
+    message_id: string;
+    
 
-  channel_member_count?: number;
+        
+    updated_at: Date;
+    
 
-  channel_message_count?: number;
+        
+    user_id: string;
+    
 
-  /**
-   * The type of the channel where the target user was unbanned
-   */
-  channel_type?: string;
+        
+    remind_at?: Date;
+    
 
-  /**
-   * The CID of the channel where the target user was unbanned
-   */
-  cid?: string;
+        
+    channel?: ChannelResponse;
+    
 
-  received_at?: Date;
+        
+    message?: MessageResponse;
+    
 
-  /**
-   * Whether the target user was shadow unbanned
-   */
-  shadow?: boolean;
+        
+    user?: UserResponse;
+    
 
-  /**
-   * The team of the channel where the target user was unbanned
-   */
-  team?: string;
+        }
+    
 
-  channel_custom?: Record<string, any>;
 
-  created_by?: UserResponseCommonFields;
-}
 
-export interface UserUpdatedEvent {
-  /**
-   * Date/time of creation
-   */
-  created_at: Date;
 
-  custom: Record<string, any>;
+    export interface RemoveUserGroupMembersRequest {
+    /**
+     * List of user IDs to remove
+     */
+    member_ids: Array<string>;
+    
 
-  user: UserResponsePrivacyFields;
+        
+    team_id?: string;
+    
 
-  /**
-   * The type of event: "user.updated" in this case
-   */
-  type: string;
+        }
+    
 
-  received_at?: Date;
-}
 
-export interface VelocityFilterConfig {
-  advanced_filters: boolean;
 
-  cascading_actions: boolean;
 
-  cids_per_user: number;
+    export interface RemoveUserGroupMembersResponse {
+    duration: string;
+    
 
-  enabled: boolean;
+        
+    user_group?: UserGroupResponse;
+    
 
-  first_message_only: boolean;
+        }
+    
 
-  rules: VelocityFilterConfigRule[];
 
-  async?: boolean;
-}
 
-export interface VelocityFilterConfigRule {
-  action: 'flag' | 'shadow' | 'remove' | 'ban';
 
-  ban_duration: number;
+    export interface RepliesMeta {
+    /**
+     * True if the subtree was cut because the requested depth was reached.
+     */
+    depth_truncated: boolean;
+    
 
-  cascading_action: 'flag' | 'shadow' | 'remove' | 'ban';
+        
+    /**
+     * True if more siblings exist in the database.
+     */
+    has_more: boolean;
+    
 
-  cascading_threshold: number;
+        
+    /**
+     * Number of unread siblings that match current filters.
+     */
+    remaining: number;
+    
 
-  check_message_context: boolean;
+        
+    /**
+     * Opaque cursor to request the next page of siblings.
+     */
+    next_cursor?: string;
+    
 
-  fast_spam_threshold: number;
+        }
+    
 
-  fast_spam_ttl: number;
 
-  ip_ban: boolean;
 
-  probation_period: number;
 
-  shadow_ban: boolean;
+    export interface Response {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
 
-  slow_spam_threshold: number;
+        }
+    
 
-  slow_spam_ttl: number;
 
-  url_only: boolean;
 
-  slow_spam_ban_duration?: number;
-}
 
-export interface VideoCallRuleConfig {
-  flag_all_labels: boolean;
+    export interface RestoreActionRequestPayload {
+    /**
+     * Reason for the appeal decision
+     */
+    decision_reason?: string;
+    
 
-  flagged_labels: string[];
+        }
+    
 
-  rules: HarmConfig[];
-}
 
-export interface VideoContentParameters {
-  label_operator?: string;
 
-  harm_labels?: string[];
-}
 
-export interface VideoEndCallRequestPayload {}
+    export interface RestoreActivityRequest {}
+    
 
-export interface VideoKickUserRequestPayload {}
 
-export interface VideoRuleParameters {
-  threshold?: number;
 
-  time_window?: string;
 
-  harm_labels?: string[];
-}
+    export interface RestoreActivityResponse {
+    duration: string;
+    
 
-export interface VideoSettingsResponse {
-  access_request_enabled: boolean;
+        
+    activity: ActivityResponse;
+    
 
-  camera_default_on: boolean;
+        }
+    
 
-  camera_facing: string;
 
-  enabled: boolean;
 
-  target_resolution: TargetResolution;
-}
 
-export interface VoteData {
-  answer_text?: string;
+    export interface RestoreCommentRequest {}
+    
 
-  option_id?: string;
-}
 
-export interface WHIPIngress {
-  address: string;
-}
 
-export interface WSAuthMessage {
-  /**
-   * JWT token for authentication
-   */
-  token: string;
 
-  user_details: ConnectUserDetailsRequest;
+    export interface RestoreCommentResponse {
+    duration: string;
+    
 
-  /**
-   * List of products to subscribe to. One of: chat, video, feeds
-   */
-  products?: string[];
-}
+        
+    activity: ActivityResponse;
+    
 
-export type WSClientEvent =
-  | ({ type: 'app.updated' } & AppUpdatedEvent)
-  | ({ type: 'feeds.activity.added' } & ActivityAddedEvent)
-  | ({ type: 'feeds.activity.deleted' } & ActivityDeletedEvent)
-  | ({ type: 'feeds.activity.feedback' } & ActivityFeedbackEvent)
-  | ({ type: 'feeds.activity.marked' } & ActivityMarkEvent)
-  | ({ type: 'feeds.activity.pinned' } & ActivityPinnedEvent)
-  | ({ type: 'feeds.activity.reaction.added' } & ActivityReactionAddedEvent)
-  | ({ type: 'feeds.activity.reaction.deleted' } & ActivityReactionDeletedEvent)
-  | ({ type: 'feeds.activity.reaction.updated' } & ActivityReactionUpdatedEvent)
-  | ({
-      type: 'feeds.activity.removed_from_feed';
-    } & ActivityRemovedFromFeedEvent)
-  | ({ type: 'feeds.activity.restored' } & ActivityRestoredEvent)
-  | ({ type: 'feeds.activity.unpinned' } & ActivityUnpinnedEvent)
-  | ({ type: 'feeds.activity.updated' } & ActivityUpdatedEvent)
-  | ({ type: 'feeds.bookmark.added' } & BookmarkAddedEvent)
-  | ({ type: 'feeds.bookmark.deleted' } & BookmarkDeletedEvent)
-  | ({ type: 'feeds.bookmark.updated' } & BookmarkUpdatedEvent)
-  | ({ type: 'feeds.bookmark_folder.deleted' } & BookmarkFolderDeletedEvent)
-  | ({ type: 'feeds.bookmark_folder.updated' } & BookmarkFolderUpdatedEvent)
-  | ({ type: 'feeds.comment.added' } & CommentAddedEvent)
-  | ({ type: 'feeds.comment.deleted' } & CommentDeletedEvent)
-  | ({ type: 'feeds.comment.reaction.added' } & CommentReactionAddedEvent)
-  | ({ type: 'feeds.comment.reaction.deleted' } & CommentReactionDeletedEvent)
-  | ({ type: 'feeds.comment.reaction.updated' } & CommentReactionUpdatedEvent)
-  | ({ type: 'feeds.comment.restored' } & CommentRestoredEvent)
-  | ({ type: 'feeds.comment.updated' } & CommentUpdatedEvent)
-  | ({ type: 'feeds.feed.created' } & FeedCreatedEvent)
-  | ({ type: 'feeds.feed.deleted' } & FeedDeletedEvent)
-  | ({ type: 'feeds.feed.updated' } & FeedUpdatedEvent)
-  | ({ type: 'feeds.feed_group.changed' } & FeedGroupChangedEvent)
-  | ({ type: 'feeds.feed_group.deleted' } & FeedGroupDeletedEvent)
-  | ({ type: 'feeds.feed_group.restored' } & FeedGroupRestoredEvent)
-  | ({ type: 'feeds.feed_member.added' } & FeedMemberAddedEvent)
-  | ({ type: 'feeds.feed_member.removed' } & FeedMemberRemovedEvent)
-  | ({ type: 'feeds.feed_member.updated' } & FeedMemberUpdatedEvent)
-  | ({ type: 'feeds.follow.created' } & FollowCreatedEvent)
-  | ({ type: 'feeds.follow.deleted' } & FollowDeletedEvent)
-  | ({ type: 'feeds.follow.updated' } & FollowUpdatedEvent)
-  | ({ type: 'feeds.notification_feed.updated' } & NotificationFeedUpdatedEvent)
-  | ({ type: 'feeds.poll.closed' } & PollClosedFeedEvent)
-  | ({ type: 'feeds.poll.deleted' } & PollDeletedFeedEvent)
-  | ({ type: 'feeds.poll.updated' } & PollUpdatedFeedEvent)
-  | ({ type: 'feeds.poll.vote_casted' } & PollVoteCastedFeedEvent)
-  | ({ type: 'feeds.poll.vote_changed' } & PollVoteChangedFeedEvent)
-  | ({ type: 'feeds.poll.vote_removed' } & PollVoteRemovedFeedEvent)
-  | ({ type: 'feeds.stories_feed.updated' } & StoriesFeedUpdatedEvent)
-  | ({ type: 'health.check' } & HealthCheckEvent)
-  | ({ type: 'moderation.custom_action' } & ModerationCustomActionEvent)
-  | ({ type: 'moderation.flagged' } & ModerationFlaggedEvent)
-  | ({ type: 'moderation.mark_reviewed' } & ModerationMarkReviewedEvent)
-  | ({ type: 'user.banned' } & UserBannedEvent)
-  | ({ type: 'user.deactivated' } & UserDeactivatedEvent)
-  | ({ type: 'user.reactivated' } & UserReactivatedEvent)
-  | ({ type: 'user.unbanned' } & UserUnbannedEvent)
-  | ({ type: 'user.updated' } & UserUpdatedEvent);
+        
+    comment: CommentResponse;
+    
 
-export type WSEvent =
-  | ({ type: 'app.updated' } & AppUpdatedEvent)
-  | ({ type: 'feeds.activity.added' } & ActivityAddedEvent)
-  | ({ type: 'feeds.activity.deleted' } & ActivityDeletedEvent)
-  | ({ type: 'feeds.activity.feedback' } & ActivityFeedbackEvent)
-  | ({ type: 'feeds.activity.marked' } & ActivityMarkEvent)
-  | ({ type: 'feeds.activity.pinned' } & ActivityPinnedEvent)
-  | ({ type: 'feeds.activity.reaction.added' } & ActivityReactionAddedEvent)
-  | ({ type: 'feeds.activity.reaction.deleted' } & ActivityReactionDeletedEvent)
-  | ({ type: 'feeds.activity.reaction.updated' } & ActivityReactionUpdatedEvent)
-  | ({
-      type: 'feeds.activity.removed_from_feed';
-    } & ActivityRemovedFromFeedEvent)
-  | ({ type: 'feeds.activity.restored' } & ActivityRestoredEvent)
-  | ({ type: 'feeds.activity.unpinned' } & ActivityUnpinnedEvent)
-  | ({ type: 'feeds.activity.updated' } & ActivityUpdatedEvent)
-  | ({ type: 'feeds.bookmark.added' } & BookmarkAddedEvent)
-  | ({ type: 'feeds.bookmark.deleted' } & BookmarkDeletedEvent)
-  | ({ type: 'feeds.bookmark.updated' } & BookmarkUpdatedEvent)
-  | ({ type: 'feeds.bookmark_folder.deleted' } & BookmarkFolderDeletedEvent)
-  | ({ type: 'feeds.bookmark_folder.updated' } & BookmarkFolderUpdatedEvent)
-  | ({ type: 'feeds.comment.added' } & CommentAddedEvent)
-  | ({ type: 'feeds.comment.deleted' } & CommentDeletedEvent)
-  | ({ type: 'feeds.comment.reaction.added' } & CommentReactionAddedEvent)
-  | ({ type: 'feeds.comment.reaction.deleted' } & CommentReactionDeletedEvent)
-  | ({ type: 'feeds.comment.reaction.updated' } & CommentReactionUpdatedEvent)
-  | ({ type: 'feeds.comment.restored' } & CommentRestoredEvent)
-  | ({ type: 'feeds.comment.updated' } & CommentUpdatedEvent)
-  | ({ type: 'feeds.feed.created' } & FeedCreatedEvent)
-  | ({ type: 'feeds.feed.deleted' } & FeedDeletedEvent)
-  | ({ type: 'feeds.feed.updated' } & FeedUpdatedEvent)
-  | ({ type: 'feeds.feed_group.changed' } & FeedGroupChangedEvent)
-  | ({ type: 'feeds.feed_group.deleted' } & FeedGroupDeletedEvent)
-  | ({ type: 'feeds.feed_group.restored' } & FeedGroupRestoredEvent)
-  | ({ type: 'feeds.feed_member.added' } & FeedMemberAddedEvent)
-  | ({ type: 'feeds.feed_member.removed' } & FeedMemberRemovedEvent)
-  | ({ type: 'feeds.feed_member.updated' } & FeedMemberUpdatedEvent)
-  | ({ type: 'feeds.follow.created' } & FollowCreatedEvent)
-  | ({ type: 'feeds.follow.deleted' } & FollowDeletedEvent)
-  | ({ type: 'feeds.follow.updated' } & FollowUpdatedEvent)
-  | ({ type: 'feeds.notification_feed.updated' } & NotificationFeedUpdatedEvent)
-  | ({ type: 'feeds.poll.closed' } & PollClosedFeedEvent)
-  | ({ type: 'feeds.poll.deleted' } & PollDeletedFeedEvent)
-  | ({ type: 'feeds.poll.updated' } & PollUpdatedFeedEvent)
-  | ({ type: 'feeds.poll.vote_casted' } & PollVoteCastedFeedEvent)
-  | ({ type: 'feeds.poll.vote_changed' } & PollVoteChangedFeedEvent)
-  | ({ type: 'feeds.poll.vote_removed' } & PollVoteRemovedFeedEvent)
-  | ({ type: 'feeds.stories_feed.updated' } & StoriesFeedUpdatedEvent)
-  | ({ type: 'health.check' } & HealthCheckEvent)
-  | ({ type: 'moderation.custom_action' } & ModerationCustomActionEvent)
-  | ({ type: 'moderation.flagged' } & ModerationFlaggedEvent)
-  | ({ type: 'moderation.mark_reviewed' } & ModerationMarkReviewedEvent)
-  | ({ type: 'user.banned' } & UserBannedEvent)
-  | ({ type: 'user.deactivated' } & UserDeactivatedEvent)
-  | ({ type: 'user.reactivated' } & UserReactivatedEvent)
-  | ({ type: 'user.unbanned' } & UserUnbannedEvent)
-  | ({ type: 'user.updated' } & UserUpdatedEvent);
+        }
+    
+
+
+
+
+    export interface ReviewQueueItemResponse {
+    /**
+     * AI-determined text severity
+     */
+    ai_text_severity: string;
+    
+
+        
+    /**
+     * When the item was created
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * ID of the entity being reviewed
+     */
+    entity_id: string;
+    
+
+        
+    /**
+     * Type of entity being reviewed
+     */
+    entity_type: string;
+    
+
+        
+    /**
+     * Whether the item has been escalated
+     */
+    escalated: boolean;
+    
+
+        
+    flags_count: number;
+    
+
+        
+    /**
+     * Unique identifier of the review queue item
+     */
+    id: string;
+    
+
+        
+    latest_moderator_action: string;
+    
+
+        
+    /**
+     * Suggested moderation action
+     */
+    recommended_action: string;
+    
+
+        
+    /**
+     * ID of the moderator who reviewed the item
+     */
+    reviewed_by: string;
+    
+
+        
+    /**
+     * Severity level of the content
+     */
+    severity: number;
+    
+
+        
+    /**
+     * Current status of the review
+     */
+    status: string;
+    
+
+        
+    /**
+     * When the item was last updated
+     */
+    updated_at: Date;
+    
+
+        
+    /**
+     * Moderation actions taken
+     */
+    actions: Array<ActionLogResponse>;
+    
+
+        
+    /**
+     * Associated ban records
+     */
+    bans: Array<BanInfoResponse>;
+    
+
+        
+    /**
+     * Associated flag records
+     */
+    flags: Array<ModerationFlagResponse>;
+    
+
+        
+    /**
+     * Detected languages in the content
+     */
+    languages: Array<string>;
+    
+
+        
+    /**
+     * When the review was completed
+     */
+    completed_at?: Date;
+    
+
+        
+    config_key?: string;
+    
+
+        
+    /**
+     * ID of who created the entity
+     */
+    entity_creator_id?: string;
+    
+
+        
+    /**
+     * When the item was escalated
+     */
+    escalated_at?: Date;
+    
+
+        
+    /**
+     * ID of the moderator who escalated the item
+     */
+    escalated_by?: string;
+    
+
+        
+    /**
+     * When the item was reviewed
+     */
+    reviewed_at?: Date;
+    
+
+        
+    /**
+     * Teams associated with this item
+     */
+    teams?: Array<string>;
+    
+
+        
+    activity?: EnrichedActivity;
+    
+
+        
+    appeal?: AppealItemResponse;
+    
+
+        
+    assigned_to?: UserResponse;
+    
+
+        
+    call?: CallResponse;
+    
+
+        
+    entity_creator?: EntityCreatorResponse;
+    
+
+        
+    escalation_metadata?: EscalationMetadata;
+    
+
+        
+    feeds_v2_activity?: EnrichedActivity;
+    
+
+        
+    feeds_v2_reaction?: Reaction;
+    
+
+        
+    feeds_v3_activity?: FeedsV3ActivityResponse;
+    
+
+        
+    feeds_v3_comment?: FeedsV3CommentResponse;
+    
+
+        
+    message?: ChatMessageResponse;
+    
+
+        
+    moderation_payload?: ModerationPayloadResponse;
+    
+
+        
+    reaction?: Reaction;
+    
+
+        }
+    
+
+
+
+
+    export interface RuleBuilderAction {
+    skip_inbox?: boolean;
+    
+
+        
+    
+        type?:| "ban_user" | "flag_user" | "flag_content" | "block_content" | "shadow_content" | "bounce_flag_content" | "bounce_content" | "bounce_remove_content" | "mute_video" | "mute_audio" | "blur" | "call_blur" | "end_call" | "kick_user" | "warning" | "call_warning" | "webhook_only" ;
+
+        
+    ban_options?: BanOptions;
+    
+
+        
+    call_options?: CallActionOptions;
+    
+
+        
+    flag_user_options?: FlagUserOptions;
+    
+
+        }
+    
+
+
+
+
+    export interface RuleBuilderCondition {
+    confidence?: number;
+    
+
+        
+    type?: string;
+    
+
+        
+    call_custom_property_params?: CallCustomPropertyParameters;
+    
+
+        
+    call_type_rule_params?: CallTypeRuleParameters;
+    
+
+        
+    call_violation_count_params?: CallViolationCountParameters;
+    
+
+        
+    channel_message_count_rule_params?: ChannelMessageCountRuleParameters;
+    
+
+        
+    closed_caption_rule_params?: ClosedCaptionRuleParameters;
+    
+
+        
+    content_count_rule_params?: ContentCountRuleParameters;
+    
+
+        
+    content_flag_count_rule_params?: FlagCountRuleParameters;
+    
+
+        
+    image_content_params?: ImageContentParameters;
+    
+
+        
+    image_rule_params?: ImageRuleParameters;
+    
+
+        
+    keyframe_rule_params?: KeyframeRuleParameters;
+    
+
+        
+    text_content_params?: TextContentParameters;
+    
+
+        
+    text_rule_params?: TextRuleParameters;
+    
+
+        
+    user_created_within_params?: UserCreatedWithinParameters;
+    
+
+        
+    user_custom_property_params?: UserCustomPropertyParameters;
+    
+
+        
+    user_flag_count_rule_params?: FlagCountRuleParameters;
+    
+
+        
+    user_identical_content_count_params?: UserIdenticalContentCountParameters;
+    
+
+        
+    user_role_params?: UserRoleParameters;
+    
+
+        
+    user_rule_params?: UserRuleParameters;
+    
+
+        
+    video_content_params?: VideoContentParameters;
+    
+
+        
+    video_rule_params?: VideoRuleParameters;
+    
+
+        }
+    
+
+
+
+
+    export interface RuleBuilderConditionGroup {
+    logic?: string;
+    
+
+        
+    conditions?: Array<RuleBuilderCondition>;
+    
+
+        }
+    
+
+
+
+
+    export interface RuleBuilderConfig {
+    async?: boolean;
+    
+
+        
+    rules?: Array<RuleBuilderRule>;
+    
+
+        }
+    
+
+
+
+
+    export interface RuleBuilderRule {
+    rule_type: string;
+    
+
+        
+    cooldown_period?: string;
+    
+
+        
+    id?: string;
+    
+
+        
+    logic?: string;
+    
+
+        
+    action_sequences?: Array<CallRuleActionSequence>;
+    
+
+        
+    conditions?: Array<RuleBuilderCondition>;
+    
+
+        
+    groups?: Array<RuleBuilderConditionGroup>;
+    
+
+        
+    action?: RuleBuilderAction;
+    
+
+        }
+    
+
+
+
+
+    export interface SearchUserGroupsResponse {
+    duration: string;
+    
+
+        
+    /**
+     * List of matching user groups
+     */
+    user_groups: Array<UserGroupResponse>;
+    
+
+        }
+    
+
+
+
+
+    export interface ShadowBlockActionRequestPayload {
+    /**
+     * Reason for shadow blocking
+     */
+    reason?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface SharedLocationResponse {
+    /**
+     * Channel CID
+     */
+    channel_cid: string;
+    
+
+        
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * Device ID that created the live location
+     */
+    created_by_device_id: string;
+    
+
+        
+    duration: string;
+    
+
+        
+    /**
+     * Latitude coordinate
+     */
+    latitude: number;
+    
+
+        
+    /**
+     * Longitude coordinate
+     */
+    longitude: number;
+    
+
+        
+    /**
+     * Message ID
+     */
+    message_id: string;
+    
+
+        
+    /**
+     * Date/time of the last update
+     */
+    updated_at: Date;
+    
+
+        
+    /**
+     * User ID
+     */
+    user_id: string;
+    
+
+        
+    /**
+     * Time when the live location expires
+     */
+    end_at?: Date;
+    
+
+        
+    channel?: ChannelResponse;
+    
+
+        
+    message?: MessageResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface SharedLocationResponseData {
+    channel_cid: string;
+    
+
+        
+    created_at: Date;
+    
+
+        
+    created_by_device_id: string;
+    
+
+        
+    latitude: number;
+    
+
+        
+    longitude: number;
+    
+
+        
+    message_id: string;
+    
+
+        
+    updated_at: Date;
+    
+
+        
+    user_id: string;
+    
+
+        
+    end_at?: Date;
+    
+
+        
+    channel?: ChannelResponse;
+    
+
+        
+    message?: MessageResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface SharedLocationsResponse {
+    duration: string;
+    
+
+        
+    active_live_locations: Array<SharedLocationResponseData>;
+    
+
+        }
+    
+
+
+
+
+    export interface SingleFollowResponse {
+    duration: string;
+    
+
+        
+    follow: FollowResponse;
+    
+
+        
+    /**
+     * Whether a notification activity was successfully created
+     */
+    notification_created?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface SortParam {
+    direction: number;
+    
+
+        
+    field: string;
+    
+
+        
+    type: string;
+    
+
+        }
+    
+
+
+
+
+    export interface SortParamRequest {
+    /**
+     * Direction of sorting, 1 for Ascending, -1 for Descending, default is 1. One of: -1, 1
+     */
+    direction?: number;
+    
+
+        
+    /**
+     * Name of field to sort by
+     */
+    field?: string;
+    
+
+        
+    /**
+     * Type of field to sort by. Empty string or omitted means string type (default). One of: number, boolean
+     */
+    type?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface StoriesConfig {
+    skip_watched?: boolean;
+    
+
+        
+    track_watched?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface StoriesFeedUpdatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * The ID of the feed
+     */
+    fid: string;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    /**
+     * The type of event: "feeds.stories_feed.updated" in this case
+     */
+    type: string;
+    
+
+        
+    feed_visibility?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    /**
+     * Individual activities for stories feeds
+     */
+    activities?: Array<ActivityResponse>;
+    
+
+        
+    /**
+     * Aggregated activities for stories feeds
+     */
+    aggregated_activities?: Array<AggregatedActivityResponse>;
+    
+
+        
+    user?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface SubmitActionRequest {
+    /**
+     * Type of moderation action to perform. One of: mark_reviewed, delete_message, delete_activity, delete_comment, delete_reaction, ban, custom, unban, restore, delete_user, unblock, block, shadow_block, unmask, kick_user, end_call, escalate, de_escalate
+     */
+    
+        action_type:| "flag" | "mark_reviewed" | "delete_message" | "delete_activity" | "delete_comment" | "delete_reaction" | "ban" | "custom" | "unban" | "restore" | "delete_user" | "unblock" | "block" | "shadow_block" | "unmask" | "kick_user" | "end_call" | "reject_appeal" | "escalate" | "de_escalate" | "bypass" ;
+
+        
+    /**
+     * UUID of the appeal to act on (required for reject_appeal, optional for other actions)
+     */
+    appeal_id?: string;
+    
+
+        
+    /**
+     * UUID of the review queue item to act on
+     */
+    item_id?: string;
+    
+
+        
+    ban?: BanActionRequestPayload;
+    
+
+        
+    block?: BlockActionRequestPayload;
+    
+
+        
+    bypass?: BypassActionRequest;
+    
+
+        
+    custom?: CustomActionRequestPayload;
+    
+
+        
+    delete_activity?: DeleteActivityRequestPayload;
+    
+
+        
+    delete_comment?: DeleteCommentRequestPayload;
+    
+
+        
+    delete_message?: DeleteMessageRequestPayload;
+    
+
+        
+    delete_reaction?: DeleteReactionRequestPayload;
+    
+
+        
+    delete_user?: DeleteUserRequestPayload;
+    
+
+        
+    escalate?: EscalatePayload;
+    
+
+        
+    flag?: FlagRequest;
+    
+
+        
+    mark_reviewed?: MarkReviewedRequestPayload;
+    
+
+        
+    reject_appeal?: RejectAppealRequestPayload;
+    
+
+        
+    restore?: RestoreActionRequestPayload;
+    
+
+        
+    shadow_block?: ShadowBlockActionRequestPayload;
+    
+
+        
+    unban?: UnbanActionRequestPayload;
+    
+
+        
+    unblock?: UnblockActionRequestPayload;
+    
+
+        }
+    
+
+
+
+
+    export interface SubmitActionResponse {
+    duration: string;
+    
+
+        
+    appeal_item?: AppealItemResponse;
+    
+
+        
+    item?: ReviewQueueItemResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface TextContentParameters {
+    contains_url?: boolean;
+    
+
+        
+    label_operator?: string;
+    
+
+        
+    severity?: string;
+    
+
+        
+    blocklist_match?: Array<string>;
+    
+
+        
+    harm_labels?: Array<string>;
+    
+
+        
+    llm_harm_labels?: Record<string, string>;
+    
+
+        }
+    
+
+
+
+
+    export interface TextRuleParameters {
+    contains_url?: boolean;
+    
+
+        
+    semantic_filter_min_threshold?: number;
+    
+
+        
+    severity?: string;
+    
+
+        
+    threshold?: number;
+    
+
+        
+    time_window?: string;
+    
+
+        
+    blocklist_match?: Array<string>;
+    
+
+        
+    harm_labels?: Array<string>;
+    
+
+        
+    semantic_filter_names?: Array<string>;
+    
+
+        
+    llm_harm_labels?: Record<string, string>;
+    
+
+        }
+    
+
+
+
+
+    export interface ThreadedCommentResponse {
+    bookmark_count: number;
+    
+
+        
+    confidence_score: number;
+    
+
+        
+    created_at: Date;
+    
+
+        
+    downvote_count: number;
+    
+
+        
+    id: string;
+    
+
+        
+    object_id: string;
+    
+
+        
+    object_type: string;
+    
+
+        
+    reaction_count: number;
+    
+
+        
+    reply_count: number;
+    
+
+        
+    score: number;
+    
+
+        
+    /**
+     * Status of the comment. One of: active, deleted, removed, hidden
+     */
+    
+        status:| "active" | "deleted" | "removed" | "hidden" | "shadow_blocked" ;
+
+        
+    updated_at: Date;
+    
+
+        
+    upvote_count: number;
+    
+
+        
+    mentioned_users: Array<UserResponse>;
+    
+
+        
+    own_reactions: Array<FeedsReactionResponse>;
+    
+
+        
+    user: UserResponse;
+    
+
+        
+    controversy_score?: number;
+    
+
+        
+    deleted_at?: Date;
+    
+
+        
+    edited_at?: Date;
+    
+
+        
+    parent_id?: string;
+    
+
+        
+    text?: string;
+    
+
+        
+    attachments?: Array<Attachment>;
+    
+
+        
+    latest_reactions?: Array<FeedsReactionResponse>;
+    
+
+        
+    /**
+     * Slice of nested comments (may be empty).
+     */
+    replies?: Array<ThreadedCommentResponse>;
+    
+
+        
+    custom?: Record<string, any>;
+    
+
+        
+    meta?: RepliesMeta;
+    
+
+        
+    moderation?: ModerationV2Response;
+    
+
+        
+    reaction_groups?: Record<string, FeedsReactionGroupResponse>;
+    
+
+        }
+    
+
+
+
+
+    export interface Thresholds {
+    explicit?: LabelThresholds;
+    
+
+        
+    spam?: LabelThresholds;
+    
+
+        
+    toxic?: LabelThresholds;
+    
+
+        }
+    
+
+
+
+
+    export interface Time {}
+    
+
+
+
+
+    export interface TrackActivityMetricsEvent {
+    /**
+     * The ID of the activity to track the metric for
+     */
+    activity_id: string;
+    
+
+        
+    /**
+     * The metric name (e.g. views, clicks, impressions). Alphanumeric and underscores only.
+     */
+    metric: string;
+    
+
+        
+    /**
+     * The amount to increment (positive) or decrement (negative). Defaults to 1. The absolute value counts against rate limits.
+     */
+    delta?: number;
+    
+
+        }
+    
+
+
+
+
+    export interface TrackActivityMetricsEventResult {
+    /**
+     * The activity ID from the request
+     */
+    activity_id: string;
+    
+
+        
+    /**
+     * Whether the metric was counted (false if rate-limited)
+     */
+    allowed: boolean;
+    
+
+        
+    /**
+     * The metric name from the request
+     */
+    metric: string;
+    
+
+        
+    /**
+     * Error message if processing failed
+     */
+    error?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface TrackActivityMetricsRequest {
+    /**
+     * List of metric events to track (max 100 per request)
+     */
+    events: Array<TrackActivityMetricsEvent>;
+    
+
+        }
+    
+
+
+
+
+    export interface TrackActivityMetricsResponse {
+    duration: string;
+    
+
+        
+    /**
+     * Results for each event in the request, in the same order
+     */
+    results: Array<TrackActivityMetricsEventResult>;
+    
+
+        }
+    
+
+
+
+
+    export interface TypingIndicatorsResponse {
+    enabled: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface UnbanActionRequestPayload {
+    /**
+     * Channel CID for channel-specific unban
+     */
+    channel_cid?: string;
+    
+
+        
+    /**
+     * Reason for the appeal decision
+     */
+    decision_reason?: string;
+    
+
+        
+    /**
+     * Also remove the future channels ban for this user
+     */
+    remove_future_channels_ban?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface UnblockActionRequestPayload {
+    /**
+     * Reason for the appeal decision
+     */
+    decision_reason?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface UnblockUsersRequest {
+    blocked_user_id: string;
+    
+
+        }
+    
+
+
+
+
+    export interface UnblockUsersResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
+
+        }
+    
+
+
+
+
+    export interface UnfollowBatchRequest {
+    /**
+     * List of follow relationships to remove, each with optional keep_history
+     */
+    follows: Array<UnfollowPair>;
+    
+
+        
+    /**
+     * Whether to delete the corresponding notification activity (default: false)
+     */
+    delete_notification_activity?: boolean;
+    
+
+        
+    /**
+     * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+     */
+    enrich_own_fields?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface UnfollowBatchResponse {
+    duration: string;
+    
+
+        
+    /**
+     * List of follow relationships that were removed
+     */
+    follows: Array<FollowResponse>;
+    
+
+        }
+    
+
+
+
+
+    export interface UnfollowPair {
+    /**
+     * Fully qualified ID of the source feed
+     */
+    source: string;
+    
+
+        
+    /**
+     * Fully qualified ID of the target feed
+     */
+    target: string;
+    
+
+        
+    /**
+     * When true, activities from the unfollowed feed will remain in the source feed's timeline (default: false)
+     */
+    keep_history?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface UnfollowResponse {
+    duration: string;
+    
+
+        
+    follow: FollowResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UnpinActivityResponse {
+    duration: string;
+    
+
+        
+    /**
+     * Fully qualified ID of the feed the activity was unpinned from
+     */
+    feed: string;
+    
+
+        
+    /**
+     * ID of the user who unpinned the activity
+     */
+    user_id: string;
+    
+
+        
+    activity: ActivityResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateActivityPartialRequest {
+    /**
+     * @deprecated
+     * Whether to copy custom data to the notification activity (only applies when handle_mention_notifications creates notifications) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+     */
+    copy_custom_to_notification?: boolean;
+    
+
+        
+    /**
+     * If true, enriches the activity's current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+     */
+    enrich_own_fields?: boolean;
+    
+
+        
+    /**
+     * If true, creates notification activities for newly mentioned users and deletes notifications for users no longer mentioned
+     */
+    handle_mention_notifications?: boolean;
+    
+
+        
+    /**
+     * If true, runs activity processors on the updated activity. Processors will only run if the activity text and/or attachments are changed. Defaults to false.
+     */
+    run_activity_processors?: boolean;
+    
+
+        
+    /**
+     * List of field names to remove. Supported fields: 'custom', 'visibility_tag', 'location', 'expires_at', 'filter_tags', 'interest_tags', 'attachments', 'poll_id', 'mentioned_user_ids', 'search_data'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
+     */
+    unset?: Array<string>;
+    
+
+        
+    /**
+     * Map of field names to new values. Supported fields: 'text', 'attachments', 'custom', 'visibility', 'visibility_tag', 'restrict_replies' (values: 'everyone', 'people_i_follow', 'nobody'), 'location', 'expires_at', 'filter_tags', 'interest_tags', 'poll_id', 'feeds', 'mentioned_user_ids', 'search_data'. For custom fields, use dot-notation (e.g., 'custom.field_name')
+     */
+    set?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateActivityPartialResponse {
+    duration: string;
+    
+
+        
+    activity: ActivityResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateActivityRequest {
+    /**
+     * @deprecated
+     * Whether to copy custom data to the notification activity (only applies when handle_mention_notifications creates notifications) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+     */
+    copy_custom_to_notification?: boolean;
+    
+
+        
+    /**
+     * If true, enriches the activity's current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+     */
+    enrich_own_fields?: boolean;
+    
+
+        
+    /**
+     * Time when the activity will expire
+     */
+    expires_at?: Date;
+    
+
+        
+    /**
+     * If true, creates notification activities for newly mentioned users and deletes notifications for users no longer mentioned
+     */
+    handle_mention_notifications?: boolean;
+    
+
+        
+    /**
+     * Poll ID
+     */
+    poll_id?: string;
+    
+
+        
+    /**
+     * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
+     */
+    
+        restrict_replies?:| "everyone" | "people_i_follow" | "nobody" ;
+
+        
+    /**
+     * If true, runs activity processors on the updated activity. Processors will only run if the activity text and/or attachments are changed. Defaults to false.
+     */
+    run_activity_processors?: boolean;
+    
+
+        
+    /**
+     * Whether to skip URL enrichment for the activity
+     */
+    skip_enrich_url?: boolean;
+    
+
+        
+    /**
+     * The text content of the activity
+     */
+    text?: string;
+    
+
+        
+    /**
+     * Visibility setting for the activity
+     */
+    
+        visibility?:| "public" | "private" | "tag" ;
+
+        
+    /**
+     * If visibility is 'tag', this is the tag name and is required
+     */
+    visibility_tag?: string;
+    
+
+        
+    /**
+     * List of attachments for the activity
+     */
+    attachments?: Array<Attachment>;
+    
+
+        
+    /**
+     * Collections that this activity references
+     */
+    collection_refs?: Array<string>;
+    
+
+        
+    /**
+     * List of feeds the activity is present in
+     */
+    feeds?: Array<string>;
+    
+
+        
+    /**
+     * Tags used for filtering the activity
+     */
+    filter_tags?: Array<string>;
+    
+
+        
+    /**
+     * Tags indicating interest categories
+     */
+    interest_tags?: Array<string>;
+    
+
+        
+    /**
+     * List of user IDs mentioned in the activity
+     */
+    mentioned_user_ids?: Array<string>;
+    
+
+        
+    /**
+     * Custom data for the activity
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    location?: Location;
+    
+
+        
+    /**
+     * Additional data for search indexing
+     */
+    search_data?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateActivityResponse {
+    duration: string;
+    
+
+        
+    activity: ActivityResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateBlockListRequest {
+    is_leet_check_enabled?: boolean;
+    
+
+        
+    is_plural_check_enabled?: boolean;
+    
+
+        
+    team?: string;
+    
+
+        
+    /**
+     * List of words to block
+     */
+    words?: Array<string>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateBlockListResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
+
+        
+    blocklist?: BlockListResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateBookmarkFolderRequest {
+    /**
+     * Name of the folder
+     */
+    name?: string;
+    
+
+        
+    /**
+     * Custom data for the folder
+     */
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateBookmarkFolderResponse {
+    duration: string;
+    
+
+        
+    bookmark_folder: BookmarkFolderResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateBookmarkRequest {
+    /**
+     * ID of the folder containing the bookmark
+     */
+    folder_id?: string;
+    
+
+        
+    /**
+     * Move the bookmark to this folder (empty string removes the folder)
+     */
+    new_folder_id?: string;
+    
+
+        
+    /**
+     * Custom data for the bookmark
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    new_folder?: AddFolderRequest;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateBookmarkResponse {
+    duration: string;
+    
+
+        
+    bookmark: BookmarkResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateCollectionRequest {
+    /**
+     * Unique identifier for the collection within its name
+     */
+    id: string;
+    
+
+        
+    /**
+     * Name/type of the collection
+     */
+    name: string;
+    
+
+        
+    /**
+     * Custom data for the collection (required, must contain at least one key)
+     */
+    custom: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateCollectionsRequest {
+    /**
+     * List of collections to update (only custom data is updatable)
+     */
+    collections: Array<UpdateCollectionRequest>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateCollectionsResponse {
+    duration: string;
+    
+
+        
+    /**
+     * List of updated collections
+     */
+    collections: Array<CollectionResponse>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateCommentBookmarkRequest {
+    /**
+     * ID of the folder containing the bookmark
+     */
+    folder_id?: string;
+    
+
+        
+    /**
+     * Move the bookmark to this folder (empty string removes the folder)
+     */
+    new_folder_id?: string;
+    
+
+        
+    /**
+     * Custom data for the bookmark
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    new_folder?: AddFolderRequest;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateCommentBookmarkResponse {
+    duration: string;
+    
+
+        
+    bookmark: BookmarkResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateCommentPartialRequest {
+    /**
+     * @deprecated
+     * Whether to copy custom data to notification activities Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+     */
+    copy_custom_to_notification?: boolean;
+    
+
+        
+    /**
+     * Whether to handle mention notification changes
+     */
+    handle_mention_notifications?: boolean;
+    
+
+        
+    /**
+     * Whether to skip URL enrichment
+     */
+    skip_enrich_url?: boolean;
+    
+
+        
+    /**
+     * Whether to skip push notifications
+     */
+    skip_push?: boolean;
+    
+
+        
+    /**
+     * List of field names to remove. Supported fields: 'custom', 'attachments', 'mentioned_user_ids', 'status'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
+     */
+    unset?: Array<string>;
+    
+
+        
+    /**
+     * Map of field names to new values. Supported fields: 'text', 'attachments', 'custom', 'mentioned_user_ids', 'status'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
+     */
+    set?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateCommentPartialResponse {
+    duration: string;
+    
+
+        
+    comment: CommentResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateCommentRequest {
+    /**
+     * Updated text content of the comment
+     */
+    comment?: string;
+    
+
+        
+    /**
+     * @deprecated
+     * Whether to copy custom data to the notification activity (only applies when handle_mention_notifications creates notifications) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+     */
+    copy_custom_to_notification?: boolean;
+    
+
+        
+    /**
+     * If true, creates notification activities for newly mentioned users and deletes notifications for users no longer mentioned
+     */
+    handle_mention_notifications?: boolean;
+    
+
+        
+    /**
+     * Whether to skip URL enrichment for this comment
+     */
+    skip_enrich_url?: boolean;
+    
+
+        
+    skip_push?: boolean;
+    
+
+        
+    /**
+     * Updated media attachments for the comment. Providing this field will replace all existing attachments.
+     */
+    attachments?: Array<Attachment>;
+    
+
+        
+    /**
+     * List of user IDs mentioned in the comment
+     */
+    mentioned_user_ids?: Array<string>;
+    
+
+        
+    /**
+     * Updated custom data for the comment
+     */
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateCommentResponse {
+    duration: string;
+    
+
+        
+    comment: CommentResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateFeedMembersRequest {
+    /**
+     * Type of update operation to perform. One of: upsert, remove, set
+     */
+    
+        operation:| "upsert" | "remove" | "set" ;
+
+        
+    limit?: number;
+    
+
+        
+    next?: string;
+    
+
+        
+    prev?: string;
+    
+
+        
+    /**
+     * List of members to upsert, remove, or set
+     */
+    members?: Array<FeedMemberRequest>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateFeedMembersResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
+
+        
+    added: Array<FeedMemberResponse>;
+    
+
+        
+    removed_ids: Array<string>;
+    
+
+        
+    updated: Array<FeedMemberResponse>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateFeedRequest {
+    /**
+     * If true, removes the geographic location from the feed
+     */
+    clear_location?: boolean;
+    
+
+        
+    /**
+     * Description of the feed
+     */
+    description?: string;
+    
+
+        
+    /**
+     * If true, enriches the feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+     */
+    enrich_own_fields?: boolean;
+    
+
+        
+    /**
+     * Name of the feed
+     */
+    name?: string;
+    
+
+        
+    /**
+     * Tags used for filtering feeds
+     */
+    filter_tags?: Array<string>;
+    
+
+        
+    /**
+     * Custom data for the feed
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    location?: Location;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateFeedResponse {
+    duration: string;
+    
+
+        
+    feed: FeedResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateFollowRequest {
+    /**
+     * Fully qualified ID of the source feed
+     */
+    source: string;
+    
+
+        
+    /**
+     * Fully qualified ID of the target feed
+     */
+    target: string;
+    
+
+        
+    /**
+     * Maximum number of historical activities to copy from the target feed when the follow is first materialized. Not set = unlimited (default). 0 = copy nothing. Range: 0-1000.
+     */
+    activity_copy_limit?: number;
+    
+
+        
+    /**
+     * @deprecated
+     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+     */
+    copy_custom_to_notification?: boolean;
+    
+
+        
+    /**
+     * Whether to create a notification activity for this follow
+     */
+    create_notification_activity?: boolean;
+    
+
+        
+    /**
+     * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+     */
+    enrich_own_fields?: boolean;
+    
+
+        
+    follower_role?: string;
+    
+
+        
+    /**
+     * Push preference for the follow relationship
+     */
+    
+        push_preference?:| "all" | "none" ;
+
+        
+    /**
+     * Whether to skip push for this follow
+     */
+    skip_push?: boolean;
+    
+
+        
+    /**
+     * Custom data for the follow relationship
+     */
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateFollowResponse {
+    duration: string;
+    
+
+        
+    follow: FollowResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateLiveLocationRequest {
+    /**
+     * Live location ID
+     */
+    message_id: string;
+    
+
+        
+    /**
+     * Time when the live location expires
+     */
+    end_at?: Date;
+    
+
+        
+    /**
+     * Latitude coordinate
+     */
+    latitude?: number;
+    
+
+        
+    /**
+     * Longitude coordinate
+     */
+    longitude?: number;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdatePollOptionRequest {
+    /**
+     * Option ID
+     */
+    id: string;
+    
+
+        
+    /**
+     * Option text
+     */
+    text: string;
+    
+
+        
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdatePollPartialRequest {
+    /**
+     * Array of field names to unset
+     */
+    unset?: Array<string>;
+    
+
+        
+    /**
+     * Sets new field values
+     */
+    set?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdatePollRequest {
+    /**
+     * Poll ID
+     */
+    id: string;
+    
+
+        
+    /**
+     * Poll name
+     */
+    name: string;
+    
+
+        
+    /**
+     * Allow answers
+     */
+    allow_answers?: boolean;
+    
+
+        
+    /**
+     * Allow user suggested options
+     */
+    allow_user_suggested_options?: boolean;
+    
+
+        
+    /**
+     * Poll description
+     */
+    description?: string;
+    
+
+        
+    /**
+     * Enforce unique vote
+     */
+    enforce_unique_vote?: boolean;
+    
+
+        
+    /**
+     * Is closed
+     */
+    is_closed?: boolean;
+    
+
+        
+    /**
+     * Max votes allowed
+     */
+    max_votes_allowed?: number;
+    
+
+        
+    /**
+     * Voting visibility
+     */
+    
+        voting_visibility?:| "anonymous" | "public" ;
+
+        
+    /**
+     * Poll options
+     */
+    options?: Array<PollOptionRequest>;
+    
+
+        
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateUserGroupRequest {
+    /**
+     * The new description for the group
+     */
+    description?: string;
+    
+
+        
+    /**
+     * The new name of the user group
+     */
+    name?: string;
+    
+
+        
+    team_id?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateUserGroupResponse {
+    duration: string;
+    
+
+        
+    user_group?: UserGroupResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateUserPartialRequest {
+    /**
+     * User ID to update
+     */
+    id: string;
+    
+
+        
+    unset?: Array<string>;
+    
+
+        
+    set?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateUsersPartialRequest {
+    users: Array<UpdateUserPartialRequest>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateUsersRequest {
+    /**
+     * Object containing users
+     */
+    users: Record<string, UserRequest>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpdateUsersResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
+
+        
+    membership_deletion_task_id: string;
+    
+
+        
+    /**
+     * Object containing users
+     */
+    users: Record<string, FullUserResponse>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpsertActionConfigItem {
+    action: string;
+    
+
+        
+    entity_type: string;
+    
+
+        
+    order: number;
+    
+
+        
+    description?: string;
+    
+
+        
+    icon?: string;
+    
+
+        
+    id?: string;
+    
+
+        
+    queue_type?: string;
+    
+
+        
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpsertActionConfigRequest {
+    /**
+     * The action to perform (e.g. ban, delete_message, custom)
+     */
+    action: string;
+    
+
+        
+    /**
+     * Type of entity this action applies to (e.g. stream:chat:v1:message)
+     */
+    entity_type: string;
+    
+
+        
+    /**
+     * Display order in the dashboard (0–100, lower numbers shown first)
+     */
+    order: number;
+    
+
+        
+    /**
+     * Human-readable label for the dashboard button
+     */
+    description?: string;
+    
+
+        
+    /**
+     * Icon identifier for the dashboard button
+     */
+    icon?: string;
+    
+
+        
+    /**
+     * UUID of an existing action config to update; omit to create a new record
+     */
+    id?: string;
+    
+
+        
+    /**
+     * Queue this config belongs to; null means the default queue
+     */
+    queue_type?: string;
+    
+
+        
+    /**
+     * Action-specific parameters passed to the action handler
+     */
+    custom?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpsertActionConfigResponse {
+    duration: string;
+    
+
+        
+    action_config?: ModerationActionConfigResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpsertActivitiesRequest {
+    /**
+     * List of activities to create or update
+     */
+    activities: Array<ActivityRequest>;
+    
+
+        
+    /**
+     * If true, enriches the activities' current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+     */
+    enrich_own_fields?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface UpsertActivitiesResponse {
+    duration: string;
+    
+
+        
+    /**
+     * List of created or updated activities
+     */
+    activities: Array<ActivityResponse>;
+    
+
+        
+    /**
+     * Total number of mention notification activities created for mentioned users across all activities
+     */
+    mention_notifications_created?: number;
+    
+
+        }
+    
+
+
+
+
+    export interface UpsertConfigRequest {
+    /**
+     * Unique identifier for the moderation configuration
+     */
+    key: string;
+    
+
+        
+    /**
+     * Whether moderation should be performed asynchronously
+     */
+    async?: boolean;
+    
+
+        
+    /**
+     * Team associated with the configuration
+     */
+    team?: string;
+    
+
+        
+    ai_image_config?: AIImageConfig;
+    
+
+        
+    ai_text_config?: AITextConfig;
+    
+
+        
+    ai_video_config?: AIVideoConfig;
+    
+
+        
+    automod_platform_circumvention_config?: AutomodPlatformCircumventionConfig;
+    
+
+        
+    automod_semantic_filters_config?: AutomodSemanticFiltersConfig;
+    
+
+        
+    automod_toxicity_config?: AutomodToxicityConfig;
+    
+
+        
+    aws_rekognition_config?: AIImageConfig;
+    
+
+        
+    block_list_config?: BlockListConfig;
+    
+
+        
+    bodyguard_config?: AITextConfig;
+    
+
+        
+    google_vision_config?: GoogleVisionConfig;
+    
+
+        
+    llm_config?: LLMConfig;
+    
+
+        
+    rule_builder_config?: RuleBuilderConfig;
+    
+
+        
+    velocity_filter_config?: VelocityFilterConfig;
+    
+
+        
+    video_call_rule_config?: VideoCallRuleConfig;
+    
+
+        }
+    
+
+
+
+
+    export interface UpsertConfigResponse {
+    duration: string;
+    
+
+        
+    config?: ConfigResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UpsertPushPreferencesRequest {
+    /**
+     * A list of push preferences for channels, calls, or the user.
+     */
+    preferences: Array<PushPreferenceInput>;
+    
+
+        }
+    
+
+
+
+
+    export interface UpsertPushPreferencesResponse {
+    /**
+     * Duration of the request in milliseconds
+     */
+    duration: string;
+    
+
+        
+    /**
+     * The channel specific push notification preferences, only returned for channels you've edited.
+     */
+    user_channel_preferences: Record<string, Record<string, ChannelPushPreferencesResponse | null>>;
+    
+
+        
+    /**
+     * The user preferences, always returned regardless if you edited it
+     */
+    user_preferences: Record<string, PushPreferencesResponse>;
+    
+
+        }
+    
+
+
+
+
+    export interface User {
+    id: string;
+    
+
+        
+    data?: Record<string, any>;
+    
+
+        }
+    
+
+
+
+
+    export interface UserBannedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    user: UserResponseCommonFields;
+    
+
+        
+    /**
+     * The type of event: "user.banned" in this case
+     */
+    type: string;
+    
+
+        
+    /**
+     * The ID of the channel where the target user was banned
+     */
+    channel_id?: string;
+    
+
+        
+    channel_member_count?: number;
+    
+
+        
+    channel_message_count?: number;
+    
+
+        
+    /**
+     * The type of the channel where the target user was banned
+     */
+    channel_type?: string;
+    
+
+        
+    /**
+     * The CID of the channel where the target user was banned
+     */
+    cid?: string;
+    
+
+        
+    /**
+     * The expiration date of the ban
+     */
+    expiration?: Date;
+    
+
+        
+    /**
+     * The reason for the ban
+     */
+    reason?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    /**
+     * Whether the user was shadow banned
+     */
+    shadow?: boolean;
+    
+
+        
+    /**
+     * The team of the channel where the target user was banned
+     */
+    team?: string;
+    
+
+        
+    total_bans?: number;
+    
+
+        
+    channel_custom?: Record<string, any>;
+    
+
+        
+    created_by?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface UserCreatedWithinParameters {
+    max_age?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface UserCustomPropertyParameters {
+    operator?: string;
+    
+
+        
+    property_key?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface UserDeactivatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    user: UserResponseCommonFields;
+    
+
+        
+    /**
+     * The type of event: "user.deactivated" in this case
+     */
+    type: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    created_by?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface UserGroupMember {
+    app_pk: number;
+    
+
+        
+    created_at: Date;
+    
+
+        
+    group_id: string;
+    
+
+        
+    is_admin: boolean;
+    
+
+        
+    user_id: string;
+    
+
+        }
+    
+
+
+
+
+    export interface UserGroupResponse {
+    created_at: Date;
+    
+
+        
+    id: string;
+    
+
+        
+    name: string;
+    
+
+        
+    updated_at: Date;
+    
+
+        
+    created_by?: string;
+    
+
+        
+    description?: string;
+    
+
+        
+    team_id?: string;
+    
+
+        
+    members?: Array<UserGroupMember>;
+    
+
+        }
+    
+
+
+
+
+    export interface UserIdenticalContentCountParameters {
+    threshold?: number;
+    
+
+        
+    time_window?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface UserMuteResponse {
+    created_at: Date;
+    
+
+        
+    updated_at: Date;
+    
+
+        
+    expires?: Date;
+    
+
+        
+    target?: UserResponse;
+    
+
+        
+    user?: UserResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UserReactivatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    user: UserResponseCommonFields;
+    
+
+        
+    /**
+     * The type of event: "user.reactivated" in this case
+     */
+    type: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    created_by?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface UserRequest {
+    /**
+     * User ID
+     */
+    id: string;
+    
+
+        
+    /**
+     * User's profile image URL
+     */
+    image?: string;
+    
+
+        
+    invisible?: boolean;
+    
+
+        
+    language?: string;
+    
+
+        
+    /**
+     * Optional name of user
+     */
+    name?: string;
+    
+
+        
+    /**
+     * Custom user data
+     */
+    custom?: Record<string, any>;
+    
+
+        
+    privacy_settings?: PrivacySettingsResponse;
+    
+
+        }
+    
+
+
+
+
+    export interface UserResponse {
+    /**
+     * Whether a user is banned or not
+     */
+    banned: boolean;
+    
+
+        
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    /**
+     * Unique user identifier
+     */
+    id: string;
+    
+
+        
+    /**
+     * Preferred language of a user
+     */
+    language: string;
+    
+
+        
+    /**
+     * Whether a user online or not
+     */
+    online: boolean;
+    
+
+        
+    /**
+     * Determines the set of user permissions
+     */
+    role: string;
+    
+
+        
+    /**
+     * Date/time of the last update
+     */
+    updated_at: Date;
+    
+
+        
+    blocked_user_ids: Array<string>;
+    
+
+        
+    /**
+     * List of teams user is a part of
+     */
+    teams: Array<string>;
+    
+
+        
+    /**
+     * Custom data for this object
+     */
+    custom: Record<string, any>;
+    
+
+        
+    avg_response_time?: number;
+    
+
+        
+    /**
+     * Date of deactivation
+     */
+    deactivated_at?: Date;
+    
+
+        
+    /**
+     * Date/time of deletion
+     */
+    deleted_at?: Date;
+    
+
+        
+    image?: string;
+    
+
+        
+    /**
+     * Date of last activity
+     */
+    last_active?: Date;
+    
+
+        
+    /**
+     * Optional name of user
+     */
+    name?: string;
+    
+
+        
+    /**
+     * Revocation date for tokens
+     */
+    revoke_tokens_issued_before?: Date;
+    
+
+        
+    teams_role?: Record<string, string>;
+    
+
+        }
+    
+
+
+
+
+    export interface UserResponseCommonFields {
+    banned: boolean;
+    
+
+        
+    created_at: Date;
+    
+
+        
+    id: string;
+    
+
+        
+    language: string;
+    
+
+        
+    online: boolean;
+    
+
+        
+    role: string;
+    
+
+        
+    updated_at: Date;
+    
+
+        
+    blocked_user_ids: Array<string>;
+    
+
+        
+    teams: Array<string>;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    avg_response_time?: number;
+    
+
+        
+    deactivated_at?: Date;
+    
+
+        
+    deleted_at?: Date;
+    
+
+        
+    image?: string;
+    
+
+        
+    last_active?: Date;
+    
+
+        
+    name?: string;
+    
+
+        
+    revoke_tokens_issued_before?: Date;
+    
+
+        
+    teams_role?: Record<string, string>;
+    
+
+        }
+    
+
+
+
+
+    export interface UserResponsePrivacyFields {
+    banned: boolean;
+    
+
+        
+    created_at: Date;
+    
+
+        
+    id: string;
+    
+
+        
+    language: string;
+    
+
+        
+    online: boolean;
+    
+
+        
+    role: string;
+    
+
+        
+    updated_at: Date;
+    
+
+        
+    blocked_user_ids: Array<string>;
+    
+
+        
+    teams: Array<string>;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    avg_response_time?: number;
+    
+
+        
+    deactivated_at?: Date;
+    
+
+        
+    deleted_at?: Date;
+    
+
+        
+    image?: string;
+    
+
+        
+    invisible?: boolean;
+    
+
+        
+    last_active?: Date;
+    
+
+        
+    name?: string;
+    
+
+        
+    revoke_tokens_issued_before?: Date;
+    
+
+        
+    privacy_settings?: PrivacySettingsResponse;
+    
+
+        
+    teams_role?: Record<string, string>;
+    
+
+        }
+    
+
+
+
+
+    export interface UserRoleParameters {
+    operator?: string;
+    
+
+        
+    role?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface UserRuleParameters {
+    max_age?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface UserUnbannedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    user: UserResponseCommonFields;
+    
+
+        
+    /**
+     * The type of event: "user.unbanned" in this case
+     */
+    type: string;
+    
+
+        
+    /**
+     * The ID of the channel where the target user was unbanned
+     */
+    channel_id?: string;
+    
+
+        
+    channel_member_count?: number;
+    
+
+        
+    channel_message_count?: number;
+    
+
+        
+    /**
+     * The type of the channel where the target user was unbanned
+     */
+    channel_type?: string;
+    
+
+        
+    /**
+     * The CID of the channel where the target user was unbanned
+     */
+    cid?: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        
+    /**
+     * Whether the target user was shadow unbanned
+     */
+    shadow?: boolean;
+    
+
+        
+    /**
+     * The team of the channel where the target user was unbanned
+     */
+    team?: string;
+    
+
+        
+    channel_custom?: Record<string, any>;
+    
+
+        
+    created_by?: UserResponseCommonFields;
+    
+
+        }
+    
+
+
+
+
+    export interface UserUpdatedEvent {
+    /**
+     * Date/time of creation
+     */
+    created_at: Date;
+    
+
+        
+    custom: Record<string, any>;
+    
+
+        
+    user: UserResponsePrivacyFields;
+    
+
+        
+    /**
+     * The type of event: "user.updated" in this case
+     */
+    type: string;
+    
+
+        
+    received_at?: Date;
+    
+
+        }
+    
+
+
+
+
+    export interface VelocityFilterConfig {
+    advanced_filters: boolean;
+    
+
+        
+    cascading_actions: boolean;
+    
+
+        
+    cids_per_user: number;
+    
+
+        
+    enabled: boolean;
+    
+
+        
+    first_message_only: boolean;
+    
+
+        
+    rules: Array<VelocityFilterConfigRule>;
+    
+
+        
+    async?: boolean;
+    
+
+        }
+    
+
+
+
+
+    export interface VelocityFilterConfigRule {
+    
+        action:| "flag" | "shadow" | "remove" | "ban" ;
+
+        
+    ban_duration: number;
+    
+
+        
+    
+        cascading_action:| "flag" | "shadow" | "remove" | "ban" ;
+
+        
+    cascading_threshold: number;
+    
+
+        
+    check_message_context: boolean;
+    
+
+        
+    fast_spam_threshold: number;
+    
+
+        
+    fast_spam_ttl: number;
+    
+
+        
+    ip_ban: boolean;
+    
+
+        
+    probation_period: number;
+    
+
+        
+    shadow_ban: boolean;
+    
+
+        
+    slow_spam_threshold: number;
+    
+
+        
+    slow_spam_ttl: number;
+    
+
+        
+    url_only: boolean;
+    
+
+        
+    slow_spam_ban_duration?: number;
+    
+
+        }
+    
+
+
+
+
+    export interface VideoCallRuleConfig {
+    flag_all_labels: boolean;
+    
+
+        
+    flagged_labels: Array<string>;
+    
+
+        
+    rules: Array<HarmConfig>;
+    
+
+        }
+    
+
+
+
+
+    export interface VideoContentParameters {
+    label_operator?: string;
+    
+
+        
+    harm_labels?: Array<string>;
+    
+
+        }
+    
+
+
+
+
+    export interface VideoEndCallRequestPayload {}
+    
+
+
+
+
+    export interface VideoKickUserRequestPayload {}
+    
+
+
+
+
+    export interface VideoRuleParameters {
+    threshold?: number;
+    
+
+        
+    time_window?: string;
+    
+
+        
+    harm_labels?: Array<string>;
+    
+
+        }
+    
+
+
+
+
+    export interface VoteData {
+    answer_text?: string;
+    
+
+        
+    option_id?: string;
+    
+
+        }
+    
+
+
+
+
+    export interface WSAuthMessage {
+    /**
+     * JWT token for authentication
+     */
+    token: string;
+    
+
+        
+    user_details: ConnectUserDetailsRequest;
+    
+
+        
+    /**
+     * List of products to subscribe to. One of: chat, video, feeds
+     */
+    products?: Array<string>;
+    
+
+        }
+    
+
+
+
+
+    export type WSClientEvent =
+        
+            | ({ type: 'app.updated' } & AppUpdatedEvent )
+        
+            | ({ type: 'feeds.activity.added' } & ActivityAddedEvent )
+        
+            | ({ type: 'feeds.activity.deleted' } & ActivityDeletedEvent )
+        
+            | ({ type: 'feeds.activity.feedback' } & ActivityFeedbackEvent )
+        
+            | ({ type: 'feeds.activity.marked' } & ActivityMarkEvent )
+        
+            | ({ type: 'feeds.activity.pinned' } & ActivityPinnedEvent )
+        
+            | ({ type: 'feeds.activity.reaction.added' } & ActivityReactionAddedEvent )
+        
+            | ({ type: 'feeds.activity.reaction.deleted' } & ActivityReactionDeletedEvent )
+        
+            | ({ type: 'feeds.activity.reaction.updated' } & ActivityReactionUpdatedEvent )
+        
+            | ({ type: 'feeds.activity.removed_from_feed' } & ActivityRemovedFromFeedEvent )
+        
+            | ({ type: 'feeds.activity.restored' } & ActivityRestoredEvent )
+        
+            | ({ type: 'feeds.activity.unpinned' } & ActivityUnpinnedEvent )
+        
+            | ({ type: 'feeds.activity.updated' } & ActivityUpdatedEvent )
+        
+            | ({ type: 'feeds.bookmark.added' } & BookmarkAddedEvent )
+        
+            | ({ type: 'feeds.bookmark.deleted' } & BookmarkDeletedEvent )
+        
+            | ({ type: 'feeds.bookmark.updated' } & BookmarkUpdatedEvent )
+        
+            | ({ type: 'feeds.bookmark_folder.deleted' } & BookmarkFolderDeletedEvent )
+        
+            | ({ type: 'feeds.bookmark_folder.updated' } & BookmarkFolderUpdatedEvent )
+        
+            | ({ type: 'feeds.comment.added' } & CommentAddedEvent )
+        
+            | ({ type: 'feeds.comment.deleted' } & CommentDeletedEvent )
+        
+            | ({ type: 'feeds.comment.reaction.added' } & CommentReactionAddedEvent )
+        
+            | ({ type: 'feeds.comment.reaction.deleted' } & CommentReactionDeletedEvent )
+        
+            | ({ type: 'feeds.comment.reaction.updated' } & CommentReactionUpdatedEvent )
+        
+            | ({ type: 'feeds.comment.restored' } & CommentRestoredEvent )
+        
+            | ({ type: 'feeds.comment.updated' } & CommentUpdatedEvent )
+        
+            | ({ type: 'feeds.feed.created' } & FeedCreatedEvent )
+        
+            | ({ type: 'feeds.feed.deleted' } & FeedDeletedEvent )
+        
+            | ({ type: 'feeds.feed.updated' } & FeedUpdatedEvent )
+        
+            | ({ type: 'feeds.feed_group.changed' } & FeedGroupChangedEvent )
+        
+            | ({ type: 'feeds.feed_group.deleted' } & FeedGroupDeletedEvent )
+        
+            | ({ type: 'feeds.feed_group.restored' } & FeedGroupRestoredEvent )
+        
+            | ({ type: 'feeds.feed_member.added' } & FeedMemberAddedEvent )
+        
+            | ({ type: 'feeds.feed_member.removed' } & FeedMemberRemovedEvent )
+        
+            | ({ type: 'feeds.feed_member.updated' } & FeedMemberUpdatedEvent )
+        
+            | ({ type: 'feeds.follow.created' } & FollowCreatedEvent )
+        
+            | ({ type: 'feeds.follow.deleted' } & FollowDeletedEvent )
+        
+            | ({ type: 'feeds.follow.updated' } & FollowUpdatedEvent )
+        
+            | ({ type: 'feeds.notification_feed.updated' } & NotificationFeedUpdatedEvent )
+        
+            | ({ type: 'feeds.poll.closed' } & PollClosedFeedEvent )
+        
+            | ({ type: 'feeds.poll.deleted' } & PollDeletedFeedEvent )
+        
+            | ({ type: 'feeds.poll.updated' } & PollUpdatedFeedEvent )
+        
+            | ({ type: 'feeds.poll.vote_casted' } & PollVoteCastedFeedEvent )
+        
+            | ({ type: 'feeds.poll.vote_changed' } & PollVoteChangedFeedEvent )
+        
+            | ({ type: 'feeds.poll.vote_removed' } & PollVoteRemovedFeedEvent )
+        
+            | ({ type: 'feeds.stories_feed.updated' } & StoriesFeedUpdatedEvent )
+        
+            | ({ type: 'health.check' } & HealthCheckEvent )
+        
+            | ({ type: 'moderation.custom_action' } & ModerationCustomActionEvent )
+        
+            | ({ type: 'moderation.flagged' } & ModerationFlaggedEvent )
+        
+            | ({ type: 'moderation.mark_reviewed' } & ModerationMarkReviewedEvent )
+        
+            | ({ type: 'user.banned' } & UserBannedEvent )
+        
+            | ({ type: 'user.deactivated' } & UserDeactivatedEvent )
+        
+            | ({ type: 'user.reactivated' } & UserReactivatedEvent )
+        
+            | ({ type: 'user.unbanned' } & UserUnbannedEvent )
+        
+            | ({ type: 'user.updated' } & UserUpdatedEvent )
+        
+
+
+
+
+
+    export type WSEvent =
+        
+            | ({ type: 'app.updated' } & AppUpdatedEvent )
+        
+            | ({ type: 'feeds.activity.added' } & ActivityAddedEvent )
+        
+            | ({ type: 'feeds.activity.deleted' } & ActivityDeletedEvent )
+        
+            | ({ type: 'feeds.activity.feedback' } & ActivityFeedbackEvent )
+        
+            | ({ type: 'feeds.activity.marked' } & ActivityMarkEvent )
+        
+            | ({ type: 'feeds.activity.pinned' } & ActivityPinnedEvent )
+        
+            | ({ type: 'feeds.activity.reaction.added' } & ActivityReactionAddedEvent )
+        
+            | ({ type: 'feeds.activity.reaction.deleted' } & ActivityReactionDeletedEvent )
+        
+            | ({ type: 'feeds.activity.reaction.updated' } & ActivityReactionUpdatedEvent )
+        
+            | ({ type: 'feeds.activity.removed_from_feed' } & ActivityRemovedFromFeedEvent )
+        
+            | ({ type: 'feeds.activity.restored' } & ActivityRestoredEvent )
+        
+            | ({ type: 'feeds.activity.unpinned' } & ActivityUnpinnedEvent )
+        
+            | ({ type: 'feeds.activity.updated' } & ActivityUpdatedEvent )
+        
+            | ({ type: 'feeds.bookmark.added' } & BookmarkAddedEvent )
+        
+            | ({ type: 'feeds.bookmark.deleted' } & BookmarkDeletedEvent )
+        
+            | ({ type: 'feeds.bookmark.updated' } & BookmarkUpdatedEvent )
+        
+            | ({ type: 'feeds.bookmark_folder.deleted' } & BookmarkFolderDeletedEvent )
+        
+            | ({ type: 'feeds.bookmark_folder.updated' } & BookmarkFolderUpdatedEvent )
+        
+            | ({ type: 'feeds.comment.added' } & CommentAddedEvent )
+        
+            | ({ type: 'feeds.comment.deleted' } & CommentDeletedEvent )
+        
+            | ({ type: 'feeds.comment.reaction.added' } & CommentReactionAddedEvent )
+        
+            | ({ type: 'feeds.comment.reaction.deleted' } & CommentReactionDeletedEvent )
+        
+            | ({ type: 'feeds.comment.reaction.updated' } & CommentReactionUpdatedEvent )
+        
+            | ({ type: 'feeds.comment.restored' } & CommentRestoredEvent )
+        
+            | ({ type: 'feeds.comment.updated' } & CommentUpdatedEvent )
+        
+            | ({ type: 'feeds.feed.created' } & FeedCreatedEvent )
+        
+            | ({ type: 'feeds.feed.deleted' } & FeedDeletedEvent )
+        
+            | ({ type: 'feeds.feed.updated' } & FeedUpdatedEvent )
+        
+            | ({ type: 'feeds.feed_group.changed' } & FeedGroupChangedEvent )
+        
+            | ({ type: 'feeds.feed_group.deleted' } & FeedGroupDeletedEvent )
+        
+            | ({ type: 'feeds.feed_group.restored' } & FeedGroupRestoredEvent )
+        
+            | ({ type: 'feeds.feed_member.added' } & FeedMemberAddedEvent )
+        
+            | ({ type: 'feeds.feed_member.removed' } & FeedMemberRemovedEvent )
+        
+            | ({ type: 'feeds.feed_member.updated' } & FeedMemberUpdatedEvent )
+        
+            | ({ type: 'feeds.follow.created' } & FollowCreatedEvent )
+        
+            | ({ type: 'feeds.follow.deleted' } & FollowDeletedEvent )
+        
+            | ({ type: 'feeds.follow.updated' } & FollowUpdatedEvent )
+        
+            | ({ type: 'feeds.notification_feed.updated' } & NotificationFeedUpdatedEvent )
+        
+            | ({ type: 'feeds.poll.closed' } & PollClosedFeedEvent )
+        
+            | ({ type: 'feeds.poll.deleted' } & PollDeletedFeedEvent )
+        
+            | ({ type: 'feeds.poll.updated' } & PollUpdatedFeedEvent )
+        
+            | ({ type: 'feeds.poll.vote_casted' } & PollVoteCastedFeedEvent )
+        
+            | ({ type: 'feeds.poll.vote_changed' } & PollVoteChangedFeedEvent )
+        
+            | ({ type: 'feeds.poll.vote_removed' } & PollVoteRemovedFeedEvent )
+        
+            | ({ type: 'feeds.stories_feed.updated' } & StoriesFeedUpdatedEvent )
+        
+            | ({ type: 'health.check' } & HealthCheckEvent )
+        
+            | ({ type: 'moderation.custom_action' } & ModerationCustomActionEvent )
+        
+            | ({ type: 'moderation.flagged' } & ModerationFlaggedEvent )
+        
+            | ({ type: 'moderation.mark_reviewed' } & ModerationMarkReviewedEvent )
+        
+            | ({ type: 'user.banned' } & UserBannedEvent )
+        
+            | ({ type: 'user.deactivated' } & UserDeactivatedEvent )
+        
+            | ({ type: 'user.reactivated' } & UserReactivatedEvent )
+        
+            | ({ type: 'user.unbanned' } & UserUnbannedEvent )
+        
+            | ({ type: 'user.updated' } & UserUpdatedEvent )
+        
+
+
+
+
+
+
+
+
+
+

--- a/packages/feeds-client/src/gen/models/index.ts
+++ b/packages/feeds-client/src/gen/models/index.ts
@@ -1,17909 +1,10269 @@
+export interface AIImageConfig {
+  enabled: boolean;
 
-    export interface AIImageConfig {
-    enabled: boolean;
-    
+  ocr_rules: OCRRule[];
 
-        
-    ocr_rules: Array<OCRRule>;
-    
+  rules: AWSRekognitionRule[];
 
-        
-    rules: Array<AWSRekognitionRule>;
-    
+  async?: boolean;
+}
 
-        
-    async?: boolean;
-    
+export interface AIImageLabelDefinition {
+  description: string;
 
-        }
-    
+  group: string;
 
+  key: string;
 
+  label: string;
+}
 
+export interface AITextConfig {
+  enabled: boolean;
 
-    export interface AIImageLabelDefinition {
-    description: string;
-    
+  profile: string;
 
-        
-    group: string;
-    
+  rules: BodyguardRule[];
 
-        
-    key: string;
-    
+  severity_rules: BodyguardSeverityRule[];
 
-        
-    label: string;
-    
+  async?: boolean;
+}
 
-        }
-    
+export interface AIVideoConfig {
+  enabled: boolean;
 
+  rules: AWSRekognitionRule[];
 
+  async?: boolean;
+}
 
+export interface APIError {
+  /**
+   * API error code
+   */
+  code: number;
 
-    export interface AITextConfig {
-    enabled: boolean;
-    
+  /**
+   * Request duration
+   */
+  duration: string;
 
-        
-    profile: string;
-    
+  /**
+   * Message describing an error
+   */
+  message: string;
 
-        
-    rules: Array<BodyguardRule>;
-    
+  /**
+   * URL with additional information
+   */
+  more_info: string;
 
-        
-    severity_rules: Array<BodyguardSeverityRule>;
-    
+  /**
+   * Response HTTP status code
+   */
+  status_code: number;
 
-        
-    async?: boolean;
-    
+  /**
+   * Additional error-specific information
+   */
+  details: number[];
 
-        }
-    
+  /**
+   * Flag that indicates if the error is unrecoverable, requests that return unrecoverable errors should not be retried, this error only applies to the request that caused it
+   */
+  unrecoverable?: boolean;
 
+  /**
+   * Additional error info
+   */
+  exception_fields?: Record<string, string>;
+}
 
+export interface AWSRekognitionRule {
+  action:
+    | 'flag'
+    | 'shadow'
+    | 'remove'
+    | 'bounce'
+    | 'bounce_flag'
+    | 'bounce_remove';
 
+  label: string;
 
-    export interface AIVideoConfig {
-    enabled: boolean;
-    
+  min_confidence: number;
 
-        
-    rules: Array<AWSRekognitionRule>;
-    
+  subclassifications?: Record<string, any>;
+}
 
-        
-    async?: boolean;
-    
+export interface AcceptFeedMemberInviteRequest {}
 
-        }
-    
+export interface AcceptFeedMemberInviteResponse {
+  duration: string;
 
+  member: FeedMemberResponse;
+}
 
+export interface AcceptFollowRequest {
+  /**
+   * Fully qualified ID of the source feed
+   */
+  source: string;
 
+  /**
+   * Fully qualified ID of the target feed
+   */
+  target: string;
 
-    export interface APIError {
-    /**
-     * API error code
-     */
-    code: number;
-    
+  /**
+   * Optional role for the follower in the follow relationship
+   */
+  follower_role?: string;
+}
 
-        
-    /**
-     * Request duration
-     */
-    duration: string;
-    
+export interface AcceptFollowResponse {
+  duration: string;
 
-        
-    /**
-     * Message describing an error
-     */
-    message: string;
-    
+  follow: FollowResponse;
+}
 
-        
-    /**
-     * URL with additional information
-     */
-    more_info: string;
-    
+export interface Action {
+  name: string;
 
-        
-    /**
-     * Response HTTP status code
-     */
-    status_code: number;
-    
+  text: string;
 
-        
-    /**
-     * Additional error-specific information
-     */
-    details: Array<number>;
-    
+  type: string;
 
-        
-    /**
-     * Flag that indicates if the error is unrecoverable, requests that return unrecoverable errors should not be retried, this error only applies to the request that caused it
-     */
-    unrecoverable?: boolean;
-    
+  style?: string;
 
-        
-    /**
-     * Additional error info
-     */
-    exception_fields?: Record<string, string>;
-    
+  value?: string;
+}
 
-        }
-    
+export interface ActionLogResponse {
+  /**
+   * Timestamp when the action was taken
+   */
+  created_at: Date;
 
+  /**
+   * Unique identifier of the action log
+   */
+  id: string;
 
+  /**
+   * Reason for the moderation action
+   */
+  reason: string;
 
+  /**
+   * Classification of who triggered the action (e.g. user, moderator, automod, api_integration)
+   */
+  reporter_type: string;
 
-    export interface AWSRekognitionRule {
-    
-        action:| "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
+  /**
+   * ID of the user who was the target of the action
+   */
+  target_user_id: string;
 
-        
-    label: string;
-    
+  /**
+   * Type of moderation action
+   */
+  type: string;
 
-        
-    min_confidence: number;
-    
+  /**
+   * ID of the user who performed the action
+   */
+  user_id: string;
 
-        
-    subclassifications?: Record<string, any>;
-    
+  ai_providers: string[];
 
-        }
-    
+  /**
+   * Additional metadata about the action
+   */
+  custom: Record<string, any>;
 
+  review_queue_item?: ReviewQueueItemResponse;
 
+  target_user?: UserResponse;
 
+  user?: UserResponse;
+}
 
-    export interface AcceptFeedMemberInviteRequest {}
-    
+export interface ActionSequence {
+  action: string;
 
+  blur: boolean;
 
+  cooldown_period: number;
 
+  threshold: number;
 
-    export interface AcceptFeedMemberInviteResponse {
-    duration: string;
-    
+  time_window: number;
 
-        
-    member: FeedMemberResponse;
-    
+  warning: boolean;
 
-        }
-    
+  warning_text: string;
+}
 
+export interface ActivityAddedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
+  fid: string;
 
+  activity: ActivityResponse;
 
-    export interface AcceptFollowRequest {
-    /**
-     * Fully qualified ID of the source feed
-     */
-    source: string;
-    
+  custom: Record<string, any>;
 
-        
-    /**
-     * Fully qualified ID of the target feed
-     */
-    target: string;
-    
+  /**
+   * The type of event: "feeds.activity.added" in this case
+   */
+  type: string;
 
-        
-    /**
-     * Optional role for the follower in the follow relationship
-     */
-    follower_role?: string;
-    
+  feed_visibility?: string;
 
-        }
-    
+  received_at?: Date;
 
+  user?: UserResponseCommonFields;
+}
 
+export interface ActivityDeletedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
+  fid: string;
 
-    export interface AcceptFollowResponse {
-    duration: string;
-    
+  activity: ActivityResponse;
 
-        
-    follow: FollowResponse;
-    
+  custom: Record<string, any>;
 
-        }
-    
+  /**
+   * The type of event: "feeds.activity.deleted" in this case
+   */
+  type: string;
 
+  feed_visibility?: string;
 
+  received_at?: Date;
 
+  user?: UserResponseCommonFields;
+}
 
-    export interface Action {
-    name: string;
-    
+export interface ActivityFeedbackEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    text: string;
-    
+  activity_feedback: ActivityFeedbackEventPayload;
 
-        
-    type: string;
-    
+  custom: Record<string, any>;
 
-        
-    style?: string;
-    
+  /**
+   * The type of event: "feeds.activity.feedback" in this case
+   */
+  type: string;
 
-        
-    value?: string;
-    
+  received_at?: Date;
 
-        }
-    
+  user?: UserResponseCommonFields;
+}
 
+export interface ActivityFeedbackEventPayload {
+  /**
+   * The type of feedback action. One of: hide, show_more, show_less
+   */
 
+  action: 'hide' | 'show_more' | 'show_less';
 
+  /**
+   * The activity that received feedback
+   */
+  activity_id: string;
 
-    export interface ActionLogResponse {
-    /**
-     * Timestamp when the action was taken
-     */
-    created_at: Date;
-    
+  /**
+   * When the feedback was created
+   */
+  created_at: Date;
 
-        
-    /**
-     * Unique identifier of the action log
-     */
-    id: string;
-    
+  /**
+   * When the feedback was last updated
+   */
+  updated_at: Date;
 
-        
-    /**
-     * Reason for the moderation action
-     */
-    reason: string;
-    
+  /**
+   * The feedback value (true/false)
+   */
+  value: string;
 
-        
-    /**
-     * Classification of who triggered the action (e.g. user, moderator, automod, api_integration)
-     */
-    reporter_type: string;
-    
+  user: UserResponse;
+}
 
-        
-    /**
-     * ID of the user who was the target of the action
-     */
-    target_user_id: string;
-    
+export interface ActivityFeedbackRequest {
+  /**
+   * Whether to hide this activity
+   */
+  hide?: boolean;
 
-        
-    /**
-     * Type of moderation action
-     */
-    type: string;
-    
+  /**
+   * Whether to show less content like this
+   */
+  show_less?: boolean;
 
-        
-    /**
-     * ID of the user who performed the action
-     */
-    user_id: string;
-    
+  /**
+   * Whether to show more content like this
+   */
+  show_more?: boolean;
+}
 
-        
-    ai_providers: Array<string>;
-    
+export interface ActivityFeedbackResponse {
+  /**
+   * The ID of the activity that received feedback
+   */
+  activity_id: string;
 
-        
-    /**
-     * Additional metadata about the action
-     */
-    custom: Record<string, any>;
-    
+  duration: string;
+}
 
-        
-    review_queue_item?: ReviewQueueItemResponse;
-    
+export interface ActivityFilterConfig {
+  exclude_owner_activities: boolean;
+}
 
-        
-    target_user?: UserResponse;
-    
+export interface ActivityMarkEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    user?: UserResponse;
-    
+  fid: string;
 
-        }
-    
+  custom: Record<string, any>;
 
+  /**
+   * The type of event: "feeds.activity.marked" in this case
+   */
+  type: string;
 
+  feed_visibility?: string;
 
+  /**
+   * Whether all activities were marked as read
+   */
+  mark_all_read?: boolean;
 
-    export interface ActionSequence {
-    action: string;
-    
+  /**
+   * Whether all activities were marked as seen
+   */
+  mark_all_seen?: boolean;
 
-        
-    blur: boolean;
-    
+  received_at?: Date;
 
-        
-    cooldown_period: number;
-    
+  /**
+   * The IDs of activities marked as read
+   */
+  mark_read?: string[];
 
-        
-    threshold: number;
-    
+  /**
+   * The IDs of activities marked as seen
+   */
+  mark_seen?: string[];
 
-        
-    time_window: number;
-    
+  /**
+   * The IDs of activities marked as watched
+   */
+  mark_watched?: string[];
 
-        
-    warning: boolean;
-    
+  user?: UserResponseCommonFields;
+}
 
-        
-    warning_text: string;
-    
+export interface ActivityPinResponse {
+  /**
+   * When the pin was created
+   */
+  created_at: Date;
 
-        }
-    
+  /**
+   * ID of the feed where activity is pinned
+   */
+  feed: string;
 
+  /**
+   * When the pin was last updated
+   */
+  updated_at: Date;
 
+  activity: ActivityResponse;
 
+  user: UserResponse;
+}
 
-    export interface ActivityAddedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+export interface ActivityPinnedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    fid: string;
-    
+  /**
+   * The ID of the feed
+   */
+  fid: string;
 
-        
-    activity: ActivityResponse;
-    
+  custom: Record<string, any>;
 
-        
-    custom: Record<string, any>;
-    
+  pinned_activity: PinActivityResponse;
 
-        
-    /**
-     * The type of event: "feeds.activity.added" in this case
-     */
-    type: string;
-    
+  /**
+   * The type of event: "feeds.activity.pinned" in this case
+   */
+  type: string;
 
-        
-    feed_visibility?: string;
-    
+  feed_visibility?: string;
 
-        
-    received_at?: Date;
-    
+  received_at?: Date;
 
-        
-    user?: UserResponseCommonFields;
-    
+  user?: UserResponseCommonFields;
+}
 
-        }
-    
+export interface ActivityProcessorConfig {
+  type: string;
 
+  openai_key?: string;
 
+  config?: Record<string, any>;
+}
 
+export interface ActivityReactionAddedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-    export interface ActivityDeletedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  fid: string;
 
-        
-    fid: string;
-    
+  activity: ActivityResponse;
 
-        
-    activity: ActivityResponse;
-    
+  custom: Record<string, any>;
 
-        
-    custom: Record<string, any>;
-    
+  reaction: FeedsReactionResponse;
 
-        
-    /**
-     * The type of event: "feeds.activity.deleted" in this case
-     */
-    type: string;
-    
+  /**
+   * The type of event: "feeds.activity.reaction.added" in this case
+   */
+  type: string;
 
-        
-    feed_visibility?: string;
-    
+  feed_visibility?: string;
 
-        
-    received_at?: Date;
-    
+  received_at?: Date;
 
-        
-    user?: UserResponseCommonFields;
-    
+  user?: UserResponseCommonFields;
+}
 
-        }
-    
+export interface ActivityReactionDeletedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
+  fid: string;
 
+  activity: ActivityResponse;
 
+  custom: Record<string, any>;
 
-    export interface ActivityFeedbackEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  reaction: FeedsReactionResponse;
 
-        
-    activity_feedback: ActivityFeedbackEventPayload;
-    
+  /**
+   * The type of the reaction that was removed
+   */
+  type: string;
 
-        
-    custom: Record<string, any>;
-    
+  feed_visibility?: string;
 
-        
-    /**
-     * The type of event: "feeds.activity.feedback" in this case
-     */
-    type: string;
-    
+  received_at?: Date;
 
-        
-    received_at?: Date;
-    
+  user?: UserResponseCommonFields;
+}
 
-        
-    user?: UserResponseCommonFields;
-    
+export interface ActivityReactionUpdatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        }
-    
+  fid: string;
 
+  activity: ActivityResponse;
 
+  custom: Record<string, any>;
 
+  reaction: FeedsReactionResponse;
 
-    export interface ActivityFeedbackEventPayload {
-    /**
-     * The type of feedback action. One of: hide, show_more, show_less
-     */
-    
-        action:| "hide" | "show_more" | "show_less" ;
+  /**
+   * The type of event: "feeds.activity.reaction.updated" in this case
+   */
+  type: string;
 
-        
-    /**
-     * The activity that received feedback
-     */
-    activity_id: string;
-    
+  feed_visibility?: string;
 
-        
-    /**
-     * When the feedback was created
-     */
-    created_at: Date;
-    
+  received_at?: Date;
 
-        
-    /**
-     * When the feedback was last updated
-     */
-    updated_at: Date;
-    
+  user?: UserResponseCommonFields;
+}
 
-        
-    /**
-     * The feedback value (true/false)
-     */
-    value: string;
-    
+export interface ActivityRemovedFromFeedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    user: UserResponse;
-    
+  fid: string;
 
-        }
-    
+  activity: ActivityResponse;
 
+  custom: Record<string, any>;
 
+  /**
+   * The type of event: "feeds.activity.removed_from_feed" in this case
+   */
+  type: string;
 
+  feed_visibility?: string;
 
-    export interface ActivityFeedbackRequest {
-    /**
-     * Whether to hide this activity
-     */
-    hide?: boolean;
-    
+  received_at?: Date;
 
-        
-    /**
-     * Whether to show less content like this
-     */
-    show_less?: boolean;
-    
+  user?: UserResponseCommonFields;
+}
 
-        
-    /**
-     * Whether to show more content like this
-     */
-    show_more?: boolean;
-    
+export interface ActivityRequest {
+  /**
+   * Type of activity
+   */
+  type: string;
 
-        }
-    
+  /**
+   * List of feeds to add the activity to with a default max limit of 25 feeds
+   */
+  feeds: string[];
 
+  /**
+   * @deprecated
+   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+   */
+  copy_custom_to_notification?: boolean;
 
+  /**
+   * Whether to create notification activities for mentioned users
+   */
+  create_notification_activity?: boolean;
 
+  /**
+   * Expiration time for the activity
+   */
+  expires_at?: string;
 
-    export interface ActivityFeedbackResponse {
-    /**
-     * The ID of the activity that received feedback
-     */
-    activity_id: string;
-    
+  /**
+   * Optional ID for the activity
+   */
+  id?: string;
 
-        
-    duration: string;
-    
+  /**
+   * ID of parent activity for replies/comments
+   */
+  parent_id?: string;
 
-        }
-    
+  /**
+   * ID of a poll to attach to activity
+   */
+  poll_id?: string;
 
+  /**
+   * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
+   */
 
+  restrict_replies?: 'everyone' | 'people_i_follow' | 'nobody';
 
+  /**
+   * Whether to skip URL enrichment for the activity
+   */
+  skip_enrich_url?: boolean;
 
-    export interface ActivityFilterConfig {
-    exclude_owner_activities: boolean;
-    
+  /**
+   * Whether to skip push notifications
+   */
+  skip_push?: boolean;
 
-        }
-    
+  /**
+   * Text content of the activity
+   */
+  text?: string;
 
+  /**
+   * Visibility setting for the activity. One of: public, private, tag
+   */
 
+  visibility?: 'public' | 'private' | 'tag';
 
+  /**
+   * If visibility is 'tag', this is the tag name and is required
+   */
+  visibility_tag?: string;
 
-    export interface ActivityMarkEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  /**
+   * List of attachments for the activity
+   */
+  attachments?: Attachment[];
 
-        
-    fid: string;
-    
+  /**
+   * Collections that this activity references
+   */
+  collection_refs?: string[];
 
-        
-    custom: Record<string, any>;
-    
+  /**
+   * Tags for filtering activities
+   */
+  filter_tags?: string[];
 
-        
-    /**
-     * The type of event: "feeds.activity.marked" in this case
-     */
-    type: string;
-    
+  /**
+   * Tags for indicating user interests
+   */
+  interest_tags?: string[];
 
-        
-    feed_visibility?: string;
-    
+  /**
+   * List of users mentioned in the activity
+   */
+  mentioned_user_ids?: string[];
 
-        
-    /**
-     * Whether all activities were marked as read
-     */
-    mark_all_read?: boolean;
-    
+  /**
+   * Custom data for the activity
+   */
+  custom?: Record<string, any>;
 
-        
-    /**
-     * Whether all activities were marked as seen
-     */
-    mark_all_seen?: boolean;
-    
+  location?: Location;
 
-        
-    received_at?: Date;
-    
+  /**
+   * Additional data for search indexing
+   */
+  search_data?: Record<string, any>;
+}
 
-        
-    /**
-     * The IDs of activities marked as read
-     */
-    mark_read?: Array<string>;
-    
+export interface ActivityResponse {
+  /**
+   * Number of bookmarks on the activity
+   */
+  bookmark_count: number;
 
-        
-    /**
-     * The IDs of activities marked as seen
-     */
-    mark_seen?: Array<string>;
-    
+  /**
+   * Number of comments on the activity
+   */
+  comment_count: number;
 
-        
-    /**
-     * The IDs of activities marked as watched
-     */
-    mark_watched?: Array<string>;
-    
+  /**
+   * When the activity was created
+   */
+  created_at: Date;
 
-        
-    user?: UserResponseCommonFields;
-    
+  /**
+   * If this activity is hidden by this user (using activity feedback)
+   */
+  hidden: boolean;
 
-        }
-    
+  /**
+   * Unique identifier for the activity
+   */
+  id: string;
 
+  /**
+   * Popularity score of the activity
+   */
+  popularity: number;
 
+  /**
+   * If this activity is obfuscated for this user. For premium content where you want to show a preview
+   */
+  preview: boolean;
 
+  /**
+   * Number of reactions to the activity
+   */
+  reaction_count: number;
 
-    export interface ActivityPinResponse {
-    /**
-     * When the pin was created
-     */
-    created_at: Date;
-    
+  /**
+   * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
+   */
 
-        
-    /**
-     * ID of the feed where activity is pinned
-     */
-    feed: string;
-    
+  restrict_replies: 'everyone' | 'people_i_follow' | 'nobody';
 
-        
-    /**
-     * When the pin was last updated
-     */
-    updated_at: Date;
-    
+  /**
+   * Ranking score for this activity
+   */
+  score: number;
 
-        
-    activity: ActivityResponse;
-    
+  /**
+   * Number of times the activity was shared
+   */
+  share_count: number;
 
-        
-    user: UserResponse;
-    
+  /**
+   * Type of activity
+   */
+  type: string;
 
-        }
-    
+  /**
+   * When the activity was last updated
+   */
+  updated_at: Date;
 
+  /**
+   * Visibility setting for the activity. One of: public, private, tag
+   */
 
+  visibility: 'public' | 'private' | 'tag';
 
+  /**
+   * Media attachments for the activity
+   */
+  attachments: Attachment[];
 
-    export interface ActivityPinnedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  /**
+   * Latest 5 comments of this activity (comment replies excluded)
+   */
+  comments: CommentResponse[];
 
-        
-    /**
-     * The ID of the feed
-     */
-    fid: string;
-    
+  /**
+   * List of feed IDs containing this activity
+   */
+  feeds: string[];
 
-        
-    custom: Record<string, any>;
-    
+  /**
+   * Tags for filtering
+   */
+  filter_tags: string[];
 
-        
-    pinned_activity: PinActivityResponse;
-    
+  /**
+   * Tags for user interests
+   */
+  interest_tags: string[];
 
-        
-    /**
-     * The type of event: "feeds.activity.pinned" in this case
-     */
-    type: string;
-    
+  /**
+   * Recent reactions to the activity
+   */
+  latest_reactions: FeedsReactionResponse[];
 
-        
-    feed_visibility?: string;
-    
+  /**
+   * Users mentioned in the activity
+   */
+  mentioned_users: UserResponse[];
 
-        
-    received_at?: Date;
-    
+  /**
+   * Current user's bookmarks for this activity
+   */
+  own_bookmarks: BookmarkResponse[];
 
-        
-    user?: UserResponseCommonFields;
-    
+  /**
+   * Current user's reactions to this activity
+   */
+  own_reactions: FeedsReactionResponse[];
 
-        }
-    
+  /**
+   * Enriched collection data referenced by this activity
+   */
+  collections: Record<string, EnrichedCollectionResponse>;
 
+  /**
+   * Custom data for the activity
+   */
+  custom: Record<string, any>;
 
+  /**
+   * Grouped reactions by type
+   */
+  reaction_groups: Record<string, FeedsReactionGroupResponse>;
 
+  /**
+   * Data for search indexing
+   */
+  search_data: Record<string, any>;
 
-    export interface ActivityProcessorConfig {
-    type: string;
-    
+  user: UserResponse;
 
-        
-    openai_key?: string;
-    
+  /**
+   * When the activity was deleted
+   */
+  deleted_at?: Date;
 
-        
-    config?: Record<string, any>;
-    
+  /**
+   * When the activity was last edited
+   */
+  edited_at?: Date;
 
-        }
-    
+  /**
+   * When the activity will expire
+   */
+  expires_at?: Date;
 
+  /**
+   * Total count of reactions from friends on this activity
+   */
+  friend_reaction_count?: number;
 
+  /**
+   * Whether this activity has been read. Only set for feed groups with notification config (track_seen/track_read enabled).
+   */
+  is_read?: boolean;
 
+  /**
+   * Whether this activity has been seen. Only set for feed groups with notification config (track_seen/track_read enabled).
+   */
+  is_seen?: boolean;
 
-    export interface ActivityReactionAddedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  is_watched?: boolean;
 
-        
-    fid: string;
-    
+  moderation_action?: string;
 
-        
-    activity: ActivityResponse;
-    
+  /**
+   * Which activity selector provided this activity (e.g., 'following', 'popular', 'interest'). Only set when using multiple activity selectors with ranking.
+   */
+  selector_source?: string;
 
-        
-    custom: Record<string, any>;
-    
+  /**
+   * Text content of the activity
+   */
+  text?: string;
 
-        
-    reaction: FeedsReactionResponse;
-    
+  /**
+   * If visibility is 'tag', this is the tag name
+   */
+  visibility_tag?: string;
 
-        
-    /**
-     * The type of event: "feeds.activity.reaction.added" in this case
-     */
-    type: string;
-    
+  /**
+   * Reactions from users the current user follows or has mutual follows with
+   */
+  friend_reactions?: FeedsReactionResponse[];
 
-        
-    feed_visibility?: string;
-    
+  current_feed?: FeedResponse;
 
-        
-    received_at?: Date;
-    
+  location?: Location;
 
-        
-    user?: UserResponseCommonFields;
-    
+  metrics?: Record<string, number>;
 
-        }
-    
+  moderation?: ModerationV2Response;
 
+  notification_context?: NotificationContext;
 
+  parent?: ActivityResponse;
 
+  poll?: PollResponseData;
 
-    export interface ActivityReactionDeletedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  /**
+   * Variable values used at ranking time. Only included when include_score_vars is enabled in enrichment options.
+   */
+  score_vars?: Record<string, any>;
+}
 
-        
-    fid: string;
-    
+export interface ActivityRestoredEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    activity: ActivityResponse;
-    
+  fid: string;
 
-        
-    custom: Record<string, any>;
-    
+  activity: ActivityResponse;
 
-        
-    reaction: FeedsReactionResponse;
-    
+  custom: Record<string, any>;
 
-        
-    /**
-     * The type of the reaction that was removed
-     */
-    type: string;
-    
+  /**
+   * The type of the event
+   */
+  type: string;
 
-        
-    feed_visibility?: string;
-    
+  feed_visibility?: string;
 
-        
-    received_at?: Date;
-    
+  received_at?: Date;
 
-        
-    user?: UserResponseCommonFields;
-    
+  user?: UserResponseCommonFields;
+}
 
-        }
-    
+export interface ActivitySelectorConfig {
+  cutoff_time: Date;
 
+  cutoff_window?: string;
 
+  min_popularity?: number;
 
+  type?: string;
 
-    export interface ActivityReactionUpdatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  sort?: SortParam[];
 
-        
-    fid: string;
-    
+  filter?: Record<string, any>;
 
-        
-    activity: ActivityResponse;
-    
+  params?: Record<string, any>;
+}
 
-        
-    custom: Record<string, any>;
-    
+export interface ActivityUnpinnedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    reaction: FeedsReactionResponse;
-    
+  /**
+   * The ID of the feed
+   */
+  fid: string;
 
-        
-    /**
-     * The type of event: "feeds.activity.reaction.updated" in this case
-     */
-    type: string;
-    
+  custom: Record<string, any>;
 
-        
-    feed_visibility?: string;
-    
+  pinned_activity: PinActivityResponse;
 
-        
-    received_at?: Date;
-    
+  /**
+   * The type of event: "feeds.activity.unpinned" in this case
+   */
+  type: string;
 
-        
-    user?: UserResponseCommonFields;
-    
+  feed_visibility?: string;
 
-        }
-    
+  received_at?: Date;
 
+  user?: UserResponseCommonFields;
+}
 
+export interface ActivityUpdatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
+  fid: string;
 
-    export interface ActivityRemovedFromFeedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  activity: ActivityResponse;
 
-        
-    fid: string;
-    
+  custom: Record<string, any>;
 
-        
-    activity: ActivityResponse;
-    
+  /**
+   * The type of the event
+   */
+  type: string;
 
-        
-    custom: Record<string, any>;
-    
+  feed_visibility?: string;
 
-        
-    /**
-     * The type of event: "feeds.activity.removed_from_feed" in this case
-     */
-    type: string;
-    
+  received_at?: Date;
 
-        
-    feed_visibility?: string;
-    
+  user?: UserResponseCommonFields;
+}
 
-        
-    received_at?: Date;
-    
+export interface AddActivityRequest {
+  /**
+   * Type of activity
+   */
+  type: string;
 
-        
-    user?: UserResponseCommonFields;
-    
+  /**
+   * List of feeds to add the activity to with a default max limit of 25 feeds
+   */
+  feeds: string[];
 
-        }
-    
+  /**
+   * @deprecated
+   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+   */
+  copy_custom_to_notification?: boolean;
 
+  /**
+   * Whether to create notification activities for mentioned users
+   */
+  create_notification_activity?: boolean;
 
+  enrich_own_fields?: boolean;
 
+  /**
+   * Expiration time for the activity
+   */
+  expires_at?: string;
 
-    export interface ActivityRequest {
-    /**
-     * Type of activity
-     */
-    type: string;
-    
+  /**
+   * Optional ID for the activity
+   */
+  id?: string;
 
-        
-    /**
-     * List of feeds to add the activity to with a default max limit of 25 feeds
-     */
-    feeds: Array<string>;
-    
+  /**
+   * ID of parent activity for replies/comments
+   */
+  parent_id?: string;
 
-        
-    /**
-     * @deprecated
-     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-     */
-    copy_custom_to_notification?: boolean;
-    
+  /**
+   * ID of a poll to attach to activity
+   */
+  poll_id?: string;
 
-        
-    /**
-     * Whether to create notification activities for mentioned users
-     */
-    create_notification_activity?: boolean;
-    
+  /**
+   * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
+   */
 
-        
-    /**
-     * Expiration time for the activity
-     */
-    expires_at?: string;
-    
+  restrict_replies?: 'everyone' | 'people_i_follow' | 'nobody';
 
-        
-    /**
-     * Optional ID for the activity
-     */
-    id?: string;
-    
+  /**
+   * Whether to skip URL enrichment for the activity
+   */
+  skip_enrich_url?: boolean;
 
-        
-    /**
-     * ID of parent activity for replies/comments
-     */
-    parent_id?: string;
-    
+  /**
+   * Whether to skip push notifications
+   */
+  skip_push?: boolean;
 
-        
-    /**
-     * ID of a poll to attach to activity
-     */
-    poll_id?: string;
-    
+  /**
+   * Text content of the activity
+   */
+  text?: string;
 
-        
-    /**
-     * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
-     */
-    
-        restrict_replies?:| "everyone" | "people_i_follow" | "nobody" ;
+  /**
+   * Visibility setting for the activity. One of: public, private, tag
+   */
 
-        
-    /**
-     * Whether to skip URL enrichment for the activity
-     */
-    skip_enrich_url?: boolean;
-    
+  visibility?: 'public' | 'private' | 'tag';
 
-        
-    /**
-     * Whether to skip push notifications
-     */
-    skip_push?: boolean;
-    
+  /**
+   * If visibility is 'tag', this is the tag name and is required
+   */
+  visibility_tag?: string;
 
-        
-    /**
-     * Text content of the activity
-     */
-    text?: string;
-    
+  /**
+   * List of attachments for the activity
+   */
+  attachments?: Attachment[];
 
-        
-    /**
-     * Visibility setting for the activity. One of: public, private, tag
-     */
-    
-        visibility?:| "public" | "private" | "tag" ;
+  /**
+   * Collections that this activity references
+   */
+  collection_refs?: string[];
 
-        
-    /**
-     * If visibility is 'tag', this is the tag name and is required
-     */
-    visibility_tag?: string;
-    
+  /**
+   * Tags for filtering activities
+   */
+  filter_tags?: string[];
 
-        
-    /**
-     * List of attachments for the activity
-     */
-    attachments?: Array<Attachment>;
-    
+  /**
+   * Tags for indicating user interests
+   */
+  interest_tags?: string[];
 
-        
-    /**
-     * Collections that this activity references
-     */
-    collection_refs?: Array<string>;
-    
+  /**
+   * List of users mentioned in the activity
+   */
+  mentioned_user_ids?: string[];
 
-        
-    /**
-     * Tags for filtering activities
-     */
-    filter_tags?: Array<string>;
-    
-
-        
-    /**
-     * Tags for indicating user interests
-     */
-    interest_tags?: Array<string>;
-    
-
-        
-    /**
-     * List of users mentioned in the activity
-     */
-    mentioned_user_ids?: Array<string>;
-    
-
-        
-    /**
-     * Custom data for the activity
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    location?: Location;
-    
-
-        
-    /**
-     * Additional data for search indexing
-     */
-    search_data?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface ActivityResponse {
-    /**
-     * Number of bookmarks on the activity
-     */
-    bookmark_count: number;
-    
-
-        
-    /**
-     * Number of comments on the activity
-     */
-    comment_count: number;
-    
-
-        
-    /**
-     * When the activity was created
-     */
-    created_at: Date;
-    
-
-        
-    /**
-     * If this activity is hidden by this user (using activity feedback)
-     */
-    hidden: boolean;
-    
-
-        
-    /**
-     * Unique identifier for the activity
-     */
-    id: string;
-    
-
-        
-    /**
-     * Popularity score of the activity
-     */
-    popularity: number;
-    
-
-        
-    /**
-     * If this activity is obfuscated for this user. For premium content where you want to show a preview
-     */
-    preview: boolean;
-    
-
-        
-    /**
-     * Number of reactions to the activity
-     */
-    reaction_count: number;
-    
-
-        
-    /**
-     * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
-     */
-    
-        restrict_replies:| "everyone" | "people_i_follow" | "nobody" ;
-
-        
-    /**
-     * Ranking score for this activity
-     */
-    score: number;
-    
-
-        
-    /**
-     * Number of times the activity was shared
-     */
-    share_count: number;
-    
-
-        
-    /**
-     * Type of activity
-     */
-    type: string;
-    
-
-        
-    /**
-     * When the activity was last updated
-     */
-    updated_at: Date;
-    
-
-        
-    /**
-     * Visibility setting for the activity. One of: public, private, tag
-     */
-    
-        visibility:| "public" | "private" | "tag" ;
-
-        
-    /**
-     * Media attachments for the activity
-     */
-    attachments: Array<Attachment>;
-    
-
-        
-    /**
-     * Latest 5 comments of this activity (comment replies excluded)
-     */
-    comments: Array<CommentResponse>;
-    
-
-        
-    /**
-     * List of feed IDs containing this activity
-     */
-    feeds: Array<string>;
-    
-
-        
-    /**
-     * Tags for filtering
-     */
-    filter_tags: Array<string>;
-    
-
-        
-    /**
-     * Tags for user interests
-     */
-    interest_tags: Array<string>;
-    
-
-        
-    /**
-     * Recent reactions to the activity
-     */
-    latest_reactions: Array<FeedsReactionResponse>;
-    
-
-        
-    /**
-     * Users mentioned in the activity
-     */
-    mentioned_users: Array<UserResponse>;
-    
-
-        
-    /**
-     * Current user's bookmarks for this activity
-     */
-    own_bookmarks: Array<BookmarkResponse>;
-    
-
-        
-    /**
-     * Current user's reactions to this activity
-     */
-    own_reactions: Array<FeedsReactionResponse>;
-    
-
-        
-    /**
-     * Enriched collection data referenced by this activity
-     */
-    collections: Record<string, EnrichedCollectionResponse>;
-    
-
-        
-    /**
-     * Custom data for the activity
-     */
-    custom: Record<string, any>;
-    
-
-        
-    /**
-     * Grouped reactions by type
-     */
-    reaction_groups: Record<string, FeedsReactionGroupResponse>;
-    
-
-        
-    /**
-     * Data for search indexing
-     */
-    search_data: Record<string, any>;
-    
-
-        
-    user: UserResponse;
-    
-
-        
-    /**
-     * When the activity was deleted
-     */
-    deleted_at?: Date;
-    
-
-        
-    /**
-     * When the activity was last edited
-     */
-    edited_at?: Date;
-    
-
-        
-    /**
-     * When the activity will expire
-     */
-    expires_at?: Date;
-    
-
-        
-    /**
-     * Total count of reactions from friends on this activity
-     */
-    friend_reaction_count?: number;
-    
-
-        
-    /**
-     * Whether this activity has been read. Only set for feed groups with notification config (track_seen/track_read enabled).
-     */
-    is_read?: boolean;
-    
-
-        
-    /**
-     * Whether this activity has been seen. Only set for feed groups with notification config (track_seen/track_read enabled).
-     */
-    is_seen?: boolean;
-    
-
-        
-    is_watched?: boolean;
-    
-
-        
-    moderation_action?: string;
-    
-
-        
-    /**
-     * Which activity selector provided this activity (e.g., 'following', 'popular', 'interest'). Only set when using multiple activity selectors with ranking.
-     */
-    selector_source?: string;
-    
-
-        
-    /**
-     * Text content of the activity
-     */
-    text?: string;
-    
-
-        
-    /**
-     * If visibility is 'tag', this is the tag name
-     */
-    visibility_tag?: string;
-    
-
-        
-    /**
-     * Reactions from users the current user follows or has mutual follows with
-     */
-    friend_reactions?: Array<FeedsReactionResponse>;
-    
-
-        
-    current_feed?: FeedResponse;
-    
-
-        
-    location?: Location;
-    
-
-        
-    metrics?: Record<string, number>;
-    
-
-        
-    moderation?: ModerationV2Response;
-    
-
-        
-    notification_context?: NotificationContext;
-    
-
-        
-    parent?: ActivityResponse;
-    
-
-        
-    poll?: PollResponseData;
-    
-
-        
-    /**
-     * Variable values used at ranking time. Only included when include_score_vars is enabled in enrichment options.
-     */
-    score_vars?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface ActivityRestoredEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    fid: string;
-    
-
-        
-    activity: ActivityResponse;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    /**
-     * The type of the event
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    user?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface ActivitySelectorConfig {
-    cutoff_time: Date;
-    
-
-        
-    cutoff_window?: string;
-    
-
-        
-    min_popularity?: number;
-    
-
-        
-    type?: string;
-    
-
-        
-    sort?: Array<SortParam>;
-    
-
-        
-    filter?: Record<string, any>;
-    
-
-        
-    params?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface ActivityUnpinnedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    /**
-     * The ID of the feed
-     */
-    fid: string;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    pinned_activity: PinActivityResponse;
-    
-
-        
-    /**
-     * The type of event: "feeds.activity.unpinned" in this case
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    user?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface ActivityUpdatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    fid: string;
-    
-
-        
-    activity: ActivityResponse;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    /**
-     * The type of the event
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    user?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface AddActivityRequest {
-    /**
-     * Type of activity
-     */
-    type: string;
-    
-
-        
-    /**
-     * List of feeds to add the activity to with a default max limit of 25 feeds
-     */
-    feeds: Array<string>;
-    
-
-        
-    /**
-     * @deprecated
-     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-     */
-    copy_custom_to_notification?: boolean;
-    
-
-        
-    /**
-     * Whether to create notification activities for mentioned users
-     */
-    create_notification_activity?: boolean;
-    
-
-        
-    enrich_own_fields?: boolean;
-    
-
-        
-    /**
-     * Expiration time for the activity
-     */
-    expires_at?: string;
-    
-
-        
-    /**
-     * Optional ID for the activity
-     */
-    id?: string;
-    
-
-        
-    /**
-     * ID of parent activity for replies/comments
-     */
-    parent_id?: string;
-    
-
-        
-    /**
-     * ID of a poll to attach to activity
-     */
-    poll_id?: string;
-    
-
-        
-    /**
-     * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
-     */
-    
-        restrict_replies?:| "everyone" | "people_i_follow" | "nobody" ;
-
-        
-    /**
-     * Whether to skip URL enrichment for the activity
-     */
-    skip_enrich_url?: boolean;
-    
-
-        
-    /**
-     * Whether to skip push notifications
-     */
-    skip_push?: boolean;
-    
-
-        
-    /**
-     * Text content of the activity
-     */
-    text?: string;
-    
-
-        
-    /**
-     * Visibility setting for the activity. One of: public, private, tag
-     */
-    
-        visibility?:| "public" | "private" | "tag" ;
-
-        
-    /**
-     * If visibility is 'tag', this is the tag name and is required
-     */
-    visibility_tag?: string;
-    
-
-        
-    /**
-     * List of attachments for the activity
-     */
-    attachments?: Array<Attachment>;
-    
-
-        
-    /**
-     * Collections that this activity references
-     */
-    collection_refs?: Array<string>;
-    
-
-        
-    /**
-     * Tags for filtering activities
-     */
-    filter_tags?: Array<string>;
-    
-
-        
-    /**
-     * Tags for indicating user interests
-     */
-    interest_tags?: Array<string>;
-    
-
-        
-    /**
-     * List of users mentioned in the activity
-     */
-    mentioned_user_ids?: Array<string>;
-    
-
-        
-    /**
-     * Custom data for the activity
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    location?: Location;
-    
-
-        
-    /**
-     * Additional data for search indexing
-     */
-    search_data?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface AddActivityResponse {
-    duration: string;
-    
-
-        
-    activity: ActivityResponse;
-    
-
-        
-    /**
-     * Number of mention notification activities created for mentioned users
-     */
-    mention_notifications_created?: number;
-    
-
-        }
-    
-
-
-
-
-    export interface AddBookmarkRequest {
-    /**
-     * ID of the folder to add the bookmark to
-     */
-    folder_id?: string;
-    
-
-        
-    /**
-     * Custom data for the bookmark
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    new_folder?: AddFolderRequest;
-    
-
-        }
-    
-
-
-
-
-    export interface AddBookmarkResponse {
-    duration: string;
-    
-
-        
-    bookmark: BookmarkResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface AddCommentBookmarkRequest {
-    /**
-     * ID of the folder to add the bookmark to
-     */
-    folder_id?: string;
-    
-
-        
-    /**
-     * Custom data for the bookmark
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    new_folder?: AddFolderRequest;
-    
-
-        }
-    
-
-
-
-
-    export interface AddCommentBookmarkResponse {
-    duration: string;
-    
-
-        
-    bookmark: BookmarkResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface AddCommentReactionRequest {
-    /**
-     * The type of reaction, eg upvote, like, ...
-     */
-    type: string;
-    
-
-        
-    /**
-     * @deprecated
-     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-     */
-    copy_custom_to_notification?: boolean;
-    
-
-        
-    /**
-     * Whether to create a notification activity for this reaction
-     */
-    create_notification_activity?: boolean;
-    
-
-        
-    /**
-     * Whether to enforce unique reactions per user (remove other reaction types from the user when adding this one)
-     */
-    enforce_unique?: boolean;
-    
-
-        
-    skip_push?: boolean;
-    
-
-        
-    /**
-     * Optional custom data to add to the reaction
-     */
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface AddCommentReactionResponse {
-    /**
-     * Duration of the request
-     */
-    duration: string;
-    
-
-        
-    comment: CommentResponse;
-    
-
-        
-    reaction: FeedsReactionResponse;
-    
-
-        
-    /**
-     * Whether a notification activity was successfully created
-     */
-    notification_created?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface AddCommentRequest {
-    /**
-     * Text content of the comment
-     */
-    comment?: string;
-    
-
-        
-    /**
-     * @deprecated
-     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-     */
-    copy_custom_to_notification?: boolean;
-    
-
-        
-    /**
-     * Whether to create a notification activity for this comment
-     */
-    create_notification_activity?: boolean;
-    
-
-        
-    /**
-     * Optional custom ID for the comment (max 255 characters). If not provided, a UUID will be generated.
-     */
-    id?: string;
-    
-
-        
-    /**
-     * ID of the object to comment on. Required for root comments
-     */
-    object_id?: string;
-    
-
-        
-    /**
-     * Type of the object to comment on. Required for root comments
-     */
-    object_type?: string;
-    
-
-        
-    /**
-     * ID of parent comment for replies. When provided, object_id and object_type are automatically inherited from the parent comment.
-     */
-    parent_id?: string;
-    
-
-        
-    /**
-     * Whether to skip URL enrichment for this comment
-     */
-    skip_enrich_url?: boolean;
-    
-
-        
-    skip_push?: boolean;
-    
-
-        
-    /**
-     * Media attachments for the reply
-     */
-    attachments?: Array<Attachment>;
-    
-
-        
-    /**
-     * List of users mentioned in the reply
-     */
-    mentioned_user_ids?: Array<string>;
-    
-
-        
-    /**
-     * Custom data for the comment
-     */
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface AddCommentResponse {
-    duration: string;
-    
-
-        
-    comment: CommentResponse;
-    
-
-        
-    /**
-     * Number of mention notification activities created for mentioned users
-     */
-    mention_notifications_created?: number;
-    
-
-        
-    /**
-     * Whether a notification activity was successfully created
-     */
-    notification_created?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface AddCommentsBatchRequest {
-    /**
-     * List of comments to add
-     */
-    comments: Array<AddCommentRequest>;
-    
-
-        }
-    
-
-
-
-
-    export interface AddCommentsBatchResponse {
-    duration: string;
-    
-
-        
-    /**
-     * List of comments added
-     */
-    comments: Array<CommentResponse>;
-    
-
-        }
-    
-
-
-
-
-    export interface AddFolderRequest {
-    /**
-     * Name of the folder
-     */
-    name: string;
-    
-
-        
-    /**
-     * Custom data for the folder
-     */
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface AddReactionRequest {
-    /**
-     * Type of reaction
-     */
-    type: string;
-    
-
-        
-    /**
-     * @deprecated
-     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-     */
-    copy_custom_to_notification?: boolean;
-    
-
-        
-    /**
-     * Whether to create a notification activity for this reaction
-     */
-    create_notification_activity?: boolean;
-    
-
-        
-    /**
-     * Whether to enforce unique reactions per user (remove other reaction types from the user when adding this one)
-     */
-    enforce_unique?: boolean;
-    
-
-        
-    skip_push?: boolean;
-    
-
-        
-    /**
-     * Custom data for the reaction
-     */
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface AddReactionResponse {
-    duration: string;
-    
-
-        
-    activity: ActivityResponse;
-    
-
-        
-    reaction: FeedsReactionResponse;
-    
-
-        
-    /**
-     * Whether a notification activity was successfully created
-     */
-    notification_created?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface AddUserGroupMembersRequest {
-    /**
-     * List of user IDs to add as members
-     */
-    member_ids: Array<string>;
-    
-
-        
-    /**
-     * Whether to add the members as group admins. Defaults to false
-     */
-    as_admin?: boolean;
-    
-
-        
-    team_id?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface AddUserGroupMembersResponse {
-    duration: string;
-    
-
-        
-    user_group?: UserGroupResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface AggregatedActivityResponse {
-    /**
-     * Number of activities in this aggregation
-     */
-    activity_count: number;
-    
-
-        
-    /**
-     * When the aggregation was created
-     */
-    created_at: Date;
-    
-
-        
-    /**
-     * Grouping identifier
-     */
-    group: string;
-    
-
-        
-    /**
-     * Ranking score for this aggregation
-     */
-    score: number;
-    
-
-        
-    /**
-     * When the aggregation was last updated
-     */
-    updated_at: Date;
-    
-
-        
-    /**
-     * Number of unique users in this aggregation
-     */
-    user_count: number;
-    
-
-        
-    /**
-     * Whether this activity group has been truncated due to exceeding the group size limit
-     */
-    user_count_truncated: boolean;
-    
-
-        
-    /**
-     * List of activities in this aggregation
-     */
-    activities: Array<ActivityResponse>;
-    
-
-        
-    /**
-     * Whether this aggregated group has been read. Only set for feed groups with notification config (track_seen/track_read enabled).
-     */
-    is_read?: boolean;
-    
-
-        
-    /**
-     * Whether this aggregated group has been seen. Only set for feed groups with notification config (track_seen/track_read enabled).
-     */
-    is_seen?: boolean;
-    
-
-        
-    is_watched?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface AggregationConfig {
-    activities_sort?: string;
-    
-
-        
-    format?: string;
-    
-
-        
-    group_size?: number;
-    
-
-        
-    score_strategy?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface AppEventResponse {
-    /**
-     * boolean
-     */
-    auto_translation_enabled: boolean;
-    
-
-        
-    /**
-     * string
-     */
-    name: string;
-    
-
-        
-    /**
-     * boolean
-     */
-    async_url_enrich_enabled?: boolean;
-    
-
-        
-    file_upload_config?: FileUploadConfig;
-    
-
-        
-    image_upload_config?: FileUploadConfig;
-    
-
-        }
-    
-
-
-
-
-    export interface AppResponseFields {
-    async_url_enrich_enabled: boolean;
-    
-
-        
-    auto_translation_enabled: boolean;
-    
-
-        
-    id: number;
-    
-
-        
-    name: string;
-    
-
-        
-    placement: string;
-    
-
-        
-    file_upload_config: FileUploadConfig;
-    
-
-        
-    image_upload_config: FileUploadConfig;
-    
-
-        }
-    
-
-
-
-
-    export interface AppUpdatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    app: AppEventResponse;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    /**
-     * The type of event: "app.updated" in this case
-     */
-    type: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        }
-    
-
-
-
-
-    export interface AppealItemResponse {
-    /**
-     * Reason Text of the Appeal Item
-     */
-    appeal_reason: string;
-    
-
-        
-    /**
-     * When the flag was created
-     */
-    created_at: Date;
-    
-
-        
-    /**
-     * ID of the entity
-     */
-    entity_id: string;
-    
-
-        
-    /**
-     * Type of entity
-     */
-    entity_type: string;
-    
-
-        
-    id: string;
-    
-
-        
-    /**
-     * Status of the Appeal Item
-     */
-    status: string;
-    
-
-        
-    /**
-     * When the flag was last updated
-     */
-    updated_at: Date;
-    
-
-        
-    /**
-     * Decision Reason of the Appeal Item
-     */
-    decision_reason?: string;
-    
-
-        
-    /**
-     * Attachments(e.g. Images) of the Appeal Item
-     */
-    attachments?: Array<string>;
-    
-
-        
-    entity_content?: ModerationPayload;
-    
-
-        
-    user?: UserResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface AppealRequest {
-    /**
-     * Explanation for why the content is being appealed
-     */
-    appeal_reason: string;
-    
-
-        
-    /**
-     * Unique identifier of the entity being appealed
-     */
-    entity_id: string;
-    
-
-        
-    /**
-     * Type of entity being appealed (e.g., message, user)
-     */
-    entity_type: string;
-    
-
-        
-    /**
-     * Array of Attachment URLs(e.g., images)
-     */
-    attachments?: Array<string>;
-    
-
-        }
-    
-
-
-
-
-    export interface AppealResponse {
-    /**
-     * Unique identifier of the created Appeal item
-     */
-    appeal_id: string;
-    
-
-        
-    duration: string;
-    
-
-        }
-    
-
-
-
-
-    export interface Attachment {
-    custom: Record<string, any>;
-    
-
-        
-    asset_url?: string;
-    
-
-        
-    author_icon?: string;
-    
-
-        
-    author_link?: string;
-    
-
-        
-    author_name?: string;
-    
-
-        
-    color?: string;
-    
-
-        
-    fallback?: string;
-    
-
-        
-    footer?: string;
-    
-
-        
-    footer_icon?: string;
-    
-
-        
-    image_url?: string;
-    
-
-        
-    og_scrape_url?: string;
-    
-
-        
-    original_height?: number;
-    
-
-        
-    original_width?: number;
-    
-
-        
-    pretext?: string;
-    
-
-        
-    text?: string;
-    
-
-        
-    thumb_url?: string;
-    
-
-        
-    title?: string;
-    
-
-        
-    title_link?: string;
-    
-
-        
-    /**
-     * Attachment type (e.g. image, video, url)
-     */
-    type?: string;
-    
-
-        
-    actions?: Array<Action>;
-    
-
-        
-    fields?: Array<Field>;
-    
-
-        
-    giphy?: Images;
-    
-
-        }
-    
-
-
-
-
-    export interface AutomodPlatformCircumventionConfig {
-    enabled: boolean;
-    
-
-        
-    rules: Array<AutomodRule>;
-    
-
-        
-    async?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface AutomodRule {
-    
-        action:| "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
-
-        
-    label: string;
-    
-
-        
-    threshold: number;
-    
-
-        }
-    
-
-
-
-
-    export interface AutomodSemanticFiltersConfig {
-    enabled: boolean;
-    
-
-        
-    rules: Array<AutomodSemanticFiltersRule>;
-    
-
-        
-    async?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface AutomodSemanticFiltersRule {
-    
-        action:| "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
-
-        
-    name: string;
-    
-
-        
-    threshold: number;
-    
-
-        }
-    
-
-
-
-
-    export interface AutomodToxicityConfig {
-    enabled: boolean;
-    
-
-        
-    rules: Array<AutomodRule>;
-    
-
-        
-    async?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface BanActionRequestPayload {
-    /**
-     * Also ban user from all channels this moderator creates in the future
-     */
-    ban_from_future_channels?: boolean;
-    
-
-        
-    /**
-     * Ban only from specific channel
-     */
-    channel_ban_only?: boolean;
-    
-
-        
-    channel_cid?: string;
-    
-
-        
-    /**
-     * Message deletion mode: soft, pruning, or hard
-     */
-    
-        delete_messages?:| "soft" | "pruning" | "hard" ;
-
-        
-    /**
-     * Whether to ban by IP address
-     */
-    ip_ban?: boolean;
-    
-
-        
-    /**
-     * Reason for the ban
-     */
-    reason?: string;
-    
-
-        
-    /**
-     * Whether this is a shadow ban
-     */
-    shadow?: boolean;
-    
-
-        
-    /**
-     * Optional: ban user directly without review item
-     */
-    target_user_id?: string;
-    
-
-        
-    /**
-     * Duration of ban in minutes
-     */
-    timeout?: number;
-    
-
-        }
-    
-
-
-
-
-    export interface BanInfoResponse {
-    /**
-     * When the ban was created
-     */
-    created_at: Date;
-    
-
-        
-    /**
-     * When the ban expires
-     */
-    expires?: Date;
-    
-
-        
-    /**
-     * Reason for the ban
-     */
-    reason?: string;
-    
-
-        
-    /**
-     * Whether this is a shadow ban
-     */
-    shadow?: boolean;
-    
-
-        
-    created_by?: UserResponse;
-    
-
-        
-    user?: UserResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface BanOptions {
-    
-        delete_messages?:| "soft" | "pruning" | "hard" ;
-
-        
-    duration?: number;
-    
-
-        
-    ip_ban?: boolean;
-    
-
-        
-    reason?: string;
-    
-
-        
-    shadow_ban?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface BanRequest {
-    /**
-     * ID of the user to ban
-     */
-    target_user_id: string;
-    
-
-        
-    /**
-     * ID of the user performing the ban
-     */
-    banned_by_id?: string;
-    
-
-        
-    /**
-     * Channel where the ban applies
-     */
-    channel_cid?: string;
-    
-
-        
-    
-        delete_messages?:| "soft" | "pruning" | "hard" ;
-
-        
-    /**
-     * Whether to ban the user's IP address
-     */
-    ip_ban?: boolean;
-    
-
-        
-    /**
-     * Optional explanation for the ban
-     */
-    reason?: string;
-    
+  /**
+   * Custom data for the activity
+   */
+  custom?: Record<string, any>;
 
-        
-    /**
-     * Whether this is a shadow ban
-     */
-    shadow?: boolean;
-    
-
-        
-    /**
-     * Duration of the ban in minutes
-     */
-    timeout?: number;
-    
-
-        
-    banned_by?: UserRequest;
-    
-
-        }
-    
-
-
-
-
-    export interface BanResponse {
-    duration: string;
-    
-
-        }
-    
-
-
-
-
-    export interface BlockActionRequestPayload {
-    /**
-     * Reason for blocking
-     */
-    reason?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface BlockListConfig {
-    enabled: boolean;
-    
-
-        
-    rules: Array<BlockListRule>;
-    
-
-        
-    async?: boolean;
-    
-
-        
-    match_substring?: boolean;
-    
+  location?: Location;
 
-        }
-    
+  /**
+   * Additional data for search indexing
+   */
+  search_data?: Record<string, any>;
+}
 
+export interface AddActivityResponse {
+  duration: string;
 
+  activity: ActivityResponse;
 
+  /**
+   * Number of mention notification activities created for mentioned users
+   */
+  mention_notifications_created?: number;
+}
 
-    export interface BlockListOptions {
-    /**
-     * Blocklist behavior. One of: flag, block, shadow_block
-     */
-    
-        behavior:| "flag" | "block" | "shadow_block" ;
+export interface AddBookmarkRequest {
+  /**
+   * ID of the folder to add the bookmark to
+   */
+  folder_id?: string;
 
-        
-    /**
-     * Blocklist name
-     */
-    blocklist: string;
-    
+  /**
+   * Custom data for the bookmark
+   */
+  custom?: Record<string, any>;
 
-        }
-    
+  new_folder?: AddFolderRequest;
+}
 
+export interface AddBookmarkResponse {
+  duration: string;
 
+  bookmark: BookmarkResponse;
+}
 
+export interface AddCommentBookmarkRequest {
+  /**
+   * ID of the folder to add the bookmark to
+   */
+  folder_id?: string;
 
-    export interface BlockListResponse {
-    is_leet_check_enabled: boolean;
-    
+  /**
+   * Custom data for the bookmark
+   */
+  custom?: Record<string, any>;
 
-        
-    is_plural_check_enabled: boolean;
-    
+  new_folder?: AddFolderRequest;
+}
 
-        
-    /**
-     * Block list name
-     */
-    name: string;
-    
+export interface AddCommentBookmarkResponse {
+  duration: string;
 
-        
-    /**
-     * Block list type. One of: regex, domain, domain_allowlist, email, email_allowlist, word
-     */
-    type: string;
-    
+  bookmark: BookmarkResponse;
+}
 
-        
-    /**
-     * List of words to block
-     */
-    words: Array<string>;
-    
+export interface AddCommentReactionRequest {
+  /**
+   * The type of reaction, eg upvote, like, ...
+   */
+  type: string;
 
-        
-    /**
-     * Date/time of creation
-     */
-    created_at?: Date;
-    
+  /**
+   * @deprecated
+   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+   */
+  copy_custom_to_notification?: boolean;
 
-        
-    id?: string;
-    
+  /**
+   * Whether to create a notification activity for this reaction
+   */
+  create_notification_activity?: boolean;
 
-        
-    team?: string;
-    
+  /**
+   * Whether to enforce unique reactions per user (remove other reaction types from the user when adding this one)
+   */
+  enforce_unique?: boolean;
 
-        
-    /**
-     * Date/time of the last update
-     */
-    updated_at?: Date;
-    
+  skip_push?: boolean;
 
-        }
-    
+  /**
+   * Optional custom data to add to the reaction
+   */
+  custom?: Record<string, any>;
+}
 
+export interface AddCommentReactionResponse {
+  /**
+   * Duration of the request
+   */
+  duration: string;
 
+  comment: CommentResponse;
 
+  reaction: FeedsReactionResponse;
 
-    export interface BlockListRule {
-    
-        action:| "flag" | "mask_flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
+  /**
+   * Whether a notification activity was successfully created
+   */
+  notification_created?: boolean;
+}
 
-        
-    name: string;
-    
+export interface AddCommentRequest {
+  /**
+   * Text content of the comment
+   */
+  comment?: string;
 
-        
-    team: string;
-    
+  /**
+   * @deprecated
+   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+   */
+  copy_custom_to_notification?: boolean;
 
-        }
-    
+  /**
+   * Whether to create a notification activity for this comment
+   */
+  create_notification_activity?: boolean;
 
+  /**
+   * Optional custom ID for the comment (max 255 characters). If not provided, a UUID will be generated.
+   */
+  id?: string;
 
+  /**
+   * ID of the object to comment on. Required for root comments
+   */
+  object_id?: string;
 
+  /**
+   * Type of the object to comment on. Required for root comments
+   */
+  object_type?: string;
 
-    export interface BlockUsersRequest {
-    /**
-     * User id to block
-     */
-    blocked_user_id: string;
-    
+  /**
+   * ID of parent comment for replies. When provided, object_id and object_type are automatically inherited from the parent comment.
+   */
+  parent_id?: string;
 
-        }
-    
+  /**
+   * Whether to skip URL enrichment for this comment
+   */
+  skip_enrich_url?: boolean;
 
+  skip_push?: boolean;
 
+  /**
+   * Media attachments for the reply
+   */
+  attachments?: Attachment[];
 
+  /**
+   * List of users mentioned in the reply
+   */
+  mentioned_user_ids?: string[];
 
-    export interface BlockUsersResponse {
-    /**
-     * User id who blocked another user
-     */
-    blocked_by_user_id: string;
-    
+  /**
+   * Custom data for the comment
+   */
+  custom?: Record<string, any>;
+}
 
-        
-    /**
-     * User id who got blocked
-     */
-    blocked_user_id: string;
-    
+export interface AddCommentResponse {
+  duration: string;
 
-        
-    /**
-     * Timestamp when the user was blocked
-     */
-    created_at: Date;
-    
+  comment: CommentResponse;
 
-        
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  /**
+   * Number of mention notification activities created for mentioned users
+   */
+  mention_notifications_created?: number;
 
-        }
-    
+  /**
+   * Whether a notification activity was successfully created
+   */
+  notification_created?: boolean;
+}
 
+export interface AddCommentsBatchRequest {
+  /**
+   * List of comments to add
+   */
+  comments: AddCommentRequest[];
+}
 
+export interface AddCommentsBatchResponse {
+  duration: string;
 
+  /**
+   * List of comments added
+   */
+  comments: CommentResponse[];
+}
 
-    export interface BlockedUserResponse {
-    /**
-     * ID of the user who got blocked
-     */
-    blocked_user_id: string;
-    
+export interface AddFolderRequest {
+  /**
+   * Name of the folder
+   */
+  name: string;
 
-        
-    created_at: Date;
-    
+  /**
+   * Custom data for the folder
+   */
+  custom?: Record<string, any>;
+}
 
-        
-    /**
-     * ID of the user who blocked another user
-     */
-    user_id: string;
-    
+export interface AddReactionRequest {
+  /**
+   * Type of reaction
+   */
+  type: string;
 
-        
-    blocked_user: UserResponse;
-    
+  /**
+   * @deprecated
+   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+   */
+  copy_custom_to_notification?: boolean;
 
-        
-    user: UserResponse;
-    
+  /**
+   * Whether to create a notification activity for this reaction
+   */
+  create_notification_activity?: boolean;
 
-        }
-    
+  /**
+   * Whether to enforce unique reactions per user (remove other reaction types from the user when adding this one)
+   */
+  enforce_unique?: boolean;
 
+  skip_push?: boolean;
 
+  /**
+   * Custom data for the reaction
+   */
+  custom?: Record<string, any>;
+}
 
+export interface AddReactionResponse {
+  duration: string;
 
-    export interface BodyguardProfileSummary {
-    name: string;
-    
+  activity: ActivityResponse;
 
-        
-    display_name?: string;
-    
+  reaction: FeedsReactionResponse;
 
-        }
-    
+  /**
+   * Whether a notification activity was successfully created
+   */
+  notification_created?: boolean;
+}
 
+export interface AddUserGroupMembersRequest {
+  /**
+   * List of user IDs to add as members
+   */
+  member_ids: string[];
 
+  /**
+   * Whether to add the members as group admins. Defaults to false
+   */
+  as_admin?: boolean;
 
+  team_id?: string;
+}
 
-    export interface BodyguardRule {
-    
-        action:| "keep" | "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
+export interface AddUserGroupMembersResponse {
+  duration: string;
 
-        
-    label: string;
-    
+  user_group?: UserGroupResponse;
+}
 
-        
-    severity_rules: Array<BodyguardSeverityRule>;
-    
+export interface AggregatedActivityResponse {
+  /**
+   * Number of activities in this aggregation
+   */
+  activity_count: number;
 
-        }
-    
+  /**
+   * When the aggregation was created
+   */
+  created_at: Date;
 
+  /**
+   * Grouping identifier
+   */
+  group: string;
 
+  /**
+   * Ranking score for this aggregation
+   */
+  score: number;
 
+  /**
+   * When the aggregation was last updated
+   */
+  updated_at: Date;
 
-    export interface BodyguardSeverityRule {
-    
-        action:| "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
+  /**
+   * Number of unique users in this aggregation
+   */
+  user_count: number;
 
-        
-    
-        severity:| "low" | "medium" | "high" | "critical" ;
+  /**
+   * Whether this activity group has been truncated due to exceeding the group size limit
+   */
+  user_count_truncated: boolean;
 
-        }
-    
+  /**
+   * List of activities in this aggregation
+   */
+  activities: ActivityResponse[];
 
+  /**
+   * Whether this aggregated group has been read. Only set for feed groups with notification config (track_seen/track_read enabled).
+   */
+  is_read?: boolean;
 
+  /**
+   * Whether this aggregated group has been seen. Only set for feed groups with notification config (track_seen/track_read enabled).
+   */
+  is_seen?: boolean;
 
+  is_watched?: boolean;
+}
 
-    export interface BookmarkAddedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+export interface AggregationConfig {
+  activities_sort?: string;
 
-        
-    bookmark: BookmarkResponse;
-    
+  format?: string;
 
-        
-    custom: Record<string, any>;
-    
+  group_size?: number;
 
-        
-    /**
-     * The type of event: "feeds.bookmark.added" in this case
-     */
-    type: string;
-    
+  score_strategy?: string;
+}
 
-        
-    received_at?: Date;
-    
+export interface AppEventResponse {
+  /**
+   * boolean
+   */
+  auto_translation_enabled: boolean;
 
-        
-    user?: UserResponseCommonFields;
-    
+  /**
+   * string
+   */
+  name: string;
 
-        }
-    
+  /**
+   * boolean
+   */
+  async_url_enrich_enabled?: boolean;
 
+  file_upload_config?: FileUploadConfig;
 
+  image_upload_config?: FileUploadConfig;
+}
 
+export interface AppResponseFields {
+  async_url_enrich_enabled: boolean;
 
-    export interface BookmarkDeletedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  auto_translation_enabled: boolean;
 
-        
-    bookmark: BookmarkResponse;
-    
+  id: number;
 
-        
-    custom: Record<string, any>;
-    
+  name: string;
 
-        
-    /**
-     * The type of event: "feeds.bookmark.deleted" in this case
-     */
-    type: string;
-    
+  placement: string;
 
-        
-    received_at?: Date;
-    
+  file_upload_config: FileUploadConfig;
 
-        
-    user?: UserResponseCommonFields;
-    
+  image_upload_config: FileUploadConfig;
+}
 
-        }
-    
+export interface AppUpdatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
+  app: AppEventResponse;
 
+  custom: Record<string, any>;
 
+  /**
+   * The type of event: "app.updated" in this case
+   */
+  type: string;
 
-    export interface BookmarkFolderDeletedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  received_at?: Date;
+}
 
-        
-    bookmark_folder: BookmarkFolderResponse;
-    
+export interface AppealItemResponse {
+  /**
+   * Reason Text of the Appeal Item
+   */
+  appeal_reason: string;
 
-        
-    custom: Record<string, any>;
-    
+  /**
+   * When the flag was created
+   */
+  created_at: Date;
 
-        
-    /**
-     * The type of event: "feeds.bookmark_folder.deleted" in this case
-     */
-    type: string;
-    
+  /**
+   * ID of the entity
+   */
+  entity_id: string;
 
-        
-    received_at?: Date;
-    
+  /**
+   * Type of entity
+   */
+  entity_type: string;
 
-        
-    user?: UserResponseCommonFields;
-    
+  id: string;
 
-        }
-    
+  /**
+   * Status of the Appeal Item
+   */
+  status: string;
 
+  /**
+   * When the flag was last updated
+   */
+  updated_at: Date;
 
+  /**
+   * Decision Reason of the Appeal Item
+   */
+  decision_reason?: string;
 
+  /**
+   * Attachments(e.g. Images) of the Appeal Item
+   */
+  attachments?: string[];
 
-    export interface BookmarkFolderResponse {
-    /**
-     * When the folder was created
-     */
-    created_at: Date;
-    
+  entity_content?: ModerationPayload;
 
-        
-    /**
-     * Unique identifier for the folder
-     */
-    id: string;
-    
+  user?: UserResponse;
+}
 
-        
-    /**
-     * Name of the folder
-     */
-    name: string;
-    
+export interface AppealRequest {
+  /**
+   * Explanation for why the content is being appealed
+   */
+  appeal_reason: string;
 
-        
-    /**
-     * When the folder was last updated
-     */
-    updated_at: Date;
-    
+  /**
+   * Unique identifier of the entity being appealed
+   */
+  entity_id: string;
 
-        
-    user: UserResponse;
-    
+  /**
+   * Type of entity being appealed (e.g., message, user)
+   */
+  entity_type: string;
 
-        
-    /**
-     * Custom data for the folder
-     */
-    custom?: Record<string, any>;
-    
+  /**
+   * Array of Attachment URLs(e.g., images)
+   */
+  attachments?: string[];
+}
 
-        }
-    
+export interface AppealResponse {
+  /**
+   * Unique identifier of the created Appeal item
+   */
+  appeal_id: string;
 
+  duration: string;
+}
 
+export interface Attachment {
+  custom: Record<string, any>;
 
+  asset_url?: string;
 
-    export interface BookmarkFolderUpdatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  author_icon?: string;
 
-        
-    bookmark_folder: BookmarkFolderResponse;
-    
+  author_link?: string;
 
-        
-    custom: Record<string, any>;
-    
+  author_name?: string;
 
-        
-    /**
-     * The type of event: "feeds.bookmark_folder.updated" in this case
-     */
-    type: string;
-    
+  color?: string;
 
-        
-    received_at?: Date;
-    
+  fallback?: string;
 
-        
-    user?: UserResponseCommonFields;
-    
+  footer?: string;
 
-        }
-    
+  footer_icon?: string;
 
+  image_url?: string;
 
+  og_scrape_url?: string;
 
+  original_height?: number;
 
-    export interface BookmarkResponse {
-    /**
-     * When the bookmark was created
-     */
-    created_at: Date;
-    
+  original_width?: number;
 
-        
-    /**
-     * ID of the bookmarked object
-     */
-    object_id: string;
-    
+  pretext?: string;
 
-        
-    /**
-     * Type of the bookmarked object (activity or comment)
-     */
-    object_type: string;
-    
+  text?: string;
 
-        
-    /**
-     * When the bookmark was last updated
-     */
-    updated_at: Date;
-    
+  thumb_url?: string;
 
-        
-    activity: ActivityResponse;
-    
+  title?: string;
 
-        
-    user: UserResponse;
-    
+  title_link?: string;
 
-        
-    activity_id?: string;
-    
+  /**
+   * Attachment type (e.g. image, video, url)
+   */
+  type?: string;
 
-        
-    comment?: CommentResponse;
-    
+  actions?: Action[];
 
-        
-    /**
-     * Custom data for the bookmark
-     */
-    custom?: Record<string, any>;
-    
+  fields?: Field[];
 
-        
-    folder?: BookmarkFolderResponse;
-    
+  giphy?: Images;
+}
 
-        }
-    
+export interface AutomodPlatformCircumventionConfig {
+  enabled: boolean;
 
+  rules: AutomodRule[];
 
+  async?: boolean;
+}
 
+export interface AutomodRule {
+  action:
+    | 'flag'
+    | 'shadow'
+    | 'remove'
+    | 'bounce'
+    | 'bounce_flag'
+    | 'bounce_remove';
 
-    export interface BookmarkUpdatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  label: string;
 
-        
-    bookmark: BookmarkResponse;
-    
+  threshold: number;
+}
 
-        
-    custom: Record<string, any>;
-    
+export interface AutomodSemanticFiltersConfig {
+  enabled: boolean;
 
-        
-    /**
-     * The type of event: "feeds.bookmark.updated" in this case
-     */
-    type: string;
-    
+  rules: AutomodSemanticFiltersRule[];
 
-        
-    received_at?: Date;
-    
+  async?: boolean;
+}
 
-        
-    user?: UserResponseCommonFields;
-    
+export interface AutomodSemanticFiltersRule {
+  action:
+    | 'flag'
+    | 'shadow'
+    | 'remove'
+    | 'bounce'
+    | 'bounce_flag'
+    | 'bounce_remove';
 
-        }
-    
+  name: string;
 
+  threshold: number;
+}
 
+export interface AutomodToxicityConfig {
+  enabled: boolean;
 
+  rules: AutomodRule[];
 
-    export interface BulkDeleteActionConfigRequest {
-    /**
-     * UUIDs of the action configs to delete
-     */
-    ids: Array<string>;
-    
+  async?: boolean;
+}
 
-        }
-    
+export interface BanActionRequestPayload {
+  /**
+   * Also ban user from all channels this moderator creates in the future
+   */
+  ban_from_future_channels?: boolean;
 
+  /**
+   * Ban only from specific channel
+   */
+  channel_ban_only?: boolean;
 
+  channel_cid?: string;
 
+  /**
+   * Message deletion mode: soft, pruning, or hard
+   */
 
-    export interface BulkDeleteActionConfigResponse {
-    /**
-     * Number of action configs deleted
-     */
-    deleted: number;
-    
+  delete_messages?: 'soft' | 'pruning' | 'hard';
 
-        
-    duration: string;
-    
+  /**
+   * Whether to ban by IP address
+   */
+  ip_ban?: boolean;
 
-        }
-    
+  /**
+   * Reason for the ban
+   */
+  reason?: string;
 
+  /**
+   * Whether this is a shadow ban
+   */
+  shadow?: boolean;
 
+  /**
+   * Optional: ban user directly without review item
+   */
+  target_user_id?: string;
 
+  /**
+   * Duration of ban in minutes
+   */
+  timeout?: number;
+}
 
-    export interface BulkUpsertActionConfigRequest {
-    /**
-     * List of action configs to create or update
-     */
-    action_configs: Array<UpsertActionConfigItem>;
-    
+export interface BanInfoResponse {
+  /**
+   * When the ban was created
+   */
+  created_at: Date;
 
-        }
-    
+  /**
+   * When the ban expires
+   */
+  expires?: Date;
 
+  /**
+   * Reason for the ban
+   */
+  reason?: string;
 
+  /**
+   * Whether this is a shadow ban
+   */
+  shadow?: boolean;
 
+  created_by?: UserResponse;
 
-    export interface BulkUpsertActionConfigResponse {
-    duration: string;
-    
+  user?: UserResponse;
+}
 
-        
-    /**
-     * The created or updated action configs in the same order as the request
-     */
-    action_configs: Array<ModerationActionConfigResponse>;
-    
+export interface BanOptions {
+  delete_messages?: 'soft' | 'pruning' | 'hard';
 
-        }
-    
+  duration?: number;
 
+  ip_ban?: boolean;
 
+  reason?: string;
 
+  shadow_ban?: boolean;
+}
 
-    export interface BypassActionRequest {
-    enabled?: boolean;
-    
+export interface BanRequest {
+  /**
+   * ID of the user to ban
+   */
+  target_user_id: string;
 
-        }
-    
+  /**
+   * ID of the user performing the ban
+   */
+  banned_by_id?: string;
 
+  /**
+   * Channel where the ban applies
+   */
+  channel_cid?: string;
 
+  delete_messages?: 'soft' | 'pruning' | 'hard';
 
+  /**
+   * Whether to ban the user's IP address
+   */
+  ip_ban?: boolean;
 
-    export interface CallActionOptions {
-    duration?: number;
-    
+  /**
+   * Optional explanation for the ban
+   */
+  reason?: string;
 
-        
-    flag_reason?: string;
-    
+  /**
+   * Whether this is a shadow ban
+   */
+  shadow?: boolean;
 
-        
-    kick_reason?: string;
-    
+  /**
+   * Duration of the ban in minutes
+   */
+  timeout?: number;
 
-        
-    mute_audio?: boolean;
-    
+  banned_by?: UserRequest;
+}
 
-        
-    mute_video?: boolean;
-    
+export interface BanResponse {
+  duration: string;
+}
 
-        
-    reason?: string;
-    
+export interface BlockActionRequestPayload {
+  /**
+   * Reason for blocking
+   */
+  reason?: string;
+}
 
-        
-    warning_text?: string;
-    
+export interface BlockListConfig {
+  enabled: boolean;
 
-        }
-    
+  rules: BlockListRule[];
 
+  async?: boolean;
 
+  match_substring?: boolean;
+}
 
+export interface BlockListOptions {
+  /**
+   * Blocklist behavior. One of: flag, block, shadow_block
+   */
 
-    export interface CallCustomPropertyParameters {
-    operator?: string;
-    
+  behavior: 'flag' | 'block' | 'shadow_block';
 
-        
-    property_key?: string;
-    
+  /**
+   * Blocklist name
+   */
+  blocklist: string;
+}
 
-        }
-    
+export interface BlockListResponse {
+  is_leet_check_enabled: boolean;
 
+  is_plural_check_enabled: boolean;
 
+  /**
+   * Block list name
+   */
+  name: string;
 
+  /**
+   * Block list type. One of: regex, domain, domain_allowlist, email, email_allowlist, word
+   */
+  type: string;
 
-    export interface CallResponse {
-    backstage: boolean;
-    
+  /**
+   * List of words to block
+   */
+  words: string[];
 
-        
-    captioning: boolean;
-    
+  /**
+   * Date/time of creation
+   */
+  created_at?: Date;
 
-        
-    cid: string;
-    
+  id?: string;
 
-        
-    created_at: Date;
-    
+  team?: string;
 
-        
-    current_session_id: string;
-    
+  /**
+   * Date/time of the last update
+   */
+  updated_at?: Date;
+}
 
-        
-    id: string;
-    
+export interface BlockListRule {
+  action:
+    | 'flag'
+    | 'mask_flag'
+    | 'shadow'
+    | 'remove'
+    | 'bounce'
+    | 'bounce_flag'
+    | 'bounce_remove';
 
-        
-    recording: boolean;
-    
+  name: string;
 
-        
-    transcribing: boolean;
-    
+  team: string;
+}
 
-        
-    translating: boolean;
-    
+export interface BlockUsersRequest {
+  /**
+   * User id to block
+   */
+  blocked_user_id: string;
+}
 
-        
-    type: string;
-    
+export interface BlockUsersResponse {
+  /**
+   * User id who blocked another user
+   */
+  blocked_by_user_id: string;
 
-        
-    updated_at: Date;
-    
+  /**
+   * User id who got blocked
+   */
+  blocked_user_id: string;
 
-        
-    blocked_user_ids: Array<string>;
-    
+  /**
+   * Timestamp when the user was blocked
+   */
+  created_at: Date;
 
-        
-    custom: Record<string, any>;
-    
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
+}
 
-        
-    channel_cid?: string;
-    
+export interface BlockedUserResponse {
+  /**
+   * ID of the user who got blocked
+   */
+  blocked_user_id: string;
 
-        
-    ended_at?: Date;
-    
+  created_at: Date;
 
-        
-    join_ahead_time_seconds?: number;
-    
+  /**
+   * ID of the user who blocked another user
+   */
+  user_id: string;
 
-        
-    routing_number?: string;
-    
+  blocked_user: UserResponse;
 
-        
-    starts_at?: Date;
-    
+  user: UserResponse;
+}
 
-        
-    team?: string;
-    
+export interface BodyguardProfileSummary {
+  name: string;
 
-        
-    created_by?: UserResponse;
-    
+  display_name?: string;
+}
 
-        }
-    
+export interface BodyguardRule {
+  action:
+    | 'keep'
+    | 'flag'
+    | 'shadow'
+    | 'remove'
+    | 'bounce'
+    | 'bounce_flag'
+    | 'bounce_remove';
 
+  label: string;
 
+  severity_rules: BodyguardSeverityRule[];
+}
 
+export interface BodyguardSeverityRule {
+  action:
+    | 'flag'
+    | 'shadow'
+    | 'remove'
+    | 'bounce'
+    | 'bounce_flag'
+    | 'bounce_remove';
 
-    export interface CallRuleActionSequence {
-    violation_number?: number;
-    
+  severity: 'low' | 'medium' | 'high' | 'critical';
+}
 
-        
-    actions?: Array<string>;
-    
+export interface BookmarkAddedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    call_options?: CallActionOptions;
-    
+  bookmark: BookmarkResponse;
 
-        }
-    
+  custom: Record<string, any>;
 
+  /**
+   * The type of event: "feeds.bookmark.added" in this case
+   */
+  type: string;
 
+  received_at?: Date;
 
+  user?: UserResponseCommonFields;
+}
 
-    export interface CallTypeRuleParameters {
-    call_type?: string;
-    
+export interface BookmarkDeletedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        }
-    
+  bookmark: BookmarkResponse;
 
+  custom: Record<string, any>;
 
+  /**
+   * The type of event: "feeds.bookmark.deleted" in this case
+   */
+  type: string;
 
+  received_at?: Date;
 
-    export interface CallViolationCountParameters {
-    threshold?: number;
-    
+  user?: UserResponseCommonFields;
+}
 
-        
-    time_window?: string;
-    
+export interface BookmarkFolderDeletedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        }
-    
+  bookmark_folder: BookmarkFolderResponse;
 
+  custom: Record<string, any>;
 
+  /**
+   * The type of event: "feeds.bookmark_folder.deleted" in this case
+   */
+  type: string;
 
+  received_at?: Date;
 
-    export interface CastPollVoteRequest {
-    vote?: VoteData;
-    
+  user?: UserResponseCommonFields;
+}
 
-        }
-    
+export interface BookmarkFolderResponse {
+  /**
+   * When the folder was created
+   */
+  created_at: Date;
 
+  /**
+   * Unique identifier for the folder
+   */
+  id: string;
 
+  /**
+   * Name of the folder
+   */
+  name: string;
 
+  /**
+   * When the folder was last updated
+   */
+  updated_at: Date;
 
-    export interface ChangeFeedVisibilityRequest {
-    /**
-     * Feed visibility level: public, visible, followers, members, or private
-     */
-    
-        visibility:| "public" | "visible" | "followers" | "members" | "private" ;
+  user: UserResponse;
 
-        
-    /**
-     * What to do with existing pending follows when loosening visibility from 'followers': auto_approve (default) or reject
-     */
-    
-        pending_follows_action?:| "auto_approve" | "reject" ;
+  /**
+   * Custom data for the folder
+   */
+  custom?: Record<string, any>;
+}
 
-        }
-    
+export interface BookmarkFolderUpdatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
+  bookmark_folder: BookmarkFolderResponse;
 
+  custom: Record<string, any>;
 
+  /**
+   * The type of event: "feeds.bookmark_folder.updated" in this case
+   */
+  type: string;
 
-    export interface ChangeFeedVisibilityResponse {
-    duration: string;
-    
+  received_at?: Date;
 
-        
-    feed: FeedResponse;
-    
+  user?: UserResponseCommonFields;
+}
 
-        }
-    
+export interface BookmarkResponse {
+  /**
+   * When the bookmark was created
+   */
+  created_at: Date;
 
+  /**
+   * ID of the bookmarked object
+   */
+  object_id: string;
 
+  /**
+   * Type of the bookmarked object (activity or comment)
+   */
+  object_type: string;
 
+  /**
+   * When the bookmark was last updated
+   */
+  updated_at: Date;
 
-    export interface ChannelConfigWithInfo {
-    
-        automod:| "disabled" | "simple" | "AI" ;
+  activity: ActivityResponse;
 
-        
-    
-        automod_behavior:| "flag" | "block" | "shadow_block" ;
+  user: UserResponse;
 
-        
-    connect_events: boolean;
-    
+  activity_id?: string;
 
-        
-    count_messages: boolean;
-    
+  comment?: CommentResponse;
 
-        
-    created_at: Date;
-    
+  /**
+   * Custom data for the bookmark
+   */
+  custom?: Record<string, any>;
 
-        
-    custom_events: boolean;
-    
+  folder?: BookmarkFolderResponse;
+}
 
-        
-    delivery_events: boolean;
-    
+export interface BookmarkUpdatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    mark_messages_pending: boolean;
-    
+  bookmark: BookmarkResponse;
 
-        
-    max_message_length: number;
-    
+  custom: Record<string, any>;
 
-        
-    mutes: boolean;
-    
+  /**
+   * The type of event: "feeds.bookmark.updated" in this case
+   */
+  type: string;
 
-        
-    name: string;
-    
+  received_at?: Date;
 
-        
-    polls: boolean;
-    
+  user?: UserResponseCommonFields;
+}
 
-        
-    push_notifications: boolean;
-    
+export interface BulkDeleteActionConfigRequest {
+  /**
+   * UUIDs of the action configs to delete
+   */
+  ids: string[];
+}
 
-        
-    quotes: boolean;
-    
+export interface BulkDeleteActionConfigResponse {
+  /**
+   * Number of action configs deleted
+   */
+  deleted: number;
 
-        
-    reactions: boolean;
-    
+  duration: string;
+}
 
-        
-    read_events: boolean;
-    
+export interface BulkUpsertActionConfigRequest {
+  /**
+   * List of action configs to create or update
+   */
+  action_configs: UpsertActionConfigItem[];
+}
 
-        
-    reminders: boolean;
-    
+export interface BulkUpsertActionConfigResponse {
+  duration: string;
 
-        
-    replies: boolean;
-    
+  /**
+   * The created or updated action configs in the same order as the request
+   */
+  action_configs: ModerationActionConfigResponse[];
+}
 
-        
-    search: boolean;
-    
+export interface BypassActionRequest {
+  enabled?: boolean;
+}
 
-        
-    shared_locations: boolean;
-    
+export interface CallActionOptions {
+  duration?: number;
 
-        
-    skip_last_msg_update_for_system_msgs: boolean;
-    
+  flag_reason?: string;
 
-        
-    typing_events: boolean;
-    
+  kick_reason?: string;
 
-        
-    updated_at: Date;
-    
+  mute_audio?: boolean;
 
-        
-    uploads: boolean;
-    
+  mute_video?: boolean;
 
-        
-    url_enrichment: boolean;
-    
+  reason?: string;
 
-        
-    user_message_reminders: boolean;
-    
+  warning_text?: string;
+}
 
-        
-    commands: Array<Command>;
-    
+export interface CallCustomPropertyParameters {
+  operator?: string;
 
-        
-    blocklist?: string;
-    
+  property_key?: string;
+}
 
-        
-    
-        blocklist_behavior?:| "flag" | "block" | "shadow_block" ;
+export interface CallResponse {
+  backstage: boolean;
 
-        
-    partition_size?: number;
-    
+  captioning: boolean;
 
-        
-    partition_ttl?: string;
-    
+  cid: string;
 
-        
-    
-        push_level?:| "all" | "all_mentions" | "mentions" | "direct_mentions" | "none" ;
+  created_at: Date;
 
-        
-    allowed_flag_reasons?: Array<string>;
-    
+  current_session_id: string;
 
-        
-    blocklists?: Array<BlockListOptions>;
-    
+  id: string;
 
-        
-    automod_thresholds?: Thresholds;
-    
+  recording: boolean;
 
-        
-    chat_preferences?: ChatPreferences;
-    
+  transcribing: boolean;
 
-        
-    grants?: Record<string, Array<string>>;
-    
+  translating: boolean;
 
-        }
-    
+  type: string;
 
+  updated_at: Date;
 
+  blocked_user_ids: string[];
 
+  custom: Record<string, any>;
 
-    export interface ChannelMemberResponse {
-    /**
-     * Whether member is banned this channel or not
-     */
-    banned: boolean;
-    
+  channel_cid?: string;
 
-        
-    /**
-     * Role of the member in the channel
-     */
-    channel_role: string;
-    
+  ended_at?: Date;
 
-        
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  join_ahead_time_seconds?: number;
 
-        
-    notifications_muted: boolean;
-    
+  routing_number?: string;
 
-        
-    /**
-     * Whether member is shadow banned in this channel or not
-     */
-    shadow_banned: boolean;
-    
+  starts_at?: Date;
 
-        
-    /**
-     * Date/time of the last update
-     */
-    updated_at: Date;
-    
+  team?: string;
 
-        
-    custom: Record<string, any>;
-    
+  created_by?: UserResponse;
+}
 
-        
-    archived_at?: Date;
-    
+export interface CallRuleActionSequence {
+  violation_number?: number;
 
-        
-    /**
-     * Expiration date of the ban
-     */
-    ban_expires?: Date;
-    
+  actions?: string[];
 
-        
-    deleted_at?: Date;
-    
+  call_options?: CallActionOptions;
+}
 
-        
-    /**
-     * Date when invite was accepted
-     */
-    invite_accepted_at?: Date;
-    
+export interface CallTypeRuleParameters {
+  call_type?: string;
+}
 
-        
-    /**
-     * Date when invite was rejected
-     */
-    invite_rejected_at?: Date;
-    
+export interface CallViolationCountParameters {
+  threshold?: number;
 
-        
-    /**
-     * Whether member was invited or not
-     */
-    invited?: boolean;
-    
+  time_window?: string;
+}
 
-        
-    /**
-     * Whether member is channel moderator or not
-     */
-    is_moderator?: boolean;
-    
+export interface CastPollVoteRequest {
+  vote?: VoteData;
+}
 
-        
-    pinned_at?: Date;
-    
+export interface ChangeFeedVisibilityRequest {
+  /**
+   * Feed visibility level: public, visible, followers, members, or private
+   */
 
-        
-    /**
-     * Permission level of the member in the channel (DEPRECATED: use channel_role instead). One of: member, moderator, admin, owner
-     */
-    role?: string;
-    
+  visibility: 'public' | 'visible' | 'followers' | 'members' | 'private';
 
-        
-    status?: string;
-    
+  /**
+   * What to do with existing pending follows when loosening visibility from 'followers': auto_approve (default) or reject
+   */
 
-        
-    user_id?: string;
-    
+  pending_follows_action?: 'auto_approve' | 'reject';
+}
 
-        
-    deleted_messages?: Array<string>;
-    
+export interface ChangeFeedVisibilityResponse {
+  duration: string;
 
-        
-    user?: UserResponse;
-    
+  feed: FeedResponse;
+}
 
-        }
-    
+export interface ChannelConfigWithInfo {
+  automod: 'disabled' | 'simple' | 'AI';
 
+  automod_behavior: 'flag' | 'block' | 'shadow_block';
 
+  connect_events: boolean;
 
+  count_messages: boolean;
 
-    export interface ChannelMessageCountRuleParameters {
-    operator?: string;
-    
+  created_at: Date;
 
-        
-    threshold?: number;
-    
+  custom_events: boolean;
 
-        }
-    
+  delivery_events: boolean;
 
+  mark_messages_pending: boolean;
 
+  max_message_length: number;
 
+  mutes: boolean;
 
-    export interface ChannelMute {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  name: string;
 
-        
-    /**
-     * Date/time of the last update
-     */
-    updated_at: Date;
-    
+  polls: boolean;
 
-        
-    /**
-     * Date/time of mute expiration
-     */
-    expires?: Date;
-    
+  push_notifications: boolean;
 
-        
-    channel?: ChannelResponse;
-    
+  quotes: boolean;
 
-        
-    user?: UserResponse;
-    
+  reactions: boolean;
 
-        }
-    
+  read_events: boolean;
 
+  reminders: boolean;
 
+  replies: boolean;
+
+  search: boolean;
+
+  shared_locations: boolean;
+
+  skip_last_msg_update_for_system_msgs: boolean;
+
+  typing_events: boolean;
+
+  updated_at: Date;
+
+  uploads: boolean;
+
+  url_enrichment: boolean;
+
+  user_message_reminders: boolean;
+
+  commands: Command[];
+
+  blocklist?: string;
+
+  blocklist_behavior?: 'flag' | 'block' | 'shadow_block';
+
+  partition_size?: number;
+
+  partition_ttl?: string;
+
+  push_level?: 'all' | 'all_mentions' | 'mentions' | 'direct_mentions' | 'none';
+
+  allowed_flag_reasons?: string[];
+
+  blocklists?: BlockListOptions[];
+
+  automod_thresholds?: Thresholds;
+
+  chat_preferences?: ChatPreferences;
+
+  grants?: Record<string, string[]>;
+}
+
+export interface ChannelMemberResponse {
+  /**
+   * Whether member is banned this channel or not
+   */
+  banned: boolean;
+
+  /**
+   * Role of the member in the channel
+   */
+  channel_role: string;
+
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
+
+  notifications_muted: boolean;
+
+  /**
+   * Whether member is shadow banned in this channel or not
+   */
+  shadow_banned: boolean;
+
+  /**
+   * Date/time of the last update
+   */
+  updated_at: Date;
+
+  custom: Record<string, any>;
+
+  archived_at?: Date;
+
+  /**
+   * Expiration date of the ban
+   */
+  ban_expires?: Date;
+
+  deleted_at?: Date;
+
+  /**
+   * Date when invite was accepted
+   */
+  invite_accepted_at?: Date;
+
+  /**
+   * Date when invite was rejected
+   */
+  invite_rejected_at?: Date;
+
+  /**
+   * Whether member was invited or not
+   */
+  invited?: boolean;
+
+  /**
+   * Whether member is channel moderator or not
+   */
+  is_moderator?: boolean;
+
+  pinned_at?: Date;
+
+  /**
+   * Permission level of the member in the channel (DEPRECATED: use channel_role instead). One of: member, moderator, admin, owner
+   */
+  role?: string;
+
+  status?: string;
+
+  user_id?: string;
+
+  deleted_messages?: string[];
+
+  user?: UserResponse;
+}
+
+export interface ChannelMessageCountRuleParameters {
+  operator?: string;
+
+  threshold?: number;
+}
+
+export interface ChannelMute {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
+
+  /**
+   * Date/time of the last update
+   */
+  updated_at: Date;
+
+  /**
+   * Date/time of mute expiration
+   */
+  expires?: Date;
+
+  channel?: ChannelResponse;
+
+  user?: UserResponse;
+}
 
 export const ChannelOwnCapability = {
-    BAN_CHANNEL_MEMBERS: 'ban-channel-members',
-    CAST_POLL_VOTE: 'cast-poll-vote',
-    CONNECT_EVENTS: 'connect-events',
-    CREATE_ATTACHMENT: 'create-attachment',
-    DELETE_ANY_MESSAGE: 'delete-any-message',
-    DELETE_CHANNEL: 'delete-channel',
-    DELETE_OWN_MESSAGE: 'delete-own-message',
-    DELIVERY_EVENTS: 'delivery-events',
-    FLAG_MESSAGE: 'flag-message',
-    FREEZE_CHANNEL: 'freeze-channel',
-    JOIN_CHANNEL: 'join-channel',
-    LEAVE_CHANNEL: 'leave-channel',
-    MUTE_CHANNEL: 'mute-channel',
-    PIN_MESSAGE: 'pin-message',
-    QUERY_POLL_VOTES: 'query-poll-votes',
-    QUOTE_MESSAGE: 'quote-message',
-    READ_EVENTS: 'read-events',
-    SEARCH_MESSAGES: 'search-messages',
-    SEND_CUSTOM_EVENTS: 'send-custom-events',
-    SEND_LINKS: 'send-links',
-    SEND_MESSAGE: 'send-message',
-    SEND_POLL: 'send-poll',
-    SEND_REACTION: 'send-reaction',
-    SEND_REPLY: 'send-reply',
-    SEND_RESTRICTED_VISIBILITY_MESSAGE: 'send-restricted-visibility-message',
-    SEND_TYPING_EVENTS: 'send-typing-events',
-    SET_CHANNEL_COOLDOWN: 'set-channel-cooldown',
-    SHARE_LOCATION: 'share-location',
-    SKIP_SLOW_MODE: 'skip-slow-mode',
-    SLOW_MODE: 'slow-mode',
-    TYPING_EVENTS: 'typing-events',
-    UPDATE_ANY_MESSAGE: 'update-any-message',
-    UPDATE_CHANNEL: 'update-channel',
-    UPDATE_CHANNEL_MEMBERS: 'update-channel-members',
-    UPDATE_OWN_MESSAGE: 'update-own-message',
-    UPDATE_THREAD: 'update-thread',
-    UPLOAD_FILE: 'upload-file',
+  BAN_CHANNEL_MEMBERS: 'ban-channel-members',
+  CAST_POLL_VOTE: 'cast-poll-vote',
+  CONNECT_EVENTS: 'connect-events',
+  CREATE_ATTACHMENT: 'create-attachment',
+  DELETE_ANY_MESSAGE: 'delete-any-message',
+  DELETE_CHANNEL: 'delete-channel',
+  DELETE_OWN_MESSAGE: 'delete-own-message',
+  DELIVERY_EVENTS: 'delivery-events',
+  FLAG_MESSAGE: 'flag-message',
+  FREEZE_CHANNEL: 'freeze-channel',
+  JOIN_CHANNEL: 'join-channel',
+  LEAVE_CHANNEL: 'leave-channel',
+  MUTE_CHANNEL: 'mute-channel',
+  PIN_MESSAGE: 'pin-message',
+  QUERY_POLL_VOTES: 'query-poll-votes',
+  QUOTE_MESSAGE: 'quote-message',
+  READ_EVENTS: 'read-events',
+  SEARCH_MESSAGES: 'search-messages',
+  SEND_CUSTOM_EVENTS: 'send-custom-events',
+  SEND_LINKS: 'send-links',
+  SEND_MESSAGE: 'send-message',
+  SEND_POLL: 'send-poll',
+  SEND_REACTION: 'send-reaction',
+  SEND_REPLY: 'send-reply',
+  SEND_RESTRICTED_VISIBILITY_MESSAGE: 'send-restricted-visibility-message',
+  SEND_TYPING_EVENTS: 'send-typing-events',
+  SET_CHANNEL_COOLDOWN: 'set-channel-cooldown',
+  SHARE_LOCATION: 'share-location',
+  SKIP_SLOW_MODE: 'skip-slow-mode',
+  SLOW_MODE: 'slow-mode',
+  TYPING_EVENTS: 'typing-events',
+  UPDATE_ANY_MESSAGE: 'update-any-message',
+  UPDATE_CHANNEL: 'update-channel',
+  UPDATE_CHANNEL_MEMBERS: 'update-channel-members',
+  UPDATE_OWN_MESSAGE: 'update-own-message',
+  UPDATE_THREAD: 'update-thread',
+  UPLOAD_FILE: 'upload-file',
 } as const;
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export type ChannelOwnCapability = typeof ChannelOwnCapability[keyof typeof ChannelOwnCapability]
-
-
-
-
-    export interface ChannelPushPreferencesResponse {
-    chat_level?: string;
-    
-
-        
-    disabled_until?: Date;
-    
-
-        
-    chat_preferences?: ChatPreferencesResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface ChannelResponse {
-    /**
-     * Channel CID (<type>:<id>)
-     */
-    cid: string;
-    
-
-        
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    disabled: boolean;
-    
-
-        
-    /**
-     * Whether channel is frozen or not
-     */
-    frozen: boolean;
-    
-
-        
-    /**
-     * Channel unique ID
-     */
-    id: string;
-    
-
-        
-    /**
-     * Type of the channel
-     */
-    type: string;
-    
-
-        
-    /**
-     * Date/time of the last update
-     */
-    updated_at: Date;
-    
-
-        
-    /**
-     * Custom data for this object
-     */
-    custom: Record<string, any>;
-    
-
-        
-    /**
-     * Whether auto translation is enabled or not
-     */
-    auto_translation_enabled?: boolean;
-    
-
-        
-    /**
-     * Language to translate to when auto translation is active
-     */
-    auto_translation_language?: string;
-    
-
-        
-    /**
-     * Whether this channel is blocked by current user or not
-     */
-    blocked?: boolean;
-    
-
-        
-    /**
-     * Cooldown period after sending each message
-     */
-    cooldown?: number;
-    
-
-        
-    /**
-     * Date/time of deletion
-     */
-    deleted_at?: Date;
-    
-
-        
-    /**
-     * Whether this channel is hidden by current user or not
-     */
-    hidden?: boolean;
-    
-
-        
-    /**
-     * Date since when the message history is accessible
-     */
-    hide_messages_before?: Date;
-    
-
-        
-    /**
-     * Date of the last message sent
-     */
-    last_message_at?: Date;
-    
-
-        
-    /**
-     * Number of members in the channel
-     */
-    member_count?: number;
-    
-
-        
-    /**
-     * Number of messages in the channel
-     */
-    message_count?: number;
-    
-
-        
-    /**
-     * Date of mute expiration
-     */
-    mute_expires_at?: Date;
-    
-
-        
-    /**
-     * Whether this channel is muted or not
-     */
-    muted?: boolean;
-    
-
-        
-    /**
-     * Team the channel belongs to (multi-tenant only)
-     */
-    team?: string;
-    
-
-        
-    /**
-     * Date of the latest truncation of the channel
-     */
-    truncated_at?: Date;
-    
-
-        
-    /**
-     * List of filter tags associated with the channel
-     */
-    filter_tags?: Array<string>;
-    
-
-        
-    /**
-     * List of channel members (max 100)
-     */
-    members?: Array<ChannelMemberResponse>;
-    
-
-        
-    /**
-     * List of channel capabilities of authenticated user
-     */
-    own_capabilities?: Array<ChannelOwnCapability>;
-    
-
-        
-    config?: ChannelConfigWithInfo;
-    
-
-        
-    created_by?: UserResponse;
-    
-
-        
-    truncated_by?: UserResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface ChatDraftPayloadResponse {
-    id: string;
-    
-
-        
-    text: string;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    html?: string;
-    
-
-        
-    mml?: string;
-    
-
-        
-    parent_id?: string;
-    
-
-        
-    poll_id?: string;
-    
-
-        
-    quoted_message_id?: string;
-    
-
-        
-    show_in_channel?: boolean;
-    
-
-        
-    silent?: boolean;
-    
-
-        
-    type?: string;
-    
-
-        
-    attachments?: Array<Attachment>;
-    
-
-        
-    mentioned_users?: Array<UserResponse>;
-    
-
-        }
-    
-
-
-
-
-    export interface ChatDraftResponse {
-    channel_cid: string;
-    
-
-        
-    created_at: Date;
-    
-
-        
-    message: ChatDraftPayloadResponse;
-    
-
-        
-    parent_id?: string;
-    
-
-        
-    parent_message?: ChatMessageResponse;
-    
-
-        
-    quoted_message?: ChatMessageResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface ChatMessageResponse {
-    cid: string;
-    
-
-        
-    created_at: Date;
-    
-
-        
-    deleted_reply_count: number;
-    
-
-        
-    html: string;
-    
-
-        
-    id: string;
-    
-
-        
-    mentioned_channel: boolean;
-    
-
-        
-    mentioned_here: boolean;
-    
-
-        
-    pinned: boolean;
-    
-
-        
-    reply_count: number;
-    
-
-        
-    shadowed: boolean;
-    
-
-        
-    silent: boolean;
-    
-
-        
-    text: string;
-    
-
-        
-    type: string;
-    
-
-        
-    updated_at: Date;
-    
-
-        
-    attachments: Array<Attachment>;
-    
-
-        
-    latest_reactions: Array<ChatReactionResponse>;
-    
-
-        
-    mentioned_users: Array<UserResponse>;
-    
-
-        
-    own_reactions: Array<ChatReactionResponse>;
-    
-
-        
-    restricted_visibility: Array<string>;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    reaction_counts: Record<string, number>;
-    
-
-        
-    reaction_scores: Record<string, number>;
-    
-
-        
-    user: UserResponse;
-    
-
-        
-    command?: string;
-    
-
-        
-    deleted_at?: Date;
-    
-
-        
-    deleted_for_me?: boolean;
-    
-
-        
-    message_text_updated_at?: Date;
-    
-
-        
-    mml?: string;
-    
-
-        
-    parent_id?: string;
-    
-
-        
-    pin_expires?: Date;
-    
-
-        
-    pinned_at?: Date;
-    
-
-        
-    poll_id?: string;
-    
-
-        
-    quoted_message_id?: string;
-    
-
-        
-    show_in_channel?: boolean;
-    
+export type ChannelOwnCapability =
+  (typeof ChannelOwnCapability)[keyof typeof ChannelOwnCapability];
+
+export interface ChannelPushPreferencesResponse {
+  chat_level?: string;
+
+  disabled_until?: Date;
+
+  chat_preferences?: ChatPreferencesResponse;
+}
+
+export interface ChannelResponse {
+  /**
+   * Channel CID (<type>:<id>)
+   */
+  cid: string;
+
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
+
+  disabled: boolean;
+
+  /**
+   * Whether channel is frozen or not
+   */
+  frozen: boolean;
+
+  /**
+   * Channel unique ID
+   */
+  id: string;
+
+  /**
+   * Type of the channel
+   */
+  type: string;
+
+  /**
+   * Date/time of the last update
+   */
+  updated_at: Date;
+
+  /**
+   * Custom data for this object
+   */
+  custom: Record<string, any>;
+
+  /**
+   * Whether auto translation is enabled or not
+   */
+  auto_translation_enabled?: boolean;
+
+  /**
+   * Language to translate to when auto translation is active
+   */
+  auto_translation_language?: string;
 
-        
-    mentioned_group_ids?: Array<string>;
-    
+  /**
+   * Whether this channel is blocked by current user or not
+   */
+  blocked?: boolean;
 
-        
-    mentioned_roles?: Array<string>;
-    
+  /**
+   * Cooldown period after sending each message
+   */
+  cooldown?: number;
 
-        
-    thread_participants?: Array<UserResponse>;
-    
+  /**
+   * Date/time of deletion
+   */
+  deleted_at?: Date;
 
-        
-    draft?: ChatDraftResponse;
-    
+  /**
+   * Whether this channel is hidden by current user or not
+   */
+  hidden?: boolean;
 
-        
-    i18n?: Record<string, string>;
-    
+  /**
+   * Date since when the message history is accessible
+   */
+  hide_messages_before?: Date;
 
-        
-    image_labels?: Record<string, Array<string>>;
-    
+  /**
+   * Date of the last message sent
+   */
+  last_message_at?: Date;
 
-        
-    member?: ChannelMemberResponse;
-    
+  /**
+   * Number of members in the channel
+   */
+  member_count?: number;
 
-        
-    moderation?: ChatModerationV2Response;
-    
+  /**
+   * Number of messages in the channel
+   */
+  message_count?: number;
 
-        
-    pinned_by?: UserResponse;
-    
+  /**
+   * Date of mute expiration
+   */
+  mute_expires_at?: Date;
 
-        
-    poll?: PollResponseData;
-    
+  /**
+   * Whether this channel is muted or not
+   */
+  muted?: boolean;
 
-        
-    quoted_message?: ChatMessageResponse;
-    
+  /**
+   * Team the channel belongs to (multi-tenant only)
+   */
+  team?: string;
 
-        
-    reaction_groups?: Record<string, ChatReactionGroupResponse>;
-    
+  /**
+   * Date of the latest truncation of the channel
+   */
+  truncated_at?: Date;
 
-        
-    reminder?: ChatReminderResponseData;
-    
+  /**
+   * List of filter tags associated with the channel
+   */
+  filter_tags?: string[];
 
-        
-    shared_location?: ChatSharedLocationResponseData;
-    
+  /**
+   * List of channel members (max 100)
+   */
+  members?: ChannelMemberResponse[];
 
-        }
-    
+  /**
+   * List of channel capabilities of authenticated user
+   */
+  own_capabilities?: ChannelOwnCapability[];
 
+  config?: ChannelConfigWithInfo;
 
+  created_by?: UserResponse;
 
+  truncated_by?: UserResponse;
+}
 
-    export interface ChatModerationV2Response {
-    action: string;
-    
+export interface ChatDraftPayloadResponse {
+  id: string;
 
-        
-    original_text: string;
-    
+  text: string;
 
-        
-    blocklist_matched?: string;
-    
+  custom: Record<string, any>;
 
-        
-    platform_circumvented?: boolean;
-    
+  html?: string;
 
-        
-    semantic_filter_matched?: string;
-    
+  mml?: string;
 
-        
-    blocklists_matched?: Array<string>;
-    
+  parent_id?: string;
 
-        
-    image_harms?: Array<string>;
-    
+  poll_id?: string;
 
-        
-    text_harms?: Array<string>;
-    
+  quoted_message_id?: string;
 
-        }
-    
+  show_in_channel?: boolean;
 
+  silent?: boolean;
 
+  type?: string;
 
+  attachments?: Attachment[];
 
-    export interface ChatPreferences {
-    channel_mentions?: string;
-    
+  mentioned_users?: UserResponse[];
+}
 
-        
-    default_preference?: string;
-    
+export interface ChatDraftResponse {
+  channel_cid: string;
 
-        
-    direct_mentions?: string;
-    
+  created_at: Date;
 
-        
-    distinct_channel_messages?: string;
-    
+  message: ChatDraftPayloadResponse;
 
-        
-    group_mentions?: string;
-    
+  parent_id?: string;
 
-        
-    here_mentions?: string;
-    
+  parent_message?: ChatMessageResponse;
 
-        
-    role_mentions?: string;
-    
+  quoted_message?: ChatMessageResponse;
+}
 
-        
-    thread_replies?: string;
-    
+export interface ChatMessageResponse {
+  cid: string;
 
-        }
-    
+  created_at: Date;
 
+  deleted_reply_count: number;
 
+  html: string;
 
+  id: string;
 
-    export interface ChatPreferencesInput {
-    
-        channel_mentions?:| "all" | "none" ;
+  mentioned_channel: boolean;
 
-        
-    
-        default_preference?:| "all" | "none" ;
+  mentioned_here: boolean;
 
-        
-    
-        direct_mentions?:| "all" | "none" ;
+  pinned: boolean;
 
-        
-    
-        group_mentions?:| "all" | "none" ;
+  reply_count: number;
 
-        
-    
-        here_mentions?:| "all" | "none" ;
+  shadowed: boolean;
 
-        
-    
-        role_mentions?:| "all" | "none" ;
+  silent: boolean;
 
-        
-    
-        thread_replies?:| "all" | "none" ;
+  text: string;
 
-        }
-    
+  type: string;
 
+  updated_at: Date;
 
+  attachments: Attachment[];
 
+  latest_reactions: ChatReactionResponse[];
 
-    export interface ChatPreferencesResponse {
-    channel_mentions?: string;
-    
+  mentioned_users: UserResponse[];
 
-        
-    default_preference?: string;
-    
+  own_reactions: ChatReactionResponse[];
 
-        
-    direct_mentions?: string;
-    
+  restricted_visibility: string[];
 
-        
-    group_mentions?: string;
-    
+  custom: Record<string, any>;
 
-        
-    here_mentions?: string;
-    
+  reaction_counts: Record<string, number>;
 
-        
-    role_mentions?: string;
-    
+  reaction_scores: Record<string, number>;
 
-        
-    thread_replies?: string;
-    
+  user: UserResponse;
 
-        }
-    
+  command?: string;
 
+  deleted_at?: Date;
 
+  deleted_for_me?: boolean;
 
+  message_text_updated_at?: Date;
 
-    export interface ChatReactionGroupResponse {
-    count: number;
-    
+  mml?: string;
 
-        
-    first_reaction_at: Date;
-    
+  parent_id?: string;
 
-        
-    last_reaction_at: Date;
-    
+  pin_expires?: Date;
 
-        
-    sum_scores: number;
-    
+  pinned_at?: Date;
 
-        
-    latest_reactions_by: Array<ChatReactionGroupUserResponse>;
-    
+  poll_id?: string;
 
-        }
-    
+  quoted_message_id?: string;
 
+  show_in_channel?: boolean;
 
+  mentioned_group_ids?: string[];
 
+  mentioned_roles?: string[];
 
-    export interface ChatReactionGroupUserResponse {
-    created_at: Date;
-    
+  thread_participants?: UserResponse[];
 
-        
-    user_id: string;
-    
+  draft?: ChatDraftResponse;
 
-        
-    user?: UserResponse;
-    
+  i18n?: Record<string, string>;
 
-        }
-    
+  image_labels?: Record<string, string[]>;
 
+  member?: ChannelMemberResponse;
 
+  moderation?: ChatModerationV2Response;
 
+  pinned_by?: UserResponse;
 
-    export interface ChatReactionResponse {
-    created_at: Date;
-    
+  poll?: PollResponseData;
 
-        
-    message_id: string;
-    
+  quoted_message?: ChatMessageResponse;
 
-        
-    score: number;
-    
+  reaction_groups?: Record<string, ChatReactionGroupResponse>;
 
-        
-    type: string;
-    
+  reminder?: ChatReminderResponseData;
 
-        
-    updated_at: Date;
-    
+  shared_location?: ChatSharedLocationResponseData;
+}
 
-        
-    user_id: string;
-    
+export interface ChatModerationV2Response {
+  action: string;
 
-        
-    custom: Record<string, any>;
-    
+  original_text: string;
 
-        
-    user: UserResponse;
-    
+  blocklist_matched?: string;
 
-        }
-    
+  platform_circumvented?: boolean;
 
+  semantic_filter_matched?: string;
 
+  blocklists_matched?: string[];
 
+  image_harms?: string[];
 
-    export interface ChatReminderResponseData {
-    channel_cid: string;
-    
+  text_harms?: string[];
+}
 
-        
-    created_at: Date;
-    
+export interface ChatPreferences {
+  channel_mentions?: string;
 
-        
-    message_id: string;
-    
+  default_preference?: string;
 
-        
-    updated_at: Date;
-    
+  direct_mentions?: string;
 
-        
-    user_id: string;
-    
+  distinct_channel_messages?: string;
 
-        
-    remind_at?: Date;
-    
+  group_mentions?: string;
 
-        
-    message?: ChatMessageResponse;
-    
+  here_mentions?: string;
 
-        
-    user?: UserResponse;
-    
+  role_mentions?: string;
 
-        }
-    
+  thread_replies?: string;
+}
 
+export interface ChatPreferencesInput {
+  channel_mentions?: 'all' | 'none';
 
+  default_preference?: 'all' | 'none';
 
+  direct_mentions?: 'all' | 'none';
 
-    export interface ChatSharedLocationResponseData {
-    channel_cid: string;
-    
+  group_mentions?: 'all' | 'none';
 
-        
-    created_at: Date;
-    
+  here_mentions?: 'all' | 'none';
 
-        
-    created_by_device_id: string;
-    
+  role_mentions?: 'all' | 'none';
 
-        
-    latitude: number;
-    
+  thread_replies?: 'all' | 'none';
+}
 
-        
-    longitude: number;
-    
+export interface ChatPreferencesResponse {
+  channel_mentions?: string;
 
-        
-    message_id: string;
-    
+  default_preference?: string;
 
-        
-    updated_at: Date;
-    
+  direct_mentions?: string;
 
-        
-    user_id: string;
-    
+  group_mentions?: string;
 
-        
-    end_at?: Date;
-    
+  here_mentions?: string;
 
-        
-    message?: ChatMessageResponse;
-    
+  role_mentions?: string;
 
-        }
-    
+  thread_replies?: string;
+}
 
+export interface ChatReactionGroupResponse {
+  count: number;
 
+  first_reaction_at: Date;
 
+  last_reaction_at: Date;
 
-    export interface ClosedCaptionRuleParameters {
-    threshold?: number;
-    
+  sum_scores: number;
 
-        
-    harm_labels?: Array<string>;
-    
+  latest_reactions_by: ChatReactionGroupUserResponse[];
+}
 
-        
-    llm_harm_labels?: Record<string, string>;
-    
+export interface ChatReactionGroupUserResponse {
+  created_at: Date;
 
-        }
-    
+  user_id: string;
 
+  user?: UserResponse;
+}
 
+export interface ChatReactionResponse {
+  created_at: Date;
 
+  message_id: string;
 
-    export interface CollectionRequest {
-    /**
-     * Name/type of the collection
-     */
-    name: string;
-    
+  score: number;
 
-        
-    /**
-     * Custom data for the collection (required, must contain at least one key)
-     */
-    custom: Record<string, any>;
-    
+  type: string;
 
-        
-    /**
-     * Unique identifier for the collection within its name (optional, will be auto-generated if not provided)
-     */
-    id?: string;
-    
+  updated_at: Date;
 
-        }
-    
+  user_id: string;
 
+  custom: Record<string, any>;
 
+  user: UserResponse;
+}
 
+export interface ChatReminderResponseData {
+  channel_cid: string;
 
-    export interface CollectionResponse {
-    /**
-     * Unique identifier for the collection within its name
-     */
-    id: string;
-    
+  created_at: Date;
 
-        
-    /**
-     * Name/type of the collection
-     */
-    name: string;
-    
+  message_id: string;
 
-        
-    /**
-     * When the collection was created
-     */
-    created_at?: Date;
-    
+  updated_at: Date;
 
-        
-    /**
-     * When the collection was last updated
-     */
-    updated_at?: Date;
-    
+  user_id: string;
 
-        
-    /**
-     * ID of the user who owns this collection
-     */
-    user_id?: string;
-    
+  remind_at?: Date;
 
-        
-    /**
-     * Custom data for the collection
-     */
-    custom?: Record<string, any>;
-    
+  message?: ChatMessageResponse;
 
-        }
-    
+  user?: UserResponse;
+}
 
+export interface ChatSharedLocationResponseData {
+  channel_cid: string;
 
+  created_at: Date;
 
+  created_by_device_id: string;
 
-    export interface Command {
-    /**
-     * Arguments help text, shown in commands auto-completion
-     */
-    args: string;
-    
+  latitude: number;
 
-        
-    /**
-     * Description, shown in commands auto-completion
-     */
-    description: string;
-    
+  longitude: number;
 
-        
-    /**
-     * Unique command name
-     */
-    name: string;
-    
+  message_id: string;
 
-        
-    /**
-     * Set name used for grouping commands
-     */
-    set: string;
-    
+  updated_at: Date;
 
-        
-    /**
-     * Date/time of creation
-     */
-    created_at?: Date;
-    
+  user_id: string;
 
-        
-    /**
-     * Date/time of the last update
-     */
-    updated_at?: Date;
-    
+  end_at?: Date;
 
-        }
-    
+  message?: ChatMessageResponse;
+}
 
+export interface ClosedCaptionRuleParameters {
+  threshold?: number;
 
+  harm_labels?: string[];
 
+  llm_harm_labels?: Record<string, string>;
+}
 
-    export interface CommentAddedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+export interface CollectionRequest {
+  /**
+   * Name/type of the collection
+   */
+  name: string;
 
-        
-    fid: string;
-    
+  /**
+   * Custom data for the collection (required, must contain at least one key)
+   */
+  custom: Record<string, any>;
 
-        
-    activity: ActivityResponse;
-    
+  /**
+   * Unique identifier for the collection within its name (optional, will be auto-generated if not provided)
+   */
+  id?: string;
+}
 
-        
-    comment: CommentResponse;
-    
+export interface CollectionResponse {
+  /**
+   * Unique identifier for the collection within its name
+   */
+  id: string;
 
-        
-    custom: Record<string, any>;
-    
+  /**
+   * Name/type of the collection
+   */
+  name: string;
 
-        
-    /**
-     * The type of event: "feeds.comment.added" in this case
-     */
-    type: string;
-    
+  /**
+   * When the collection was created
+   */
+  created_at?: Date;
 
-        
-    feed_visibility?: string;
-    
+  /**
+   * When the collection was last updated
+   */
+  updated_at?: Date;
 
-        
-    received_at?: Date;
-    
+  /**
+   * ID of the user who owns this collection
+   */
+  user_id?: string;
 
-        
-    user?: UserResponseCommonFields;
-    
+  /**
+   * Custom data for the collection
+   */
+  custom?: Record<string, any>;
+}
 
-        }
-    
+export interface Command {
+  /**
+   * Arguments help text, shown in commands auto-completion
+   */
+  args: string;
 
+  /**
+   * Description, shown in commands auto-completion
+   */
+  description: string;
 
+  /**
+   * Unique command name
+   */
+  name: string;
 
+  /**
+   * Set name used for grouping commands
+   */
+  set: string;
 
-    export interface CommentDeletedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  /**
+   * Date/time of creation
+   */
+  created_at?: Date;
 
-        
-    fid: string;
-    
+  /**
+   * Date/time of the last update
+   */
+  updated_at?: Date;
+}
 
-        
-    comment: CommentResponse;
-    
+export interface CommentAddedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    custom: Record<string, any>;
-    
+  fid: string;
 
-        
-    /**
-     * The type of event: "feeds.comment.deleted" in this case
-     */
-    type: string;
-    
+  activity: ActivityResponse;
 
-        
-    feed_visibility?: string;
-    
+  comment: CommentResponse;
 
-        
-    received_at?: Date;
-    
+  custom: Record<string, any>;
 
-        
-    user?: UserResponseCommonFields;
-    
+  /**
+   * The type of event: "feeds.comment.added" in this case
+   */
+  type: string;
 
-        }
-    
+  feed_visibility?: string;
 
+  received_at?: Date;
 
+  user?: UserResponseCommonFields;
+}
 
+export interface CommentDeletedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-    export interface CommentReactionAddedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  fid: string;
 
-        
-    fid: string;
-    
+  comment: CommentResponse;
 
-        
-    activity: ActivityResponse;
-    
+  custom: Record<string, any>;
 
-        
-    comment: CommentResponse;
-    
+  /**
+   * The type of event: "feeds.comment.deleted" in this case
+   */
+  type: string;
 
-        
-    custom: Record<string, any>;
-    
+  feed_visibility?: string;
 
-        
-    reaction: FeedsReactionResponse;
-    
+  received_at?: Date;
 
-        
-    /**
-     * The type of event: "feeds.comment.reaction.added" in this case
-     */
-    type: string;
-    
+  user?: UserResponseCommonFields;
+}
 
-        
-    feed_visibility?: string;
-    
+export interface CommentReactionAddedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    received_at?: Date;
-    
+  fid: string;
 
-        
-    user?: UserResponseCommonFields;
-    
+  activity: ActivityResponse;
 
-        }
-    
+  comment: CommentResponse;
 
+  custom: Record<string, any>;
 
+  reaction: FeedsReactionResponse;
 
+  /**
+   * The type of event: "feeds.comment.reaction.added" in this case
+   */
+  type: string;
 
-    export interface CommentReactionDeletedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  feed_visibility?: string;
 
-        
-    fid: string;
-    
+  received_at?: Date;
 
-        
-    comment: CommentResponse;
-    
+  user?: UserResponseCommonFields;
+}
 
-        
-    custom: Record<string, any>;
-    
+export interface CommentReactionDeletedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    reaction: FeedsReactionResponse;
-    
+  fid: string;
 
-        
-    /**
-     * The type of reaction that was removed
-     */
-    type: string;
-    
+  comment: CommentResponse;
 
-        
-    feed_visibility?: string;
-    
+  custom: Record<string, any>;
 
-        
-    received_at?: Date;
-    
+  reaction: FeedsReactionResponse;
 
-        }
-    
+  /**
+   * The type of reaction that was removed
+   */
+  type: string;
 
+  feed_visibility?: string;
 
+  received_at?: Date;
+}
 
+export interface CommentReactionUpdatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-    export interface CommentReactionUpdatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  fid: string;
 
-        
-    fid: string;
-    
+  activity: ActivityResponse;
 
-        
-    activity: ActivityResponse;
-    
+  comment: CommentResponse;
 
-        
-    comment: CommentResponse;
-    
+  custom: Record<string, any>;
 
-        
-    custom: Record<string, any>;
-    
+  reaction: FeedsReactionResponse;
 
-        
-    reaction: FeedsReactionResponse;
-    
+  /**
+   * The type of event: "feeds.comment.reaction.updated" in this case
+   */
+  type: string;
 
-        
-    /**
-     * The type of event: "feeds.comment.reaction.updated" in this case
-     */
-    type: string;
-    
+  feed_visibility?: string;
 
-        
-    feed_visibility?: string;
-    
+  received_at?: Date;
 
-        
-    received_at?: Date;
-    
+  user?: UserResponseCommonFields;
+}
 
-        
-    user?: UserResponseCommonFields;
-    
+export interface CommentResponse {
+  bookmark_count: number;
 
-        }
-    
+  /**
+   * Confidence score of the comment
+   */
+  confidence_score: number;
 
+  /**
+   * When the comment was created
+   */
+  created_at: Date;
 
+  /**
+   * Number of downvotes for this comment
+   */
+  downvote_count: number;
 
+  /**
+   * Unique identifier for the comment
+   */
+  id: string;
 
-    export interface CommentResponse {
-    bookmark_count: number;
-    
+  /**
+   * ID of the object this comment is associated with
+   */
+  object_id: string;
 
-        
-    /**
-     * Confidence score of the comment
-     */
-    confidence_score: number;
-    
+  /**
+   * Type of the object this comment is associated with
+   */
+  object_type: string;
 
-        
-    /**
-     * When the comment was created
-     */
-    created_at: Date;
-    
+  /**
+   * Number of reactions to this comment
+   */
+  reaction_count: number;
 
-        
-    /**
-     * Number of downvotes for this comment
-     */
-    downvote_count: number;
-    
+  /**
+   * Number of replies to this comment
+   */
+  reply_count: number;
 
-        
-    /**
-     * Unique identifier for the comment
-     */
-    id: string;
-    
+  /**
+   * Score of the comment based on reactions
+   */
+  score: number;
 
-        
-    /**
-     * ID of the object this comment is associated with
-     */
-    object_id: string;
-    
+  /**
+   * Status of the comment. One of: active, deleted, removed, hidden
+   */
 
-        
-    /**
-     * Type of the object this comment is associated with
-     */
-    object_type: string;
-    
+  status: 'active' | 'deleted' | 'removed' | 'hidden' | 'shadow_blocked';
 
-        
-    /**
-     * Number of reactions to this comment
-     */
-    reaction_count: number;
-    
+  /**
+   * When the comment was last updated
+   */
+  updated_at: Date;
 
-        
-    /**
-     * Number of replies to this comment
-     */
-    reply_count: number;
-    
+  /**
+   * Number of upvotes for this comment
+   */
+  upvote_count: number;
 
-        
-    /**
-     * Score of the comment based on reactions
-     */
-    score: number;
-    
+  /**
+   * Users mentioned in the comment
+   */
+  mentioned_users: UserResponse[];
 
-        
-    /**
-     * Status of the comment. One of: active, deleted, removed, hidden
-     */
-    
-        status:| "active" | "deleted" | "removed" | "hidden" | "shadow_blocked" ;
+  /**
+   * Current user's reactions to this activity
+   */
+  own_reactions: FeedsReactionResponse[];
 
-        
-    /**
-     * When the comment was last updated
-     */
-    updated_at: Date;
-    
+  user: UserResponse;
 
-        
-    /**
-     * Number of upvotes for this comment
-     */
-    upvote_count: number;
-    
+  /**
+   * Controversy score of the comment
+   */
+  controversy_score?: number;
 
-        
-    /**
-     * Users mentioned in the comment
-     */
-    mentioned_users: Array<UserResponse>;
-    
+  /**
+   * When the comment was deleted
+   */
+  deleted_at?: Date;
 
-        
-    /**
-     * Current user's reactions to this activity
-     */
-    own_reactions: Array<FeedsReactionResponse>;
-    
+  /**
+   * When the comment was last edited
+   */
+  edited_at?: Date;
 
-        
-    user: UserResponse;
-    
+  /**
+   * ID of parent comment for nested replies
+   */
+  parent_id?: string;
 
-        
-    /**
-     * Controversy score of the comment
-     */
-    controversy_score?: number;
-    
+  /**
+   * Text content of the comment
+   */
+  text?: string;
 
-        
-    /**
-     * When the comment was deleted
-     */
-    deleted_at?: Date;
-    
+  /**
+   * Attachments associated with the comment
+   */
+  attachments?: Attachment[];
 
-        
-    /**
-     * When the comment was last edited
-     */
-    edited_at?: Date;
-    
+  /**
+   * Recent reactions to the comment
+   */
+  latest_reactions?: FeedsReactionResponse[];
 
-        
-    /**
-     * ID of parent comment for nested replies
-     */
-    parent_id?: string;
-    
+  /**
+   * Custom data for the comment
+   */
+  custom?: Record<string, any>;
 
-        
-    /**
-     * Text content of the comment
-     */
-    text?: string;
-    
+  moderation?: ModerationV2Response;
 
-        
-    /**
-     * Attachments associated with the comment
-     */
-    attachments?: Array<Attachment>;
-    
+  /**
+   * Grouped reactions by type
+   */
+  reaction_groups?: Record<string, FeedsReactionGroupResponse>;
+}
 
-        
-    /**
-     * Recent reactions to the comment
-     */
-    latest_reactions?: Array<FeedsReactionResponse>;
-    
+export interface CommentRestoredEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    /**
-     * Custom data for the comment
-     */
-    custom?: Record<string, any>;
-    
+  fid: string;
 
-        
-    moderation?: ModerationV2Response;
-    
+  comment: CommentResponse;
 
-        
-    /**
-     * Grouped reactions by type
-     */
-    reaction_groups?: Record<string, FeedsReactionGroupResponse>;
-    
+  custom: Record<string, any>;
 
-        }
-    
+  /**
+   * The type of event: "feeds.comment.restored" in this case
+   */
+  type: string;
 
+  feed_visibility?: string;
 
+  received_at?: Date;
 
+  user?: UserResponseCommonFields;
+}
 
-    export interface CommentRestoredEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+export interface CommentUpdatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    fid: string;
-    
+  fid: string;
 
-        
-    comment: CommentResponse;
-    
+  comment: CommentResponse;
 
-        
-    custom: Record<string, any>;
-    
+  custom: Record<string, any>;
 
-        
-    /**
-     * The type of event: "feeds.comment.restored" in this case
-     */
-    type: string;
-    
+  /**
+   * The type of event: "feeds.comment.updated" in this case
+   */
+  type: string;
 
-        
-    feed_visibility?: string;
-    
+  feed_visibility?: string;
 
-        
-    received_at?: Date;
-    
+  received_at?: Date;
 
-        
-    user?: UserResponseCommonFields;
-    
+  user?: UserResponseCommonFields;
+}
 
-        }
-    
+export interface ConfigResponse {
+  /**
+   * Whether moderation should be performed asynchronously
+   */
+  async: boolean;
 
+  /**
+   * When the configuration was created
+   */
+  created_at: Date;
 
+  /**
+   * Unique identifier for the moderation configuration
+   */
+  key: string;
 
+  /**
+   * Team associated with the configuration
+   */
+  team: string;
 
-    export interface CommentUpdatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  /**
+   * When the configuration was last updated
+   */
+  updated_at: Date;
 
-        
-    fid: string;
-    
+  supported_video_call_harm_types: string[];
 
-        
-    comment: CommentResponse;
-    
+  /**
+   * Configurable image moderation label definitions for dashboard rendering
+   */
+  ai_image_label_definitions?: AIImageLabelDefinition[];
 
-        
-    custom: Record<string, any>;
-    
+  /**
+   * Names of Bodyguard credential profiles registered on this app. The dashboard uses this list to render the profile picker on the AI Text section.
+   */
+  available_bodyguard_profiles?: BodyguardProfileSummary[];
 
-        
-    /**
-     * The type of event: "feeds.comment.updated" in this case
-     */
-    type: string;
-    
+  ai_image_config?: AIImageConfig;
 
-        
-    feed_visibility?: string;
-    
+  /**
+   * Available L2 subclassifications per L1 image moderation label, based on the active provider
+   */
+  ai_image_subclassifications?: Record<string, string[]>;
 
-        
-    received_at?: Date;
-    
+  ai_text_config?: AITextConfig;
 
-        
-    user?: UserResponseCommonFields;
-    
+  ai_video_config?: AIVideoConfig;
 
-        }
-    
+  automod_platform_circumvention_config?: AutomodPlatformCircumventionConfig;
 
+  automod_semantic_filters_config?: AutomodSemanticFiltersConfig;
 
+  automod_toxicity_config?: AutomodToxicityConfig;
 
+  block_list_config?: BlockListConfig;
 
-    export interface ConfigResponse {
-    /**
-     * Whether moderation should be performed asynchronously
-     */
-    async: boolean;
-    
+  llm_config?: LLMConfig;
 
-        
-    /**
-     * When the configuration was created
-     */
-    created_at: Date;
-    
+  velocity_filter_config?: VelocityFilterConfig;
 
-        
-    /**
-     * Unique identifier for the moderation configuration
-     */
-    key: string;
-    
+  video_call_rule_config?: VideoCallRuleConfig;
+}
 
-        
-    /**
-     * Team associated with the configuration
-     */
-    team: string;
-    
+export interface ConnectUserDetailsRequest {
+  id: string;
 
-        
-    /**
-     * When the configuration was last updated
-     */
-    updated_at: Date;
-    
+  image?: string;
 
-        
-    supported_video_call_harm_types: Array<string>;
-    
+  invisible?: boolean;
 
-        
-    /**
-     * Configurable image moderation label definitions for dashboard rendering
-     */
-    ai_image_label_definitions?: Array<AIImageLabelDefinition>;
-    
+  language?: string;
 
-        
-    /**
-     * Names of Bodyguard credential profiles registered on this app. The dashboard uses this list to render the profile picker on the AI Text section.
-     */
-    available_bodyguard_profiles?: Array<BodyguardProfileSummary>;
-    
+  name?: string;
 
-        
-    ai_image_config?: AIImageConfig;
-    
+  custom?: Record<string, any>;
 
-        
-    /**
-     * Available L2 subclassifications per L1 image moderation label, based on the active provider
-     */
-    ai_image_subclassifications?: Record<string, Array<string>>;
-    
+  privacy_settings?: PrivacySettingsResponse;
+}
 
-        
-    ai_text_config?: AITextConfig;
-    
+export interface ContentCountRuleParameters {
+  threshold?: number;
 
-        
-    ai_video_config?: AIVideoConfig;
-    
+  time_window?: string;
+}
 
-        
-    automod_platform_circumvention_config?: AutomodPlatformCircumventionConfig;
-    
+export interface CreateBlockListRequest {
+  /**
+   * Block list name
+   */
+  name: string;
 
-        
-    automod_semantic_filters_config?: AutomodSemanticFiltersConfig;
-    
+  /**
+   * List of words to block
+   */
+  words: string[];
 
-        
-    automod_toxicity_config?: AutomodToxicityConfig;
-    
+  is_leet_check_enabled?: boolean;
 
-        
-    block_list_config?: BlockListConfig;
-    
+  is_plural_check_enabled?: boolean;
 
-        
-    llm_config?: LLMConfig;
-    
+  team?: string;
 
-        
-    velocity_filter_config?: VelocityFilterConfig;
-    
+  /**
+   * Block list type. One of: regex, domain, domain_allowlist, email, email_allowlist, word
+   */
 
-        
-    video_call_rule_config?: VideoCallRuleConfig;
-    
+  type?:
+    | 'regex'
+    | 'domain'
+    | 'domain_allowlist'
+    | 'email'
+    | 'email_allowlist'
+    | 'word';
+}
 
-        }
-    
+export interface CreateBlockListResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
+  blocklist?: BlockListResponse;
+}
 
+export interface CreateCollectionsRequest {
+  /**
+   * List of collections to create
+   */
+  collections: CollectionRequest[];
+}
 
+export interface CreateCollectionsResponse {
+  duration: string;
 
-    export interface ConnectUserDetailsRequest {
-    id: string;
-    
+  /**
+   * List of created collections
+   */
+  collections: CollectionResponse[];
+}
 
-        
-    image?: string;
-    
+export interface CreateDeviceRequest {
+  /**
+   * Device ID
+   */
+  id: string;
 
-        
-    invisible?: boolean;
-    
+  /**
+   * Push provider
+   */
 
-        
-    language?: string;
-    
+  push_provider: 'firebase' | 'apn' | 'huawei' | 'xiaomi';
 
-        
-    name?: string;
-    
+  /**
+   * Push provider name
+   */
+  push_provider_name?: string;
 
-        
-    custom?: Record<string, any>;
-    
+  /**
+   * When true the token is for Apple VoIP push notifications
+   */
+  voip_token?: boolean;
+}
 
-        
-    privacy_settings?: PrivacySettingsResponse;
-    
+export interface CreateFeedsBatchRequest {
+  /**
+   * List of feeds to create
+   */
+  feeds: FeedRequest[];
 
-        }
-    
+  /**
+   * If true, enriches the created feeds with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+   */
+  enrich_own_fields?: boolean;
+}
 
+export interface CreateFeedsBatchResponse {
+  duration: string;
 
+  /**
+   * List of created feeds
+   */
+  feeds: FeedResponse[];
+}
 
+export interface CreateGuestRequest {
+  user: UserRequest;
+}
 
-    export interface ContentCountRuleParameters {
-    threshold?: number;
-    
+export interface CreateGuestResponse {
+  /**
+   * the access token to authenticate the user
+   */
+  access_token: string;
 
-        
-    time_window?: string;
-    
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-        }
-    
+  user: UserResponse;
+}
 
+export interface CreatePollOptionRequest {
+  /**
+   * Option text
+   */
+  text: string;
 
+  custom?: Record<string, any>;
+}
 
+export interface CreatePollRequest {
+  /**
+   * The name of the poll
+   */
+  name: string;
 
-    export interface CreateBlockListRequest {
-    /**
-     * Block list name
-     */
-    name: string;
-    
+  /**
+   * Indicates whether users can suggest user defined answers
+   */
+  allow_answers?: boolean;
 
-        
-    /**
-     * List of words to block
-     */
-    words: Array<string>;
-    
+  allow_user_suggested_options?: boolean;
 
-        
-    is_leet_check_enabled?: boolean;
-    
+  /**
+   * A description of the poll
+   */
+  description?: string;
 
-        
-    is_plural_check_enabled?: boolean;
-    
+  /**
+   * Indicates whether users can cast multiple votes
+   */
+  enforce_unique_vote?: boolean;
 
-        
-    team?: string;
-    
+  id?: string;
 
-        
-    /**
-     * Block list type. One of: regex, domain, domain_allowlist, email, email_allowlist, word
-     */
-    
-        type?:| "regex" | "domain" | "domain_allowlist" | "email" | "email_allowlist" | "word" ;
+  /**
+   * Indicates whether the poll is open for voting
+   */
+  is_closed?: boolean;
 
-        }
-    
+  /**
+   * Indicates the maximum amount of votes a user can cast
+   */
+  max_votes_allowed?: number;
 
+  voting_visibility?: 'anonymous' | 'public';
 
+  options?: PollOptionInput[];
 
+  custom?: Record<string, any>;
+}
 
-    export interface CreateBlockListResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+export interface CreateUserGroupRequest {
+  /**
+   * The user friendly name of the user group
+   */
+  name: string;
 
-        
-    blocklist?: BlockListResponse;
-    
+  /**
+   * An optional description for the group
+   */
+  description?: string;
 
-        }
-    
+  /**
+   * Optional user group ID. If not provided, a UUID v7 will be generated
+   */
+  id?: string;
 
+  /**
+   * Optional team ID to scope the group to a team
+   */
+  team_id?: string;
 
+  /**
+   * Optional initial list of user IDs to add as members
+   */
+  member_ids?: string[];
+}
 
+export interface CreateUserGroupResponse {
+  duration: string;
 
-    export interface CreateCollectionsRequest {
-    /**
-     * List of collections to create
-     */
-    collections: Array<CollectionRequest>;
-    
+  user_group?: UserGroupResponse;
+}
 
-        }
-    
+export interface CustomActionRequestPayload {
+  /**
+   * Custom action identifier
+   */
+  id?: string;
 
+  /**
+   * Custom action options
+   */
+  options?: Record<string, any>;
+}
 
+export interface Data {
+  id: string;
+}
 
+export interface DecayFunctionConfig {
+  base?: string;
 
-    export interface CreateCollectionsResponse {
-    duration: string;
-    
+  decay?: string;
 
-        
-    /**
-     * List of created collections
-     */
-    collections: Array<CollectionResponse>;
-    
+  direction?: string;
 
-        }
-    
+  offset?: string;
 
+  origin?: string;
 
+  scale?: string;
+}
 
+export interface DeleteActionConfigResponse {
+  /**
+   * Number of action configs deleted (0 or 1)
+   */
+  deleted: number;
 
-    export interface CreateDeviceRequest {
-    /**
-     * Device ID
-     */
-    id: string;
-    
+  duration: string;
+}
 
-        
-    /**
-     * Push provider
-     */
-    
-        push_provider:| "firebase" | "apn" | "huawei" | "xiaomi" ;
+export interface DeleteActivitiesRequest {
+  /**
+   * List of activity IDs to delete
+   */
+  ids: string[];
 
-        
-    /**
-     * Push provider name
-     */
-    push_provider_name?: string;
-    
+  /**
+   * Whether to also delete any notification activities created from mentions in these activities
+   */
+  delete_notification_activity?: boolean;
 
-        
-    /**
-     * When true the token is for Apple VoIP push notifications
-     */
-    voip_token?: boolean;
-    
+  /**
+   * Whether to permanently delete the activities
+   */
+  hard_delete?: boolean;
+}
 
-        }
-    
+export interface DeleteActivitiesResponse {
+  duration: string;
 
+  /**
+   * List of activity IDs that were successfully deleted
+   */
+  deleted_ids: string[];
+}
 
+export interface DeleteActivityReactionResponse {
+  duration: string;
 
+  activity: ActivityResponse;
 
-    export interface CreateFeedsBatchRequest {
-    /**
-     * List of feeds to create
-     */
-    feeds: Array<FeedRequest>;
-    
+  reaction: FeedsReactionResponse;
+}
 
-        
-    /**
-     * If true, enriches the created feeds with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-     */
-    enrich_own_fields?: boolean;
-    
+export interface DeleteActivityRequestPayload {
+  /**
+   * ID of the activity to delete (alternative to item_id)
+   */
+  entity_id?: string;
 
-        }
-    
+  /**
+   * Type of the entity (required for delete_activity to distinguish v2 vs v3)
+   */
+  entity_type?: string;
 
+  /**
+   * Whether to permanently delete the activity
+   */
+  hard_delete?: boolean;
 
+  /**
+   * Reason for deletion
+   */
+  reason?: string;
+}
 
+export interface DeleteActivityResponse {
+  duration: string;
+}
 
-    export interface CreateFeedsBatchResponse {
-    duration: string;
-    
+export interface DeleteBookmarkFolderResponse {
+  duration: string;
+}
 
-        
-    /**
-     * List of created feeds
-     */
-    feeds: Array<FeedResponse>;
-    
+export interface DeleteBookmarkResponse {
+  duration: string;
 
-        }
-    
+  bookmark: BookmarkResponse;
+}
 
+export interface DeleteCollectionsResponse {
+  duration: string;
+}
 
+export interface DeleteCommentBookmarkResponse {
+  duration: string;
 
+  bookmark: BookmarkResponse;
+}
 
-    export interface CreateGuestRequest {
-    user: UserRequest;
-    
+export interface DeleteCommentReactionResponse {
+  duration: string;
 
-        }
-    
+  comment: CommentResponse;
 
+  reaction: FeedsReactionResponse;
+}
 
+export interface DeleteCommentRequestPayload {
+  /**
+   * ID of the comment to delete (alternative to item_id)
+   */
+  entity_id?: string;
 
+  /**
+   * Type of the entity
+   */
+  entity_type?: string;
 
-    export interface CreateGuestResponse {
-    /**
-     * the access token to authenticate the user
-     */
-    access_token: string;
-    
+  /**
+   * Whether to permanently delete the comment
+   */
+  hard_delete?: boolean;
 
-        
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  /**
+   * Reason for deletion
+   */
+  reason?: string;
+}
 
-        
-    user: UserResponse;
-    
+export interface DeleteCommentResponse {
+  duration: string;
 
-        }
-    
+  activity: ActivityResponse;
 
+  comment: CommentResponse;
+}
 
+export interface DeleteFeedResponse {
+  duration: string;
 
+  /**
+   * The ID of the async task that will handle feed cleanup and hard deletion
+   */
+  task_id: string;
+}
 
-    export interface CreatePollOptionRequest {
-    /**
-     * Option text
-     */
-    text: string;
-    
+export interface DeleteMessageRequestPayload {
+  /**
+   * ID of the message to delete (alternative to item_id)
+   */
+  entity_id?: string;
 
-        
-    custom?: Record<string, any>;
-    
+  /**
+   * Type of the entity
+   */
+  entity_type?: string;
 
-        }
-    
+  /**
+   * Whether to permanently delete the message
+   */
+  hard_delete?: boolean;
 
+  /**
+   * Reason for deletion
+   */
+  reason?: string;
+}
 
+export interface DeleteModerationConfigResponse {
+  duration: string;
+}
 
+export interface DeleteReactionRequestPayload {
+  /**
+   * ID of the reaction to delete (alternative to item_id)
+   */
+  entity_id?: string;
 
-    export interface CreatePollRequest {
-    /**
-     * The name of the poll
-     */
-    name: string;
-    
+  /**
+   * Type of the entity
+   */
+  entity_type?: string;
 
-        
-    /**
-     * Indicates whether users can suggest user defined answers
-     */
-    allow_answers?: boolean;
-    
+  /**
+   * Whether to permanently delete the reaction
+   */
+  hard_delete?: boolean;
 
-        
-    allow_user_suggested_options?: boolean;
-    
+  /**
+   * Reason for deletion
+   */
+  reason?: string;
+}
 
-        
-    /**
-     * A description of the poll
-     */
-    description?: string;
-    
+export interface DeleteUserRequestPayload {
+  /**
+   * Also delete all user conversations
+   */
+  delete_conversation_channels?: boolean;
 
-        
-    /**
-     * Indicates whether users can cast multiple votes
-     */
-    enforce_unique_vote?: boolean;
-    
+  /**
+   * Delete flagged feeds content
+   */
+  delete_feeds_content?: boolean;
 
-        
-    id?: string;
-    
+  /**
+   * ID of the user to delete (alternative to item_id)
+   */
+  entity_id?: string;
 
-        
-    /**
-     * Indicates whether the poll is open for voting
-     */
-    is_closed?: boolean;
-    
+  /**
+   * Type of the entity
+   */
+  entity_type?: string;
 
-        
-    /**
-     * Indicates the maximum amount of votes a user can cast
-     */
-    max_votes_allowed?: number;
-    
+  /**
+   * Whether to permanently delete the user
+   */
+  hard_delete?: boolean;
 
-        
-    
-        voting_visibility?:| "anonymous" | "public" ;
+  /**
+   * Also delete all user messages
+   */
+  mark_messages_deleted?: boolean;
 
-        
-    options?: Array<PollOptionInput>;
-    
+  /**
+   * Reason for deletion
+   */
+  reason?: string;
+}
 
-        
-    custom?: Record<string, any>;
-    
+export interface DeliveryReceiptsResponse {
+  enabled: boolean;
+}
 
-        }
-    
+export interface DeviceResponse {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
+  /**
+   * Device ID
+   */
+  id: string;
 
+  /**
+   * Push provider
+   */
+  push_provider: string;
 
+  /**
+   * User ID
+   */
+  user_id: string;
 
-    export interface CreateUserGroupRequest {
-    /**
-     * The user friendly name of the user group
-     */
-    name: string;
-    
+  /**
+   * Whether device is disabled or not
+   */
+  disabled?: boolean;
 
-        
-    /**
-     * An optional description for the group
-     */
-    description?: string;
-    
+  /**
+   * Reason explaining why device had been disabled
+   */
+  disabled_reason?: string;
 
-        
-    /**
-     * Optional user group ID. If not provided, a UUID v7 will be generated
-     */
-    id?: string;
-    
+  /**
+   * Push provider name
+   */
+  push_provider_name?: string;
 
-        
-    /**
-     * Optional team ID to scope the group to a team
-     */
-    team_id?: string;
-    
+  /**
+   * When true the token is for Apple VoIP push notifications
+   */
+  voip?: boolean;
+}
 
-        
-    /**
-     * Optional initial list of user IDs to add as members
-     */
-    member_ids?: Array<string>;
-    
+export interface DraftPayloadResponse {
+  /**
+   * Message ID is unique string identifier of the message
+   */
+  id: string;
 
-        }
-    
+  /**
+   * Text of the message
+   */
+  text: string;
 
+  custom: Record<string, any>;
 
+  /**
+   * Contains HTML markup of the message
+   */
+  html?: string;
 
+  /**
+   * MML content of the message
+   */
+  mml?: string;
 
-    export interface CreateUserGroupResponse {
-    duration: string;
-    
+  /**
+   * ID of parent message (thread)
+   */
+  parent_id?: string;
 
-        
-    user_group?: UserGroupResponse;
-    
+  /**
+   * Identifier of the poll to include in the message
+   */
+  poll_id?: string;
 
-        }
-    
+  quoted_message_id?: string;
 
+  /**
+   * Whether thread reply should be shown in the channel as well
+   */
+  show_in_channel?: boolean;
 
+  /**
+   * Whether message is silent or not
+   */
+  silent?: boolean;
 
+  /**
+   * Contains type of the message. One of: regular, system
+   */
+  type?: string;
 
-    export interface CustomActionRequestPayload {
-    /**
-     * Custom action identifier
-     */
-    id?: string;
-    
+  /**
+   * Array of message attachments
+   */
+  attachments?: Attachment[];
 
-        
-    /**
-     * Custom action options
-     */
-    options?: Record<string, any>;
-    
+  /**
+   * List of mentioned users
+   */
+  mentioned_users?: UserResponse[];
+}
 
-        }
-    
+export interface DraftResponse {
+  channel_cid: string;
 
+  created_at: Date;
 
+  message: DraftPayloadResponse;
 
+  parent_id?: string;
 
-    export interface Data {
-    id: string;
-    
+  channel?: ChannelResponse;
 
-        }
-    
+  parent_message?: MessageResponse;
 
+  quoted_message?: MessageResponse;
+}
 
+export interface EnrichedActivity {
+  foreign_id?: string;
 
+  id?: string;
 
-    export interface DecayFunctionConfig {
-    base?: string;
-    
+  score?: number;
 
-        
-    decay?: string;
-    
+  verb?: string;
 
-        
-    direction?: string;
-    
+  to?: string[];
 
-        
-    offset?: string;
-    
+  actor?: Data;
 
-        
-    origin?: string;
-    
+  latest_reactions?: Record<string, EnrichedReaction[]>;
 
-        
-    scale?: string;
-    
+  object?: Data;
 
-        }
-    
+  origin?: Data;
 
+  own_reactions?: Record<string, EnrichedReaction[]>;
 
+  reaction_counts?: Record<string, number>;
 
+  target?: Data;
+}
 
-    export interface DeleteActionConfigResponse {
-    /**
-     * Number of action configs deleted (0 or 1)
-     */
-    deleted: number;
-    
+export interface EnrichedCollectionResponse {
+  /**
+   * Unique identifier for the collection within its name
+   */
+  id: string;
 
-        
-    duration: string;
-    
+  /**
+   * Name/type of the collection
+   */
+  name: string;
 
-        }
-    
+  /**
+   * Enrichment status of the collection. One of: ok, notfound
+   */
 
+  status: 'ok' | 'notfound';
 
+  /**
+   * When the collection was created
+   */
+  created_at?: Date;
 
+  /**
+   * When the collection was last updated
+   */
+  updated_at?: Date;
 
-    export interface DeleteActivitiesRequest {
-    /**
-     * List of activity IDs to delete
-     */
-    ids: Array<string>;
-    
+  /**
+   * ID of the user who owns this collection
+   */
+  user_id?: string;
 
-        
-    /**
-     * Whether to also delete any notification activities created from mentions in these activities
-     */
-    delete_notification_activity?: boolean;
-    
+  /**
+   * Custom data for the collection
+   */
+  custom?: Record<string, any>;
+}
 
-        
-    /**
-     * Whether to permanently delete the activities
-     */
-    hard_delete?: boolean;
-    
+export interface EnrichedReaction {
+  activity_id: string;
 
-        }
-    
+  kind: string;
 
+  user_id: string;
 
+  id?: string;
 
+  parent?: string;
 
-    export interface DeleteActivitiesResponse {
-    duration: string;
-    
+  target_feeds?: string[];
 
-        
-    /**
-     * List of activity IDs that were successfully deleted
-     */
-    deleted_ids: Array<string>;
-    
+  children_counts?: Record<string, number>;
 
-        }
-    
+  created_at?: Time;
 
+  data?: Record<string, any>;
 
+  latest_children?: Record<string, EnrichedReaction[]>;
 
+  own_children?: Record<string, EnrichedReaction[]>;
 
-    export interface DeleteActivityReactionResponse {
-    duration: string;
-    
+  updated_at?: Time;
 
-        
-    activity: ActivityResponse;
-    
+  user?: Data;
+}
 
-        
-    reaction: FeedsReactionResponse;
-    
+export interface EnrichmentOptions {
+  /**
+   * Default: false. When true, includes fetching and enriching own_followings (follows where activity author's feeds follow current user's feeds).
+   */
+  enrich_own_followings?: boolean;
 
-        }
-    
+  /**
+   * Controls the top-level flat 'activities' array for aggregated feeds. For new apps, defaults to false (excluded); set to true to include. For older apps, defaults to true (included) for backward compatibility; set to false to exclude.
+   */
+  include_flat_activities?: boolean;
 
+  /**
+   * Default: false. When true, includes score_vars in activity responses containing variable values used at ranking time.
+   */
+  include_score_vars?: boolean;
 
+  /**
+   * Default: false. When true, skips all activity enrichments.
+   */
+  skip_activity?: boolean;
 
+  /**
+   * Default: false. When true, skips enriching collections on activities.
+   */
+  skip_activity_collections?: boolean;
 
-    export interface DeleteActivityRequestPayload {
-    /**
-     * ID of the activity to delete (alternative to item_id)
-     */
-    entity_id?: string;
-    
+  /**
+   * Default: false. When true, skips enriching comments on activities.
+   */
+  skip_activity_comments?: boolean;
 
-        
-    /**
-     * Type of the entity (required for delete_activity to distinguish v2 vs v3)
-     */
-    entity_type?: string;
-    
+  /**
+   * Default: false. When true, skips enriching current_feed on activities. Note: CurrentFeed is still computed for permission checks, but enrichment is skipped.
+   */
+  skip_activity_current_feed?: boolean;
 
-        
-    /**
-     * Whether to permanently delete the activity
-     */
-    hard_delete?: boolean;
-    
+  /**
+   * Default: false. When true, skips enriching mentioned users on activities.
+   */
+  skip_activity_mentioned_users?: boolean;
 
-        
-    /**
-     * Reason for deletion
-     */
-    reason?: string;
-    
+  /**
+   * Default: false. When true, skips enriching own bookmarks on activities.
+   */
+  skip_activity_own_bookmarks?: boolean;
 
-        }
-    
+  /**
+   * Default: false. When true, skips enriching parent activities.
+   */
+  skip_activity_parents?: boolean;
 
+  /**
+   * Default: false. When true, skips enriching poll data on activities.
+   */
+  skip_activity_poll?: boolean;
 
+  /**
+   * Default: false. When true, skips fetching and enriching latest and own reactions on activities. Note: If reactions are already denormalized in the database, they will still be included.
+   */
+  skip_activity_reactions?: boolean;
 
+  /**
+   * Default: false. When true, skips refreshing image URLs on activities.
+   */
+  skip_activity_refresh_image_urls?: boolean;
 
-    export interface DeleteActivityResponse {
-    duration: string;
-    
+  /**
+   * Default: false. When true, skips all enrichments.
+   */
+  skip_all?: boolean;
 
-        }
-    
+  /**
+   * Default: false. When true, skips enriching user data on feed members.
+   */
+  skip_feed_member_user?: boolean;
 
+  /**
+   * Default: false. When true, skips fetching and enriching followers. Note: If followers_pagination is explicitly provided, followers will be fetched regardless of this setting.
+   */
+  skip_followers?: boolean;
 
+  /**
+   * Default: false. When true, skips fetching and enriching following. Note: If following_pagination is explicitly provided, following will be fetched regardless of this setting.
+   */
+  skip_following?: boolean;
 
+  /**
+   * Default: false. When true, skips computing and including capabilities for feeds.
+   */
+  skip_own_capabilities?: boolean;
 
-    export interface DeleteBookmarkFolderResponse {
-    duration: string;
-    
+  /**
+   * Default: false. When true, skips fetching and enriching own_follows (follows where user's feeds follow target feeds).
+   */
+  skip_own_follows?: boolean;
 
-        }
-    
+  /**
+   * Default: false. When true, skips enriching pinned activities.
+   */
+  skip_pins?: boolean;
+}
 
+export interface EntityCreatorResponse {
+  /**
+   * Number of minor actions performed on the user
+   */
+  ban_count: number;
 
+  banned: boolean;
 
+  created_at: Date;
 
-    export interface DeleteBookmarkResponse {
-    duration: string;
-    
+  /**
+   * Number of major actions performed on the user
+   */
+  deleted_content_count: number;
 
-        
-    bookmark: BookmarkResponse;
-    
+  /**
+   * Number of flag actions performed on the user
+   */
+  flagged_count: number;
 
-        }
-    
+  id: string;
 
+  language: string;
 
+  online: boolean;
 
+  role: string;
 
-    export interface DeleteCollectionsResponse {
-    duration: string;
-    
+  updated_at: Date;
 
-        }
-    
+  blocked_user_ids: string[];
 
+  teams: string[];
 
+  custom: Record<string, any>;
 
+  avg_response_time?: number;
 
-    export interface DeleteCommentBookmarkResponse {
-    duration: string;
-    
+  deactivated_at?: Date;
 
-        
-    bookmark: BookmarkResponse;
-    
+  deleted_at?: Date;
 
-        }
-    
+  image?: string;
 
+  last_active?: Date;
 
+  name?: string;
 
+  revoke_tokens_issued_before?: Date;
 
-    export interface DeleteCommentReactionResponse {
-    duration: string;
-    
+  teams_role?: Record<string, string>;
+}
 
-        
-    comment: CommentResponse;
-    
+export interface EscalatePayload {
+  /**
+   * Additional context for the reviewer
+   */
+  notes?: string;
 
-        
-    reaction: FeedsReactionResponse;
-    
+  /**
+   * Priority of the escalation (low, medium, high)
+   */
+  priority?: string;
 
-        }
-    
+  /**
+   * Reason for the escalation (from configured escalation_reasons)
+   */
+  reason?: string;
+}
 
+export interface EscalationMetadata {
+  notes?: string;
 
+  priority?: string;
 
+  reason?: string;
+}
 
-    export interface DeleteCommentRequestPayload {
-    /**
-     * ID of the comment to delete (alternative to item_id)
-     */
-    entity_id?: string;
-    
+export interface FeedCreatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    /**
-     * Type of the entity
-     */
-    entity_type?: string;
-    
+  fid: string;
 
-        
-    /**
-     * Whether to permanently delete the comment
-     */
-    hard_delete?: boolean;
-    
+  members: FeedMemberResponse[];
 
-        
-    /**
-     * Reason for deletion
-     */
-    reason?: string;
-    
+  custom: Record<string, any>;
 
-        }
-    
+  feed: FeedResponse;
 
+  user: UserResponseCommonFields;
 
+  /**
+   * The type of event: "feeds.feed.created" in this case
+   */
+  type: string;
 
+  feed_visibility?: string;
 
-    export interface DeleteCommentResponse {
-    duration: string;
-    
+  received_at?: Date;
+}
 
-        
-    activity: ActivityResponse;
-    
+export interface FeedDeletedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    comment: CommentResponse;
-    
+  fid: string;
 
-        }
-    
+  custom: Record<string, any>;
 
+  /**
+   * The type of event: "feeds.feed.deleted" in this case
+   */
+  type: string;
 
+  feed_visibility?: string;
 
+  received_at?: Date;
 
-    export interface DeleteFeedResponse {
-    duration: string;
-    
+  user?: UserResponseCommonFields;
+}
 
-        
-    /**
-     * The ID of the async task that will handle feed cleanup and hard deletion
-     */
-    task_id: string;
-    
+export interface FeedGroup {
+  aggregation_version: number;
 
-        }
-    
+  app_pk: number;
 
+  created_at: Date;
 
+  default_visibility: string;
 
+  group_id: string;
 
-    export interface DeleteMessageRequestPayload {
-    /**
-     * ID of the message to delete (alternative to item_id)
-     */
-    entity_id?: string;
-    
+  updated_at: Date;
 
-        
-    /**
-     * Type of the entity
-     */
-    entity_type?: string;
-    
+  activity_processors: ActivityProcessorConfig[];
 
-        
-    /**
-     * Whether to permanently delete the message
-     */
-    hard_delete?: boolean;
-    
+  activity_selectors: ActivitySelectorConfig[];
 
-        
-    /**
-     * Reason for deletion
-     */
-    reason?: string;
-    
+  custom: Record<string, any>;
 
-        }
-    
+  deleted_at?: Date;
 
+  last_feed_get_at?: Date;
 
+  activity_filter?: ActivityFilterConfig;
 
+  aggregation?: AggregationConfig;
 
-    export interface DeleteModerationConfigResponse {
-    duration: string;
-    
+  notification?: NotificationConfig;
 
-        }
-    
+  push_notification?: PushNotificationConfig;
 
+  ranking?: RankingConfig;
 
+  stories?: StoriesConfig;
+}
 
+export interface FeedGroupChangedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-    export interface DeleteReactionRequestPayload {
-    /**
-     * ID of the reaction to delete (alternative to item_id)
-     */
-    entity_id?: string;
-    
+  fid: string;
 
-        
-    /**
-     * Type of the entity
-     */
-    entity_type?: string;
-    
+  custom: Record<string, any>;
 
-        
-    /**
-     * Whether to permanently delete the reaction
-     */
-    hard_delete?: boolean;
-    
+  /**
+   * The type of event: "feeds.feed_group.changed" in this case
+   */
+  type: string;
 
-        
-    /**
-     * Reason for deletion
-     */
-    reason?: string;
-    
+  feed_visibility?: string;
 
-        }
-    
+  received_at?: Date;
 
+  feed_group?: FeedGroup;
 
+  user?: UserResponseCommonFields;
+}
 
+export interface FeedGroupDeletedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-    export interface DeleteUserRequestPayload {
-    /**
-     * Also delete all user conversations
-     */
-    delete_conversation_channels?: boolean;
-    
+  fid: string;
 
-        
-    /**
-     * Delete flagged feeds content
-     */
-    delete_feeds_content?: boolean;
-    
+  /**
+   * The ID of the feed group that was deleted
+   */
+  group_id: string;
 
-        
-    /**
-     * ID of the user to delete (alternative to item_id)
-     */
-    entity_id?: string;
-    
+  custom: Record<string, any>;
 
-        
-    /**
-     * Type of the entity
-     */
-    entity_type?: string;
-    
+  /**
+   * The type of event: "feeds.feed_group.deleted" in this case
+   */
+  type: string;
 
-        
-    /**
-     * Whether to permanently delete the user
-     */
-    hard_delete?: boolean;
-    
+  feed_visibility?: string;
 
-        
-    /**
-     * Also delete all user messages
-     */
-    mark_messages_deleted?: boolean;
-    
+  received_at?: Date;
+}
 
-        
-    /**
-     * Reason for deletion
-     */
-    reason?: string;
-    
+export interface FeedGroupRestoredEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        }
-    
+  fid: string;
 
+  /**
+   * The ID of the feed group that was restored
+   */
+  group_id: string;
 
+  custom: Record<string, any>;
 
+  /**
+   * The type of event: "feeds.feed_group.restored" in this case
+   */
+  type: string;
 
-    export interface DeliveryReceiptsResponse {
-    enabled: boolean;
-    
+  feed_visibility?: string;
 
-        }
-    
+  received_at?: Date;
+}
 
+export interface FeedInput {
+  description?: string;
 
+  name?: string;
 
+  visibility?: 'public' | 'visible' | 'followers' | 'members' | 'private';
 
-    export interface DeviceResponse {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  filter_tags?: string[];
 
-        
-    /**
-     * Device ID
-     */
-    id: string;
-    
+  members?: FeedMemberRequest[];
 
-        
-    /**
-     * Push provider
-     */
-    push_provider: string;
-    
+  custom?: Record<string, any>;
 
-        
-    /**
-     * User ID
-     */
-    user_id: string;
-    
+  location?: Location;
+}
 
-        
-    /**
-     * Whether device is disabled or not
-     */
-    disabled?: boolean;
-    
+export interface FeedMemberAddedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    /**
-     * Reason explaining why device had been disabled
-     */
-    disabled_reason?: string;
-    
+  fid: string;
 
-        
-    /**
-     * Push provider name
-     */
-    push_provider_name?: string;
-    
+  custom: Record<string, any>;
 
-        
-    /**
-     * When true the token is for Apple VoIP push notifications
-     */
-    voip?: boolean;
-    
+  member: FeedMemberResponse;
 
-        }
-    
+  /**
+   * The type of event: "feeds.feed_member.added" in this case
+   */
+  type: string;
 
+  feed_visibility?: string;
 
+  received_at?: Date;
 
+  user?: UserResponseCommonFields;
+}
 
-    export interface DraftPayloadResponse {
-    /**
-     * Message ID is unique string identifier of the message
-     */
-    id: string;
-    
+export interface FeedMemberRemovedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    /**
-     * Text of the message
-     */
-    text: string;
-    
+  fid: string;
 
-        
-    custom: Record<string, any>;
-    
+  member_id: string;
 
-        
-    /**
-     * Contains HTML markup of the message
-     */
-    html?: string;
-    
+  custom: Record<string, any>;
 
-        
-    /**
-     * MML content of the message
-     */
-    mml?: string;
-    
+  /**
+   * The type of event: "feeds.feed_member.removed" in this case
+   */
+  type: string;
 
-        
-    /**
-     * ID of parent message (thread)
-     */
-    parent_id?: string;
-    
+  feed_visibility?: string;
 
-        
-    /**
-     * Identifier of the poll to include in the message
-     */
-    poll_id?: string;
-    
+  received_at?: Date;
 
-        
-    quoted_message_id?: string;
-    
+  user?: UserResponseCommonFields;
+}
 
-        
-    /**
-     * Whether thread reply should be shown in the channel as well
-     */
-    show_in_channel?: boolean;
-    
+export interface FeedMemberRequest {
+  /**
+   * ID of the user to add as a member
+   */
+  user_id: string;
 
-        
-    /**
-     * Whether message is silent or not
-     */
-    silent?: boolean;
-    
+  /**
+   * Whether this is an invite to become a member
+   */
+  invite?: boolean;
 
-        
-    /**
-     * Contains type of the message. One of: regular, system
-     */
-    type?: string;
-    
+  /**
+   * ID of the membership level to assign to the member
+   */
+  membership_level?: string;
 
-        
-    /**
-     * Array of message attachments
-     */
-    attachments?: Array<Attachment>;
-    
+  /**
+   * Role of the member in the feed
+   */
+  role?: string;
 
-        
-    /**
-     * List of mentioned users
-     */
-    mentioned_users?: Array<UserResponse>;
-    
+  /**
+   * Custom data for the member
+   */
+  custom?: Record<string, any>;
+}
 
-        }
-    
+export interface FeedMemberResponse {
+  /**
+   * When the membership was created
+   */
+  created_at: Date;
 
+  /**
+   * Role of the member in the feed
+   */
+  role: string;
 
+  /**
+   * Status of the membership. One of: member, pending, rejected
+   */
 
+  status: 'member' | 'pending' | 'rejected';
 
-    export interface DraftResponse {
-    channel_cid: string;
-    
+  /**
+   * When the membership was last updated
+   */
+  updated_at: Date;
 
-        
-    created_at: Date;
-    
+  user: UserResponse;
 
-        
-    message: DraftPayloadResponse;
-    
+  /**
+   * When the invite was accepted
+   */
+  invite_accepted_at?: Date;
 
-        
-    parent_id?: string;
-    
+  /**
+   * When the invite was rejected
+   */
+  invite_rejected_at?: Date;
 
-        
-    channel?: ChannelResponse;
-    
+  /**
+   * Custom data for the membership
+   */
+  custom?: Record<string, any>;
 
-        
-    parent_message?: MessageResponse;
-    
+  membership_level?: MembershipLevelResponse;
+}
 
-        
-    quoted_message?: MessageResponse;
-    
+export interface FeedMemberUpdatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        }
-    
+  fid: string;
 
+  custom: Record<string, any>;
 
+  member: FeedMemberResponse;
 
+  /**
+   * The type of event: "feeds.feed_member.updated" in this case
+   */
+  type: string;
 
-    export interface EnrichedActivity {
-    foreign_id?: string;
-    
+  feed_visibility?: string;
 
-        
-    id?: string;
-    
+  received_at?: Date;
 
-        
-    score?: number;
-    
-
-        
-    verb?: string;
-    
-
-        
-    to?: Array<string>;
-    
-
-        
-    actor?: Data;
-    
-
-        
-    latest_reactions?: Record<string, Array<EnrichedReaction>>;
-    
-
-        
-    object?: Data;
-    
-
-        
-    origin?: Data;
-    
-
-        
-    own_reactions?: Record<string, Array<EnrichedReaction>>;
-    
-
-        
-    reaction_counts?: Record<string, number>;
-    
-
-        
-    target?: Data;
-    
-
-        }
-    
-
-
-
-
-    export interface EnrichedCollectionResponse {
-    /**
-     * Unique identifier for the collection within its name
-     */
-    id: string;
-    
-
-        
-    /**
-     * Name/type of the collection
-     */
-    name: string;
-    
-
-        
-    /**
-     * Enrichment status of the collection. One of: ok, notfound
-     */
-    
-        status:| "ok" | "notfound" ;
-
-        
-    /**
-     * When the collection was created
-     */
-    created_at?: Date;
-    
-
-        
-    /**
-     * When the collection was last updated
-     */
-    updated_at?: Date;
-    
-
-        
-    /**
-     * ID of the user who owns this collection
-     */
-    user_id?: string;
-    
-
-        
-    /**
-     * Custom data for the collection
-     */
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface EnrichedReaction {
-    activity_id: string;
-    
-
-        
-    kind: string;
-    
-
-        
-    user_id: string;
-    
-
-        
-    id?: string;
-    
-
-        
-    parent?: string;
-    
-
-        
-    target_feeds?: Array<string>;
-    
-
-        
-    children_counts?: Record<string, number>;
-    
-
-        
-    created_at?: Time;
-    
-
-        
-    data?: Record<string, any>;
-    
-
-        
-    latest_children?: Record<string, Array<EnrichedReaction>>;
-    
-
-        
-    own_children?: Record<string, Array<EnrichedReaction>>;
-    
-
-        
-    updated_at?: Time;
-    
-
-        
-    user?: Data;
-    
-
-        }
-    
-
-
-
-
-    export interface EnrichmentOptions {
-    /**
-     * Default: false. When true, includes fetching and enriching own_followings (follows where activity author's feeds follow current user's feeds).
-     */
-    enrich_own_followings?: boolean;
-    
-
-        
-    /**
-     * Controls the top-level flat 'activities' array for aggregated feeds. For new apps, defaults to false (excluded); set to true to include. For older apps, defaults to true (included) for backward compatibility; set to false to exclude.
-     */
-    include_flat_activities?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, includes score_vars in activity responses containing variable values used at ranking time.
-     */
-    include_score_vars?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips all activity enrichments.
-     */
-    skip_activity?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips enriching collections on activities.
-     */
-    skip_activity_collections?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips enriching comments on activities.
-     */
-    skip_activity_comments?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips enriching current_feed on activities. Note: CurrentFeed is still computed for permission checks, but enrichment is skipped.
-     */
-    skip_activity_current_feed?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips enriching mentioned users on activities.
-     */
-    skip_activity_mentioned_users?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips enriching own bookmarks on activities.
-     */
-    skip_activity_own_bookmarks?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips enriching parent activities.
-     */
-    skip_activity_parents?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips enriching poll data on activities.
-     */
-    skip_activity_poll?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips fetching and enriching latest and own reactions on activities. Note: If reactions are already denormalized in the database, they will still be included.
-     */
-    skip_activity_reactions?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips refreshing image URLs on activities.
-     */
-    skip_activity_refresh_image_urls?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips all enrichments.
-     */
-    skip_all?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips enriching user data on feed members.
-     */
-    skip_feed_member_user?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips fetching and enriching followers. Note: If followers_pagination is explicitly provided, followers will be fetched regardless of this setting.
-     */
-    skip_followers?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips fetching and enriching following. Note: If following_pagination is explicitly provided, following will be fetched regardless of this setting.
-     */
-    skip_following?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips computing and including capabilities for feeds.
-     */
-    skip_own_capabilities?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips fetching and enriching own_follows (follows where user's feeds follow target feeds).
-     */
-    skip_own_follows?: boolean;
-    
-
-        
-    /**
-     * Default: false. When true, skips enriching pinned activities.
-     */
-    skip_pins?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface EntityCreatorResponse {
-    /**
-     * Number of minor actions performed on the user
-     */
-    ban_count: number;
-    
-
-        
-    banned: boolean;
-    
-
-        
-    created_at: Date;
-    
-
-        
-    /**
-     * Number of major actions performed on the user
-     */
-    deleted_content_count: number;
-    
-
-        
-    /**
-     * Number of flag actions performed on the user
-     */
-    flagged_count: number;
-    
-
-        
-    id: string;
-    
-
-        
-    language: string;
-    
-
-        
-    online: boolean;
-    
-
-        
-    role: string;
-    
-
-        
-    updated_at: Date;
-    
-
-        
-    blocked_user_ids: Array<string>;
-    
-
-        
-    teams: Array<string>;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    avg_response_time?: number;
-    
-
-        
-    deactivated_at?: Date;
-    
-
-        
-    deleted_at?: Date;
-    
-
-        
-    image?: string;
-    
-
-        
-    last_active?: Date;
-    
-
-        
-    name?: string;
-    
-
-        
-    revoke_tokens_issued_before?: Date;
-    
-
-        
-    teams_role?: Record<string, string>;
-    
-
-        }
-    
-
-
-
-
-    export interface EscalatePayload {
-    /**
-     * Additional context for the reviewer
-     */
-    notes?: string;
-    
-
-        
-    /**
-     * Priority of the escalation (low, medium, high)
-     */
-    priority?: string;
-    
-
-        
-    /**
-     * Reason for the escalation (from configured escalation_reasons)
-     */
-    reason?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface EscalationMetadata {
-    notes?: string;
-    
-
-        
-    priority?: string;
-    
-
-        
-    reason?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedCreatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    fid: string;
-    
-
-        
-    members: Array<FeedMemberResponse>;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    feed: FeedResponse;
-    
-
-        
-    user: UserResponseCommonFields;
-    
-
-        
-    /**
-     * The type of event: "feeds.feed.created" in this case
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedDeletedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    fid: string;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    /**
-     * The type of event: "feeds.feed.deleted" in this case
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    user?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedGroup {
-    aggregation_version: number;
-    
-
-        
-    app_pk: number;
-    
-
-        
-    created_at: Date;
-    
-
-        
-    default_visibility: string;
-    
-
-        
-    group_id: string;
-    
-
-        
-    updated_at: Date;
-    
-
-        
-    activity_processors: Array<ActivityProcessorConfig>;
-    
-
-        
-    activity_selectors: Array<ActivitySelectorConfig>;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    deleted_at?: Date;
-    
-
-        
-    last_feed_get_at?: Date;
-    
-
-        
-    activity_filter?: ActivityFilterConfig;
-    
-
-        
-    aggregation?: AggregationConfig;
-    
-
-        
-    notification?: NotificationConfig;
-    
-
-        
-    push_notification?: PushNotificationConfig;
-    
-
-        
-    ranking?: RankingConfig;
-    
-
-        
-    stories?: StoriesConfig;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedGroupChangedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    fid: string;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    /**
-     * The type of event: "feeds.feed_group.changed" in this case
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    feed_group?: FeedGroup;
-    
-
-        
-    user?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedGroupDeletedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    fid: string;
-    
-
-        
-    /**
-     * The ID of the feed group that was deleted
-     */
-    group_id: string;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    /**
-     * The type of event: "feeds.feed_group.deleted" in this case
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedGroupRestoredEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    fid: string;
-    
-
-        
-    /**
-     * The ID of the feed group that was restored
-     */
-    group_id: string;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    /**
-     * The type of event: "feeds.feed_group.restored" in this case
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedInput {
-    description?: string;
-    
-
-        
-    name?: string;
-    
-
-        
-    
-        visibility?:| "public" | "visible" | "followers" | "members" | "private" ;
-
-        
-    filter_tags?: Array<string>;
-    
-
-        
-    members?: Array<FeedMemberRequest>;
-    
-
-        
-    custom?: Record<string, any>;
-    
-
-        
-    location?: Location;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedMemberAddedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    fid: string;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    member: FeedMemberResponse;
-    
-
-        
-    /**
-     * The type of event: "feeds.feed_member.added" in this case
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    user?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedMemberRemovedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    fid: string;
-    
-
-        
-    member_id: string;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    /**
-     * The type of event: "feeds.feed_member.removed" in this case
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    user?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedMemberRequest {
-    /**
-     * ID of the user to add as a member
-     */
-    user_id: string;
-    
-
-        
-    /**
-     * Whether this is an invite to become a member
-     */
-    invite?: boolean;
-    
-
-        
-    /**
-     * ID of the membership level to assign to the member
-     */
-    membership_level?: string;
-    
-
-        
-    /**
-     * Role of the member in the feed
-     */
-    role?: string;
-    
-
-        
-    /**
-     * Custom data for the member
-     */
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedMemberResponse {
-    /**
-     * When the membership was created
-     */
-    created_at: Date;
-    
-
-        
-    /**
-     * Role of the member in the feed
-     */
-    role: string;
-    
-
-        
-    /**
-     * Status of the membership. One of: member, pending, rejected
-     */
-    
-        status:| "member" | "pending" | "rejected" ;
-
-        
-    /**
-     * When the membership was last updated
-     */
-    updated_at: Date;
-    
-
-        
-    user: UserResponse;
-    
-
-        
-    /**
-     * When the invite was accepted
-     */
-    invite_accepted_at?: Date;
-    
-
-        
-    /**
-     * When the invite was rejected
-     */
-    invite_rejected_at?: Date;
-    
-
-        
-    /**
-     * Custom data for the membership
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    membership_level?: MembershipLevelResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedMemberUpdatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    fid: string;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    member: FeedMemberResponse;
-    
-
-        
-    /**
-     * The type of event: "feeds.feed_member.updated" in this case
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    user?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
+  user?: UserResponseCommonFields;
+}
 
 export const FeedOwnCapability = {
-    ADD_ACTIVITY: 'add-activity',
-    ADD_ACTIVITY_BOOKMARK: 'add-activity-bookmark',
-    ADD_ACTIVITY_REACTION: 'add-activity-reaction',
-    ADD_COMMENT: 'add-comment',
-    ADD_COMMENT_REACTION: 'add-comment-reaction',
-    CREATE_FEED: 'create-feed',
-    DELETE_ANY_ACTIVITY: 'delete-any-activity',
-    DELETE_ANY_COMMENT: 'delete-any-comment',
-    DELETE_FEED: 'delete-feed',
-    DELETE_OWN_ACTIVITY: 'delete-own-activity',
-    DELETE_OWN_ACTIVITY_BOOKMARK: 'delete-own-activity-bookmark',
-    DELETE_OWN_ACTIVITY_REACTION: 'delete-own-activity-reaction',
-    DELETE_OWN_COMMENT: 'delete-own-comment',
-    DELETE_OWN_COMMENT_REACTION: 'delete-own-comment-reaction',
-    FOLLOW: 'follow',
-    PIN_ACTIVITY: 'pin-activity',
-    QUERY_FEED_MEMBERS: 'query-feed-members',
-    QUERY_FOLLOWS: 'query-follows',
-    READ_ACTIVITIES: 'read-activities',
-    READ_FEED: 'read-feed',
-    UNFOLLOW: 'unfollow',
-    UPDATE_ANY_ACTIVITY: 'update-any-activity',
-    UPDATE_ANY_COMMENT: 'update-any-comment',
-    UPDATE_FEED: 'update-feed',
-    UPDATE_FEED_FOLLOWERS: 'update-feed-followers',
-    UPDATE_FEED_MEMBERS: 'update-feed-members',
-    UPDATE_OWN_ACTIVITY: 'update-own-activity',
-    UPDATE_OWN_ACTIVITY_BOOKMARK: 'update-own-activity-bookmark',
-    UPDATE_OWN_COMMENT: 'update-own-comment',
+  ADD_ACTIVITY: 'add-activity',
+  ADD_ACTIVITY_BOOKMARK: 'add-activity-bookmark',
+  ADD_ACTIVITY_REACTION: 'add-activity-reaction',
+  ADD_COMMENT: 'add-comment',
+  ADD_COMMENT_REACTION: 'add-comment-reaction',
+  CREATE_FEED: 'create-feed',
+  DELETE_ANY_ACTIVITY: 'delete-any-activity',
+  DELETE_ANY_COMMENT: 'delete-any-comment',
+  DELETE_FEED: 'delete-feed',
+  DELETE_OWN_ACTIVITY: 'delete-own-activity',
+  DELETE_OWN_ACTIVITY_BOOKMARK: 'delete-own-activity-bookmark',
+  DELETE_OWN_ACTIVITY_REACTION: 'delete-own-activity-reaction',
+  DELETE_OWN_COMMENT: 'delete-own-comment',
+  DELETE_OWN_COMMENT_REACTION: 'delete-own-comment-reaction',
+  FOLLOW: 'follow',
+  PIN_ACTIVITY: 'pin-activity',
+  QUERY_FEED_MEMBERS: 'query-feed-members',
+  QUERY_FOLLOWS: 'query-follows',
+  READ_ACTIVITIES: 'read-activities',
+  READ_FEED: 'read-feed',
+  UNFOLLOW: 'unfollow',
+  UPDATE_ANY_ACTIVITY: 'update-any-activity',
+  UPDATE_ANY_COMMENT: 'update-any-comment',
+  UPDATE_FEED: 'update-feed',
+  UPDATE_FEED_FOLLOWERS: 'update-feed-followers',
+  UPDATE_FEED_MEMBERS: 'update-feed-members',
+  UPDATE_OWN_ACTIVITY: 'update-own-activity',
+  UPDATE_OWN_ACTIVITY_BOOKMARK: 'update-own-activity-bookmark',
+  UPDATE_OWN_COMMENT: 'update-own-comment',
 } as const;
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export type FeedOwnCapability = typeof FeedOwnCapability[keyof typeof FeedOwnCapability]
-
-
-
-
-    export interface FeedOwnData {
-    /**
-     * Capabilities the current user has for this feed
-     */
-    own_capabilities?: Array<FeedOwnCapability>;
-    
-
-        
-    /**
-     * Follow relationships where the feed owner's feeds are following the current user's feeds (up to 5 total)
-     */
-    own_followings?: Array<FollowResponse>;
-    
-
-        
-    /**
-     * Follow relationships where the current user's feeds are following this feed
-     */
-    own_follows?: Array<FollowResponse>;
-    
-
-        
-    own_membership?: FeedMemberResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedRequest {
-    /**
-     * ID of the feed group
-     */
-    feed_group_id: string;
-    
-
-        
-    /**
-     * ID of the feed
-     */
-    feed_id: string;
-    
-
-        
-    /**
-     * ID of the feed creator
-     */
-    created_by_id?: string;
-    
-
-        
-    /**
-     * Description of the feed
-     */
-    description?: string;
-    
-
-        
-    /**
-     * Name of the feed
-     */
-    name?: string;
-    
-
-        
-    /**
-     * Visibility setting for the feed. One of: public, visible, followers, members, private
-     */
-    
-        visibility?:| "public" | "visible" | "followers" | "members" | "private" ;
-
-        
-    /**
-     * Tags used for filtering feeds
-     */
-    filter_tags?: Array<string>;
-    
-
-        
-    /**
-     * Initial members for the feed
-     */
-    members?: Array<FeedMemberRequest>;
-    
-
-        
-    /**
-     * Custom data for the feed
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    location?: Location;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedResponse {
-    activity_count: number;
-    
-
-        
-    /**
-     * When the feed was created
-     */
-    created_at: Date;
-    
-
-        
-    /**
-     * Description of the feed
-     */
-    description: string;
-    
-
-        
-    /**
-     * Fully qualified feed ID (group_id:id)
-     */
-    feed: string;
-    
-
-        
-    /**
-     * Number of followers of this feed
-     */
-    follower_count: number;
-    
-
-        
-    /**
-     * Number of feeds this feed follows
-     */
-    following_count: number;
-    
-
-        
-    /**
-     * Group this feed belongs to
-     */
-    group_id: string;
-    
-
-        
-    /**
-     * Unique identifier for the feed
-     */
-    id: string;
-    
-
-        
-    /**
-     * Number of members in this feed
-     */
-    member_count: number;
-    
-
-        
-    /**
-     * Name of the feed
-     */
-    name: string;
-    
-
-        
-    /**
-     * Number of pinned activities in this feed
-     */
-    pin_count: number;
-    
-
-        
-    /**
-     * When the feed was last updated
-     */
-    updated_at: Date;
-    
-
-        
-    created_by: UserResponse;
-    
-
-        
-    /**
-     * When the feed was deleted
-     */
-    deleted_at?: Date;
-    
-
-        
-    /**
-     * Visibility setting for the feed
-     */
-    
-        visibility?:| "public" | "visible" | "followers" | "members" | "private" ;
-
-        
-    /**
-     * Tags used for filtering feeds
-     */
-    filter_tags?: Array<string>;
-    
-
-        
-    /**
-     * Capabilities the current user has for this feed
-     */
-    own_capabilities?: Array<FeedOwnCapability>;
-    
-
-        
-    /**
-     * Follow relationships where the feed owner’s feeds are following the current user's feeds
-     */
-    own_followings?: Array<FollowResponse>;
-    
-
-        
-    /**
-     * Follow relationships where the current user's feeds are following this feed
-     */
-    own_follows?: Array<FollowResponse>;
-    
-
-        
-    /**
-     * Custom data for the feed
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    location?: Location;
-    
-
-        
-    own_membership?: FeedMemberResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedSuggestionResponse {
-    activity_count: number;
-    
-
-        
-    /**
-     * When the feed was created
-     */
-    created_at: Date;
-    
-
-        
-    /**
-     * Description of the feed
-     */
-    description: string;
-    
-
-        
-    /**
-     * Fully qualified feed ID (group_id:id)
-     */
-    feed: string;
-    
-
-        
-    /**
-     * Number of followers of this feed
-     */
-    follower_count: number;
-    
-
-        
-    /**
-     * Number of feeds this feed follows
-     */
-    following_count: number;
-    
-
-        
-    /**
-     * Group this feed belongs to
-     */
-    group_id: string;
-    
-
-        
-    /**
-     * Unique identifier for the feed
-     */
-    id: string;
-    
-
-        
-    /**
-     * Number of members in this feed
-     */
-    member_count: number;
-    
-
-        
-    /**
-     * Name of the feed
-     */
-    name: string;
-    
-
-        
-    /**
-     * Number of pinned activities in this feed
-     */
-    pin_count: number;
-    
-
-        
-    /**
-     * When the feed was last updated
-     */
-    updated_at: Date;
-    
-
-        
-    created_by: UserResponse;
-    
-
-        
-    /**
-     * When the feed was deleted
-     */
-    deleted_at?: Date;
-    
-
-        
-    reason?: string;
-    
-
-        
-    recommendation_score?: number;
-    
-
-        
-    /**
-     * Visibility setting for the feed
-     */
-    
-        visibility?:| "public" | "visible" | "followers" | "members" | "private" ;
-
-        
-    /**
-     * Tags used for filtering feeds
-     */
-    filter_tags?: Array<string>;
-    
-
-        
-    /**
-     * Capabilities the current user has for this feed
-     */
-    own_capabilities?: Array<FeedOwnCapability>;
-    
-
-        
-    /**
-     * Follow relationships where the feed owner’s feeds are following the current user's feeds
-     */
-    own_followings?: Array<FollowResponse>;
-    
-
-        
-    /**
-     * Follow relationships where the current user's feeds are following this feed
-     */
-    own_follows?: Array<FollowResponse>;
-    
-
-        
-    algorithm_scores?: Record<string, number>;
-    
-
-        
-    /**
-     * Custom data for the feed
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    location?: Location;
-    
-
-        
-    own_membership?: FeedMemberResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedUpdatedEvent {
-    created_at: Date;
-    
-
-        
-    fid: string;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    feed: FeedResponse;
-    
-
-        
-    /**
-     * The type of event: "feeds.feed.updated" in this case
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    user?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedsActivityLocation {
-    lat: number;
-    
-
-        
-    lng: number;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedsBookmarkResponse {
-    created_at: Date;
-    
-
-        
-    object_id: string;
-    
-
-        
-    object_type: string;
-    
-
-        
-    updated_at: Date;
-    
-
-        
-    user: UserResponse;
-    
-
-        
-    activity_id?: string;
-    
-
-        
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedsEnrichedCollectionResponse {
-    created_at: Date;
-    
-
-        
-    id: string;
-    
-
-        
-    name: string;
-    
-
-        
-    status: string;
-    
-
-        
-    updated_at: Date;
-    
-
-        
-    user_id: string;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedsFeedResponse {
-    activity_count: number;
-    
-
-        
-    created_at: Date;
-    
-
-        
-    description: string;
-    
-
-        
-    feed: string;
-    
-
-        
-    follower_count: number;
-    
-
-        
-    following_count: number;
-    
-
-        
-    group_id: string;
-    
-
-        
-    id: string;
-    
-
-        
-    member_count: number;
-    
-
-        
-    name: string;
-    
-
-        
-    pin_count: number;
-    
-
-        
-    updated_at: Date;
-    
-
-        
-    created_by: UserResponse;
-    
-
-        
-    deleted_at?: Date;
-    
-
-        
-    visibility?: string;
-    
-
-        
-    filter_tags?: Array<string>;
-    
-
-        
-    custom?: Record<string, any>;
-    
-
-        
-    location?: FeedsActivityLocation;
-    
-
-        }
-    
-
-
-
-
-    export interface FeedsNotificationComment {
-    comment: string;
-    
+export type FeedOwnCapability =
+  (typeof FeedOwnCapability)[keyof typeof FeedOwnCapability];
+
+export interface FeedOwnData {
+  /**
+   * Capabilities the current user has for this feed
+   */
+  own_capabilities?: FeedOwnCapability[];
+
+  /**
+   * Follow relationships where the feed owner's feeds are following the current user's feeds (up to 5 total)
+   */
+  own_followings?: FollowResponse[];
+
+  /**
+   * Follow relationships where the current user's feeds are following this feed
+   */
+  own_follows?: FollowResponse[];
+
+  own_membership?: FeedMemberResponse;
+}
+
+export interface FeedRequest {
+  /**
+   * ID of the feed group
+   */
+  feed_group_id: string;
+
+  /**
+   * ID of the feed
+   */
+  feed_id: string;
+
+  /**
+   * ID of the feed creator
+   */
+  created_by_id?: string;
+
+  /**
+   * Description of the feed
+   */
+  description?: string;
+
+  /**
+   * Name of the feed
+   */
+  name?: string;
+
+  /**
+   * Visibility setting for the feed. One of: public, visible, followers, members, private
+   */
+
+  visibility?: 'public' | 'visible' | 'followers' | 'members' | 'private';
+
+  /**
+   * Tags used for filtering feeds
+   */
+  filter_tags?: string[];
+
+  /**
+   * Initial members for the feed
+   */
+  members?: FeedMemberRequest[];
+
+  /**
+   * Custom data for the feed
+   */
+  custom?: Record<string, any>;
+
+  location?: Location;
+}
+
+export interface FeedResponse {
+  activity_count: number;
+
+  /**
+   * When the feed was created
+   */
+  created_at: Date;
+
+  /**
+   * Description of the feed
+   */
+  description: string;
+
+  /**
+   * Fully qualified feed ID (group_id:id)
+   */
+  feed: string;
+
+  /**
+   * Number of followers of this feed
+   */
+  follower_count: number;
+
+  /**
+   * Number of feeds this feed follows
+   */
+  following_count: number;
+
+  /**
+   * Group this feed belongs to
+   */
+  group_id: string;
+
+  /**
+   * Unique identifier for the feed
+   */
+  id: string;
+
+  /**
+   * Number of members in this feed
+   */
+  member_count: number;
+
+  /**
+   * Name of the feed
+   */
+  name: string;
+
+  /**
+   * Number of pinned activities in this feed
+   */
+  pin_count: number;
+
+  /**
+   * When the feed was last updated
+   */
+  updated_at: Date;
+
+  created_by: UserResponse;
+
+  /**
+   * When the feed was deleted
+   */
+  deleted_at?: Date;
+
+  /**
+   * Visibility setting for the feed
+   */
+
+  visibility?: 'public' | 'visible' | 'followers' | 'members' | 'private';
+
+  /**
+   * Tags used for filtering feeds
+   */
+  filter_tags?: string[];
+
+  /**
+   * Capabilities the current user has for this feed
+   */
+  own_capabilities?: FeedOwnCapability[];
+
+  /**
+   * Follow relationships where the feed owner’s feeds are following the current user's feeds
+   */
+  own_followings?: FollowResponse[];
+
+  /**
+   * Follow relationships where the current user's feeds are following this feed
+   */
+  own_follows?: FollowResponse[];
+
+  /**
+   * Custom data for the feed
+   */
+  custom?: Record<string, any>;
+
+  location?: Location;
+
+  own_membership?: FeedMemberResponse;
+}
+
+export interface FeedSuggestionResponse {
+  activity_count: number;
+
+  /**
+   * When the feed was created
+   */
+  created_at: Date;
+
+  /**
+   * Description of the feed
+   */
+  description: string;
+
+  /**
+   * Fully qualified feed ID (group_id:id)
+   */
+  feed: string;
+
+  /**
+   * Number of followers of this feed
+   */
+  follower_count: number;
+
+  /**
+   * Number of feeds this feed follows
+   */
+  following_count: number;
 
-        
-    id: string;
-    
+  /**
+   * Group this feed belongs to
+   */
+  group_id: string;
 
-        
-    user_id: string;
-    
+  /**
+   * Unique identifier for the feed
+   */
+  id: string;
 
-        
-    attachments?: Array<Attachment>;
-    
+  /**
+   * Number of members in this feed
+   */
+  member_count: number;
 
-        }
-    
+  /**
+   * Name of the feed
+   */
+  name: string;
 
+  /**
+   * Number of pinned activities in this feed
+   */
+  pin_count: number;
 
+  /**
+   * When the feed was last updated
+   */
+  updated_at: Date;
 
+  created_by: UserResponse;
 
-    export interface FeedsNotificationContext {
-    target?: FeedsNotificationTarget;
-    
+  /**
+   * When the feed was deleted
+   */
+  deleted_at?: Date;
 
-        
-    trigger?: FeedsNotificationTrigger;
-    
+  reason?: string;
 
-        }
-    
+  recommendation_score?: number;
 
+  /**
+   * Visibility setting for the feed
+   */
 
+  visibility?: 'public' | 'visible' | 'followers' | 'members' | 'private';
 
+  /**
+   * Tags used for filtering feeds
+   */
+  filter_tags?: string[];
 
-    export interface FeedsNotificationParentActivity {
-    id: string;
-    
+  /**
+   * Capabilities the current user has for this feed
+   */
+  own_capabilities?: FeedOwnCapability[];
 
-        
-    text?: string;
-    
+  /**
+   * Follow relationships where the feed owner’s feeds are following the current user's feeds
+   */
+  own_followings?: FollowResponse[];
 
-        
-    type?: string;
-    
+  /**
+   * Follow relationships where the current user's feeds are following this feed
+   */
+  own_follows?: FollowResponse[];
 
-        
-    user_id?: string;
-    
+  algorithm_scores?: Record<string, number>;
 
-        
-    attachments?: Array<Attachment>;
-    
+  /**
+   * Custom data for the feed
+   */
+  custom?: Record<string, any>;
 
-        }
-    
+  location?: Location;
 
+  own_membership?: FeedMemberResponse;
+}
 
+export interface FeedUpdatedEvent {
+  created_at: Date;
 
+  fid: string;
 
-    export interface FeedsNotificationTarget {
-    id: string;
-    
+  custom: Record<string, any>;
 
-        
-    name?: string;
-    
+  feed: FeedResponse;
 
-        
-    text?: string;
-    
-
-        
-    type?: string;
-    
-
-        
-    user_id?: string;
-    
-
-        
-    attachments?: Array<Attachment>;
-    
-
-        
-    comment?: FeedsNotificationComment;
-    
+  /**
+   * The type of event: "feeds.feed.updated" in this case
+   */
+  type: string;
 
-        
-    custom?: Record<string, any>;
-    
+  feed_visibility?: string;
 
-        
-    parent_activity?: FeedsNotificationParentActivity;
-    
+  received_at?: Date;
 
-        }
-    
+  user?: UserResponseCommonFields;
+}
 
+export interface FeedsActivityLocation {
+  lat: number;
 
+  lng: number;
+}
 
+export interface FeedsBookmarkResponse {
+  created_at: Date;
 
-    export interface FeedsNotificationTrigger {
-    text: string;
-    
+  object_id: string;
 
-        
-    type: string;
-    
+  object_type: string;
 
-        
-    comment?: FeedsNotificationComment;
-    
+  updated_at: Date;
 
-        
-    custom?: Record<string, any>;
-    
+  user: UserResponse;
 
-        }
-    
+  activity_id?: string;
 
+  custom?: Record<string, any>;
+}
 
+export interface FeedsEnrichedCollectionResponse {
+  created_at: Date;
 
+  id: string;
 
-    export interface FeedsPreferences {
-    /**
-     * Push notification preference for comments on user's activities. One of: all, none
-     */
-    
-        comment?:| "all" | "none" ;
+  name: string;
 
-        
-    /**
-     * Push notification preference for mentions in comments. One of: all, none
-     */
-    
-        comment_mention?:| "all" | "none" ;
+  status: string;
 
-        
-    /**
-     * Push notification preference for reactions on comments. One of: all, none
-     */
-    
-        comment_reaction?:| "all" | "none" ;
+  updated_at: Date;
 
-        
-    /**
-     * Push notification preference for replies to comments. One of: all, none
-     */
-    
-        comment_reply?:| "all" | "none" ;
+  user_id: string;
 
-        
-    /**
-     * Push notification preference for new followers. One of: all, none
-     */
-    
-        follow?:| "all" | "none" ;
+  custom: Record<string, any>;
+}
 
-        
-    /**
-     * Push notification preference for mentions in activities. One of: all, none
-     */
-    
-        mention?:| "all" | "none" ;
+export interface FeedsFeedResponse {
+  activity_count: number;
 
-        
-    /**
-     * Push notification preference for reactions on user's activities or comments. One of: all, none
-     */
-    
-        reaction?:| "all" | "none" ;
+  created_at: Date;
 
-        
-    /**
-     * Push notification preferences for custom activity types. Map of activity type to preference (all or none)
-     */
-    custom_activity_types?: Record<string, string>;
-    
+  description: string;
 
-        }
-    
+  feed: string;
 
+  follower_count: number;
 
+  following_count: number;
 
+  group_id: string;
 
-    export interface FeedsPreferencesResponse {
-    comment?: string;
-    
+  id: string;
 
-        
-    comment_mention?: string;
-    
+  member_count: number;
 
-        
-    comment_reaction?: string;
-    
+  name: string;
 
-        
-    comment_reply?: string;
-    
+  pin_count: number;
 
-        
-    follow?: string;
-    
+  updated_at: Date;
 
-        
-    mention?: string;
-    
+  created_by: UserResponse;
 
-        
-    reaction?: string;
-    
+  deleted_at?: Date;
 
-        
-    custom_activity_types?: Record<string, string>;
-    
+  visibility?: string;
 
-        }
-    
+  filter_tags?: string[];
 
+  custom?: Record<string, any>;
 
+  location?: FeedsActivityLocation;
+}
 
+export interface FeedsNotificationComment {
+  comment: string;
 
-    export interface FeedsReactionGroupResponse {
-    count: number;
-    
+  id: string;
 
-        
-    first_reaction_at: Date;
-    
+  user_id: string;
 
-        
-    last_reaction_at: Date;
-    
+  attachments?: Attachment[];
+}
 
-        }
-    
+export interface FeedsNotificationContext {
+  target?: FeedsNotificationTarget;
 
+  trigger?: FeedsNotificationTrigger;
+}
 
+export interface FeedsNotificationParentActivity {
+  id: string;
 
+  text?: string;
 
-    export interface FeedsReactionResponse {
-    activity_id: string;
-    
+  type?: string;
 
-        
-    created_at: Date;
-    
+  user_id?: string;
 
-        
-    type: string;
-    
+  attachments?: Attachment[];
+}
 
-        
-    updated_at: Date;
-    
+export interface FeedsNotificationTarget {
+  id: string;
 
-        
-    user: UserResponse;
-    
+  name?: string;
 
-        
-    comment_id?: string;
-    
+  text?: string;
 
-        
-    custom?: Record<string, any>;
-    
+  type?: string;
 
-        }
-    
+  user_id?: string;
 
+  attachments?: Attachment[];
 
+  comment?: FeedsNotificationComment;
 
+  custom?: Record<string, any>;
 
-    export interface FeedsV3ActivityResponse {
-    bookmark_count: number;
-    
+  parent_activity?: FeedsNotificationParentActivity;
+}
 
-        
-    comment_count: number;
-    
+export interface FeedsNotificationTrigger {
+  text: string;
 
-        
-    created_at: Date;
-    
+  type: string;
 
-        
-    hidden: boolean;
-    
+  comment?: FeedsNotificationComment;
 
-        
-    id: string;
-    
+  custom?: Record<string, any>;
+}
 
-        
-    popularity: number;
-    
+export interface FeedsPreferences {
+  /**
+   * Push notification preference for comments on user's activities. One of: all, none
+   */
 
-        
-    preview: boolean;
-    
+  comment?: 'all' | 'none';
 
-        
-    reaction_count: number;
-    
+  /**
+   * Push notification preference for mentions in comments. One of: all, none
+   */
 
-        
-    restrict_replies: string;
-    
+  comment_mention?: 'all' | 'none';
 
-        
-    score: number;
-    
+  /**
+   * Push notification preference for reactions on comments. One of: all, none
+   */
 
-        
-    share_count: number;
-    
+  comment_reaction?: 'all' | 'none';
 
-        
-    type: string;
-    
+  /**
+   * Push notification preference for replies to comments. One of: all, none
+   */
 
-        
-    updated_at: Date;
-    
+  comment_reply?: 'all' | 'none';
 
-        
-    visibility: string;
-    
+  /**
+   * Push notification preference for new followers. One of: all, none
+   */
 
-        
-    attachments: Array<Attachment>;
-    
+  follow?: 'all' | 'none';
 
-        
-    comments: Array<FeedsV3CommentResponse>;
-    
+  /**
+   * Push notification preference for mentions in activities. One of: all, none
+   */
 
-        
-    feeds: Array<string>;
-    
+  mention?: 'all' | 'none';
 
-        
-    filter_tags: Array<string>;
-    
+  /**
+   * Push notification preference for reactions on user's activities or comments. One of: all, none
+   */
 
-        
-    interest_tags: Array<string>;
-    
+  reaction?: 'all' | 'none';
 
-        
-    latest_reactions: Array<FeedsReactionResponse>;
-    
+  /**
+   * Push notification preferences for custom activity types. Map of activity type to preference (all or none)
+   */
+  custom_activity_types?: Record<string, string>;
+}
 
-        
-    mentioned_users: Array<UserResponse>;
-    
+export interface FeedsPreferencesResponse {
+  comment?: string;
 
-        
-    own_bookmarks: Array<FeedsBookmarkResponse>;
-    
+  comment_mention?: string;
 
-        
-    own_reactions: Array<FeedsReactionResponse>;
-    
+  comment_reaction?: string;
 
-        
-    collections: Record<string, FeedsEnrichedCollectionResponse>;
-    
+  comment_reply?: string;
 
-        
-    custom: Record<string, any>;
-    
+  follow?: string;
 
-        
-    reaction_groups: Record<string, FeedsReactionGroupResponse>;
-    
+  mention?: string;
 
-        
-    search_data: Record<string, any>;
-    
+  reaction?: string;
 
-        
-    user: UserResponse;
-    
+  custom_activity_types?: Record<string, string>;
+}
 
-        
-    deleted_at?: Date;
-    
+export interface FeedsReactionGroupResponse {
+  count: number;
 
-        
-    edited_at?: Date;
-    
+  first_reaction_at: Date;
 
-        
-    expires_at?: Date;
-    
+  last_reaction_at: Date;
+}
 
-        
-    friend_reaction_count?: number;
-    
+export interface FeedsReactionResponse {
+  activity_id: string;
 
-        
-    is_read?: boolean;
-    
+  created_at: Date;
 
-        
-    is_seen?: boolean;
-    
+  type: string;
 
-        
-    is_watched?: boolean;
-    
+  updated_at: Date;
 
-        
-    moderation_action?: string;
-    
+  user: UserResponse;
 
-        
-    selector_source?: string;
-    
+  comment_id?: string;
 
-        
-    text?: string;
-    
+  custom?: Record<string, any>;
+}
 
-        
-    visibility_tag?: string;
-    
+export interface FeedsV3ActivityResponse {
+  bookmark_count: number;
 
-        
-    friend_reactions?: Array<FeedsReactionResponse>;
-    
+  comment_count: number;
 
-        
-    current_feed?: FeedsFeedResponse;
-    
+  created_at: Date;
 
-        
-    location?: FeedsActivityLocation;
-    
+  hidden: boolean;
 
-        
-    metrics?: Record<string, number>;
-    
+  id: string;
 
-        
-    moderation?: ModerationV2Response;
-    
+  popularity: number;
 
-        
-    notification_context?: FeedsNotificationContext;
-    
+  preview: boolean;
 
-        
-    parent?: FeedsV3ActivityResponse;
-    
+  reaction_count: number;
 
-        
-    poll?: PollResponseData;
-    
+  restrict_replies: string;
 
-        
-    score_vars?: Record<string, any>;
-    
+  score: number;
 
-        }
-    
+  share_count: number;
 
+  type: string;
 
+  updated_at: Date;
 
+  visibility: string;
 
-    export interface FeedsV3CommentResponse {
-    bookmark_count: number;
-    
+  attachments: Attachment[];
 
-        
-    confidence_score: number;
-    
+  comments: FeedsV3CommentResponse[];
 
-        
-    created_at: Date;
-    
+  feeds: string[];
 
-        
-    downvote_count: number;
-    
+  filter_tags: string[];
 
-        
-    id: string;
-    
+  interest_tags: string[];
 
-        
-    object_id: string;
-    
+  latest_reactions: FeedsReactionResponse[];
 
-        
-    object_type: string;
-    
+  mentioned_users: UserResponse[];
 
-        
-    reaction_count: number;
-    
+  own_bookmarks: FeedsBookmarkResponse[];
 
-        
-    reply_count: number;
-    
+  own_reactions: FeedsReactionResponse[];
 
-        
-    score: number;
-    
+  collections: Record<string, FeedsEnrichedCollectionResponse>;
 
-        
-    status: string;
-    
+  custom: Record<string, any>;
 
-        
-    updated_at: Date;
-    
+  reaction_groups: Record<string, FeedsReactionGroupResponse>;
 
-        
-    upvote_count: number;
-    
+  search_data: Record<string, any>;
 
-        
-    mentioned_users: Array<UserResponse>;
-    
+  user: UserResponse;
 
-        
-    own_reactions: Array<FeedsReactionResponse>;
-    
+  deleted_at?: Date;
 
-        
-    user: UserResponse;
-    
+  edited_at?: Date;
 
-        
-    controversy_score?: number;
-    
+  expires_at?: Date;
 
-        
-    deleted_at?: Date;
-    
+  friend_reaction_count?: number;
 
-        
-    edited_at?: Date;
-    
+  is_read?: boolean;
 
-        
-    parent_id?: string;
-    
+  is_seen?: boolean;
 
-        
-    text?: string;
-    
+  is_watched?: boolean;
 
-        
-    attachments?: Array<Attachment>;
-    
+  moderation_action?: string;
 
-        
-    latest_reactions?: Array<FeedsReactionResponse>;
-    
+  selector_source?: string;
 
-        
-    custom?: Record<string, any>;
-    
+  text?: string;
 
-        
-    moderation?: ModerationV2Response;
-    
+  visibility_tag?: string;
 
-        
-    reaction_groups?: Record<string, FeedsReactionGroupResponse>;
-    
+  friend_reactions?: FeedsReactionResponse[];
 
-        }
-    
+  current_feed?: FeedsFeedResponse;
 
+  location?: FeedsActivityLocation;
 
+  metrics?: Record<string, number>;
 
+  moderation?: ModerationV2Response;
 
-    export interface Field {
-    short: boolean;
-    
+  notification_context?: FeedsNotificationContext;
 
-        
-    title: string;
-    
+  parent?: FeedsV3ActivityResponse;
 
-        
-    value: string;
-    
+  poll?: PollResponseData;
 
-        }
-    
+  score_vars?: Record<string, any>;
+}
 
+export interface FeedsV3CommentResponse {
+  bookmark_count: number;
 
+  confidence_score: number;
 
+  created_at: Date;
 
-    export interface FileUploadConfig {
-    size_limit: number;
-    
+  downvote_count: number;
 
-        
-    allowed_file_extensions: Array<string>;
-    
+  id: string;
 
-        
-    allowed_mime_types: Array<string>;
-    
+  object_id: string;
 
-        
-    blocked_file_extensions: Array<string>;
-    
+  object_type: string;
 
-        
-    blocked_mime_types: Array<string>;
-    
+  reaction_count: number;
 
-        }
-    
+  reply_count: number;
 
+  score: number;
 
+  status: string;
 
+  updated_at: Date;
 
-    export interface FileUploadRequest {
-    /**
-     * file field
-     */
-    file?: string;
-    
+  upvote_count: number;
 
-        
-    user?: OnlyUserID;
-    
+  mentioned_users: UserResponse[];
 
-        }
-    
+  own_reactions: FeedsReactionResponse[];
 
+  user: UserResponse;
 
+  controversy_score?: number;
 
+  deleted_at?: Date;
 
-    export interface FileUploadResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  edited_at?: Date;
 
-        
-    /**
-     * URL to the uploaded asset. Should be used to put to `asset_url` attachment field
-     */
-    file?: string;
-    
+  parent_id?: string;
 
-        
-    /**
-     * URL of the file thumbnail for supported file formats. Should be put to `thumb_url` attachment field
-     */
-    thumb_url?: string;
-    
+  text?: string;
 
-        }
-    
+  attachments?: Attachment[];
 
+  latest_reactions?: FeedsReactionResponse[];
 
+  custom?: Record<string, any>;
 
+  moderation?: ModerationV2Response;
 
-    export interface FilterConfigResponse {
-    llm_labels: Array<string>;
-    
+  reaction_groups?: Record<string, FeedsReactionGroupResponse>;
+}
 
-        
-    ai_text_labels?: Array<string>;
-    
+export interface Field {
+  short: boolean;
 
-        
-    config_keys?: Array<string>;
-    
+  title: string;
 
-        }
-    
+  value: string;
+}
 
+export interface FileUploadConfig {
+  size_limit: number;
 
+  allowed_file_extensions: string[];
 
+  allowed_mime_types: string[];
 
-    export interface FlagCountRuleParameters {
-    threshold?: number;
-    
+  blocked_file_extensions: string[];
 
-        }
-    
+  blocked_mime_types: string[];
+}
 
+export interface FileUploadRequest {
+  /**
+   * file field
+   */
+  file?: string;
 
+  user?: OnlyUserID;
+}
 
+export interface FileUploadResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-    export interface FlagRequest {
-    /**
-     * Unique identifier of the entity being flagged
-     */
-    entity_id: string;
-    
+  /**
+   * URL to the uploaded asset. Should be used to put to `asset_url` attachment field
+   */
+  file?: string;
 
-        
-    /**
-     * Type of entity being flagged (e.g., message, user)
-     */
-    entity_type: string;
-    
+  /**
+   * URL of the file thumbnail for supported file formats. Should be put to `thumb_url` attachment field
+   */
+  thumb_url?: string;
+}
 
-        
-    /**
-     * ID of the user who created the flagged entity
-     */
-    entity_creator_id?: string;
-    
+export interface FilterConfigResponse {
+  llm_labels: string[];
 
-        
-    /**
-     * Optional explanation for why the content is being flagged
-     */
-    reason?: string;
-    
+  ai_text_labels?: string[];
 
-        
-    /**
-     * Additional metadata about the flag
-     */
-    custom?: Record<string, any>;
-    
+  config_keys?: string[];
+}
 
-        
-    moderation_payload?: ModerationPayload;
-    
+export interface FlagCountRuleParameters {
+  threshold?: number;
+}
 
-        }
-    
+export interface FlagRequest {
+  /**
+   * Unique identifier of the entity being flagged
+   */
+  entity_id: string;
 
+  /**
+   * Type of entity being flagged (e.g., message, user)
+   */
+  entity_type: string;
 
+  /**
+   * ID of the user who created the flagged entity
+   */
+  entity_creator_id?: string;
 
+  /**
+   * Optional explanation for why the content is being flagged
+   */
+  reason?: string;
 
-    export interface FlagResponse {
-    duration: string;
-    
+  /**
+   * Additional metadata about the flag
+   */
+  custom?: Record<string, any>;
 
-        
-    /**
-     * Unique identifier of the created moderation item
-     */
-    item_id: string;
-    
+  moderation_payload?: ModerationPayload;
+}
 
-        }
-    
+export interface FlagResponse {
+  duration: string;
 
+  /**
+   * Unique identifier of the created moderation item
+   */
+  item_id: string;
+}
 
+export interface FlagUserOptions {
+  reason?: string;
+}
 
+export interface FollowBatchRequest {
+  /**
+   * List of follow relationships to create
+   */
+  follows: FollowRequest[];
 
-    export interface FlagUserOptions {
-    reason?: string;
-    
+  /**
+   * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+   */
+  enrich_own_fields?: boolean;
+}
 
-        }
-    
+export interface FollowBatchResponse {
+  duration: string;
 
+  /**
+   * List of newly created follow relationships
+   */
+  created: FollowResponse[];
 
+  /**
+   * List of current follow relationships
+   */
+  follows: FollowResponse[];
+}
 
+export interface FollowCreatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-    export interface FollowBatchRequest {
-    /**
-     * List of follow relationships to create
-     */
-    follows: Array<FollowRequest>;
-    
+  fid: string;
 
-        
-    /**
-     * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-     */
-    enrich_own_fields?: boolean;
-    
+  custom: Record<string, any>;
 
-        }
-    
+  follow: FollowResponse;
 
+  /**
+   * The type of event: "feeds.follow.created" in this case
+   */
+  type: string;
 
+  feed_visibility?: string;
 
+  received_at?: Date;
+}
 
-    export interface FollowBatchResponse {
-    duration: string;
-    
+export interface FollowDeletedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    /**
-     * List of newly created follow relationships
-     */
-    created: Array<FollowResponse>;
-    
+  fid: string;
 
-        
-    /**
-     * List of current follow relationships
-     */
-    follows: Array<FollowResponse>;
-    
+  custom: Record<string, any>;
 
-        }
-    
+  follow: FollowResponse;
 
+  /**
+   * The type of event: "feeds.follow.deleted" in this case
+   */
+  type: string;
 
+  feed_visibility?: string;
 
+  received_at?: Date;
+}
 
-    export interface FollowCreatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+export interface FollowRequest {
+  /**
+   * Fully qualified ID of the source feed
+   */
+  source: string;
 
-        
-    fid: string;
-    
+  /**
+   * Fully qualified ID of the target feed
+   */
+  target: string;
 
-        
-    custom: Record<string, any>;
-    
+  /**
+   * Maximum number of historical activities to copy from the target feed when the follow is first materialized. Not set = unlimited (default). 0 = copy nothing. Range: 0-1000.
+   */
+  activity_copy_limit?: number;
 
-        
-    follow: FollowResponse;
-    
+  /**
+   * @deprecated
+   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+   */
+  copy_custom_to_notification?: boolean;
 
-        
-    /**
-     * The type of event: "feeds.follow.created" in this case
-     */
-    type: string;
-    
+  /**
+   * Whether to create a notification activity for this follow
+   */
+  create_notification_activity?: boolean;
 
-        
-    feed_visibility?: string;
-    
+  /**
+   * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+   */
+  enrich_own_fields?: boolean;
 
-        
-    received_at?: Date;
-    
+  /**
+   * Push preference for the follow relationship
+   */
 
-        }
-    
+  push_preference?: 'all' | 'none';
 
+  /**
+   * Whether to skip push for this follow
+   */
+  skip_push?: boolean;
 
+  /**
+   * Custom data for the follow relationship
+   */
+  custom?: Record<string, any>;
+}
 
+export interface FollowResponse {
+  /**
+   * When the follow relationship was created
+   */
+  created_at: Date;
 
-    export interface FollowDeletedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  /**
+   * Role of the follower (source user) in the follow relationship
+   */
+  follower_role: string;
 
-        
-    fid: string;
-    
+  /**
+   * Push preference for notifications. One of: all, none
+   */
 
-        
-    custom: Record<string, any>;
-    
+  push_preference: 'all' | 'none';
 
-        
-    follow: FollowResponse;
-    
+  /**
+   * Status of the follow relationship. One of: accepted, pending, rejected
+   */
 
-        
-    /**
-     * The type of event: "feeds.follow.deleted" in this case
-     */
-    type: string;
-    
+  status: 'accepted' | 'pending' | 'rejected';
 
-        
-    feed_visibility?: string;
-    
+  /**
+   * When the follow relationship was last updated
+   */
+  updated_at: Date;
 
-        
-    received_at?: Date;
-    
+  source_feed: FeedResponse;
 
-        }
-    
+  target_feed: FeedResponse;
 
+  /**
+   * When the follow request was accepted
+   */
+  request_accepted_at?: Date;
 
+  /**
+   * When the follow request was rejected
+   */
+  request_rejected_at?: Date;
 
+  /**
+   * Custom data for the follow relationship
+   */
+  custom?: Record<string, any>;
+}
 
-    export interface FollowRequest {
-    /**
-     * Fully qualified ID of the source feed
-     */
-    source: string;
-    
+export interface FollowUpdatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    /**
-     * Fully qualified ID of the target feed
-     */
-    target: string;
-    
+  fid: string;
 
-        
-    /**
-     * Maximum number of historical activities to copy from the target feed when the follow is first materialized. Not set = unlimited (default). 0 = copy nothing. Range: 0-1000.
-     */
-    activity_copy_limit?: number;
-    
+  custom: Record<string, any>;
 
-        
-    /**
-     * @deprecated
-     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-     */
-    copy_custom_to_notification?: boolean;
-    
+  follow: FollowResponse;
 
-        
-    /**
-     * Whether to create a notification activity for this follow
-     */
-    create_notification_activity?: boolean;
-    
+  /**
+   * The type of event: "feeds.follow.updated" in this case
+   */
+  type: string;
 
-        
-    /**
-     * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-     */
-    enrich_own_fields?: boolean;
-    
+  feed_visibility?: string;
 
-        
-    /**
-     * Push preference for the follow relationship
-     */
-    
-        push_preference?:| "all" | "none" ;
+  received_at?: Date;
+}
 
-        
-    /**
-     * Whether to skip push for this follow
-     */
-    skip_push?: boolean;
-    
+export interface FriendReactionsOptions {
+  /**
+   * Default: false. When true, fetches friend reactions for activities.
+   */
+  enabled?: boolean;
 
-        
-    /**
-     * Custom data for the follow relationship
-     */
-    custom?: Record<string, any>;
-    
+  /**
+   * Default: 3, Max: 10. The maximum number of friend reactions to return per activity.
+   */
+  limit?: number;
 
-        }
-    
+  /**
+   * Default: 'following'. The type of friend relationship to use. 'following' = users you follow, 'mutual' = users with mutual follows. One of: following, mutual
+   */
 
+  type?: 'following' | 'mutual';
+}
 
+export interface FullUserResponse {
+  banned: boolean;
 
+  created_at: Date;
 
-    export interface FollowResponse {
-    /**
-     * When the follow relationship was created
-     */
-    created_at: Date;
-    
+  id: string;
 
-        
-    /**
-     * Role of the follower (source user) in the follow relationship
-     */
-    follower_role: string;
-    
+  invisible: boolean;
 
-        
-    /**
-     * Push preference for notifications. One of: all, none
-     */
-    
-        push_preference:| "all" | "none" ;
+  language: string;
 
-        
-    /**
-     * Status of the follow relationship. One of: accepted, pending, rejected
-     */
-    
-        status:| "accepted" | "pending" | "rejected" ;
+  online: boolean;
 
-        
-    /**
-     * When the follow relationship was last updated
-     */
-    updated_at: Date;
-    
+  role: string;
 
-        
-    source_feed: FeedResponse;
-    
+  shadow_banned: boolean;
 
-        
-    target_feed: FeedResponse;
-    
+  total_unread_count: number;
 
-        
-    /**
-     * When the follow request was accepted
-     */
-    request_accepted_at?: Date;
-    
+  unread_channels: number;
 
-        
-    /**
-     * When the follow request was rejected
-     */
-    request_rejected_at?: Date;
-    
+  unread_count: number;
 
-        
-    /**
-     * Custom data for the follow relationship
-     */
-    custom?: Record<string, any>;
-    
+  unread_threads: number;
 
-        }
-    
+  updated_at: Date;
 
+  blocked_user_ids: string[];
 
+  channel_mutes: ChannelMute[];
 
+  devices: DeviceResponse[];
 
-    export interface FollowUpdatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  mutes: UserMuteResponse[];
 
-        
-    fid: string;
-    
+  teams: string[];
 
-        
-    custom: Record<string, any>;
-    
+  custom: Record<string, any>;
 
-        
-    follow: FollowResponse;
-    
+  avg_response_time?: number;
 
-        
-    /**
-     * The type of event: "feeds.follow.updated" in this case
-     */
-    type: string;
-    
+  ban_expires?: Date;
 
-        
-    feed_visibility?: string;
-    
+  deactivated_at?: Date;
 
-        
-    received_at?: Date;
-    
+  deleted_at?: Date;
 
-        }
-    
+  image?: string;
 
+  last_active?: Date;
 
+  name?: string;
 
+  revoke_tokens_issued_before?: Date;
 
-    export interface FriendReactionsOptions {
-    /**
-     * Default: false. When true, fetches friend reactions for activities.
-     */
-    enabled?: boolean;
-    
+  latest_hidden_channels?: string[];
 
-        
-    /**
-     * Default: 3, Max: 10. The maximum number of friend reactions to return per activity.
-     */
-    limit?: number;
-    
+  privacy_settings?: PrivacySettingsResponse;
 
-        
-    /**
-     * Default: 'following'. The type of friend relationship to use. 'following' = users you follow, 'mutual' = users with mutual follows. One of: following, mutual
-     */
-    
-        type?:| "following" | "mutual" ;
+  teams_role?: Record<string, string>;
+}
 
-        }
-    
+export interface GetActionConfigResponse {
+  duration: string;
 
+  /**
+   * Moderation action configs grouped by entity type, sorted by order ascending
+   */
+  action_config: Record<string, ModerationActionConfigResponse[]>;
+}
 
+export interface GetActivityResponse {
+  duration: string;
 
+  activity: ActivityResponse;
+}
 
-    export interface FullUserResponse {
-    banned: boolean;
-    
+export interface GetAppealResponse {
+  duration: string;
 
-        
-    created_at: Date;
-    
+  item?: AppealItemResponse;
+}
 
-        
-    id: string;
-    
+export interface GetApplicationResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-        
-    invisible: boolean;
-    
+  app: AppResponseFields;
+}
 
-        
-    language: string;
-    
+export interface GetBlockedUsersResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-        
-    online: boolean;
-    
+  /**
+   * Array of blocked user object
+   */
+  blocks: BlockedUserResponse[];
+}
 
-        
-    role: string;
-    
+export interface GetCommentRepliesResponse {
+  duration: string;
 
-        
-    shadow_banned: boolean;
-    
+  /**
+   * Sort order used for the replies (first, last, top, best, controversial)
+   */
+  sort: string;
 
-        
-    total_unread_count: number;
-    
+  /**
+   * Threaded listing of replies to the comment
+   */
+  comments: ThreadedCommentResponse[];
 
-        
-    unread_channels: number;
-    
+  next?: string;
 
-        
-    unread_count: number;
-    
+  prev?: string;
+}
 
-        
-    unread_threads: number;
-    
+export interface GetCommentResponse {
+  duration: string;
 
-        
-    updated_at: Date;
-    
+  comment: CommentResponse;
+}
 
-        
-    blocked_user_ids: Array<string>;
-    
+export interface GetCommentsResponse {
+  duration: string;
 
-        
-    channel_mutes: Array<ChannelMute>;
-    
+  /**
+   * Sort order used for the comments (first, last, top, best, controversial)
+   */
+  sort: string;
 
-        
-    devices: Array<DeviceResponse>;
-    
+  /**
+   * Threaded listing for the activity
+   */
+  comments: ThreadedCommentResponse[];
 
-        
-    mutes: Array<UserMuteResponse>;
-    
+  next?: string;
 
-        
-    teams: Array<string>;
-    
+  prev?: string;
+}
 
-        
-    custom: Record<string, any>;
-    
+export interface GetConfigResponse {
+  duration: string;
 
-        
-    avg_response_time?: number;
-    
+  config?: ConfigResponse;
+}
 
-        
-    ban_expires?: Date;
-    
+export interface GetFollowSuggestionsResponse {
+  duration: string;
 
-        
-    deactivated_at?: Date;
-    
+  /**
+   * List of suggested feeds to follow
+   */
+  suggestions: FeedSuggestionResponse[];
 
-        
-    deleted_at?: Date;
-    
+  algorithm_used?: string;
+}
 
-        
-    image?: string;
-    
+export interface GetOGResponse {
+  duration: string;
 
-        
-    last_active?: Date;
-    
+  custom: Record<string, any>;
 
-        
-    name?: string;
-    
+  /**
+   * URL of detected video or audio
+   */
+  asset_url?: string;
 
-        
-    revoke_tokens_issued_before?: Date;
-    
+  author_icon?: string;
 
-        
-    latest_hidden_channels?: Array<string>;
-    
+  /**
+   * og:site
+   */
+  author_link?: string;
 
-        
-    privacy_settings?: PrivacySettingsResponse;
-    
+  /**
+   * og:site_name
+   */
+  author_name?: string;
 
-        
-    teams_role?: Record<string, string>;
-    
+  color?: string;
 
-        }
-    
+  fallback?: string;
 
+  footer?: string;
 
+  footer_icon?: string;
 
+  /**
+   * URL of detected image
+   */
+  image_url?: string;
 
-    export interface GetActionConfigResponse {
-    duration: string;
-    
+  /**
+   * extracted url from the text
+   */
+  og_scrape_url?: string;
 
-        
-    /**
-     * Moderation action configs grouped by entity type, sorted by order ascending
-     */
-    action_config: Record<string, Array<ModerationActionConfigResponse>>;
-    
+  original_height?: number;
 
-        }
-    
+  original_width?: number;
 
+  pretext?: string;
 
+  /**
+   * og:description
+   */
+  text?: string;
 
+  /**
+   * URL of detected thumb image
+   */
+  thumb_url?: string;
 
-    export interface GetActivityResponse {
-    duration: string;
-    
+  /**
+   * og:title
+   */
+  title?: string;
 
-        
-    activity: ActivityResponse;
-    
+  /**
+   * og:url
+   */
+  title_link?: string;
 
-        }
-    
+  /**
+   * Attachment type, could be empty, image, audio or video
+   */
+  type?: string;
 
+  actions?: Action[];
 
+  fields?: Field[];
 
+  giphy?: Images;
+}
 
-    export interface GetAppealResponse {
-    duration: string;
-    
+export interface GetOrCreateFeedRequest {
+  id_around?: string;
 
-        
-    item?: AppealItemResponse;
-    
+  limit?: number;
 
-        }
-    
+  next?: string;
 
+  prev?: string;
 
+  view?: string;
 
+  watch?: boolean;
 
-    export interface GetApplicationResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  data?: FeedInput;
 
-        
-    app: AppResponseFields;
-    
+  enrichment_options?: EnrichmentOptions;
 
-        }
-    
+  external_ranking?: Record<string, any>;
 
+  filter?: Record<string, any>;
 
+  followers_pagination?: PagerRequest;
 
+  following_pagination?: PagerRequest;
 
-    export interface GetBlockedUsersResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  friend_reactions_options?: FriendReactionsOptions;
 
-        
-    /**
-     * Array of blocked user object
-     */
-    blocks: Array<BlockedUserResponse>;
-    
+  interest_weights?: Record<string, number>;
 
-        }
-    
+  member_pagination?: PagerRequest;
+}
 
+export interface GetOrCreateFeedResponse {
+  created: boolean;
 
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
+  activities: ActivityResponse[];
 
-    export interface GetCommentRepliesResponse {
-    duration: string;
-    
+  aggregated_activities: AggregatedActivityResponse[];
 
-        
-    /**
-     * Sort order used for the replies (first, last, top, best, controversial)
-     */
-    sort: string;
-    
+  followers: FollowResponse[];
 
-        
-    /**
-     * Threaded listing of replies to the comment
-     */
-    comments: Array<ThreadedCommentResponse>;
-    
+  following: FollowResponse[];
 
-        
-    next?: string;
-    
+  members: FeedMemberResponse[];
 
-        
-    prev?: string;
-    
+  pinned_activities: ActivityPinResponse[];
 
-        }
-    
+  feed: FeedResponse;
 
+  next?: string;
 
+  prev?: string;
 
+  followers_pagination?: PagerResponse;
 
-    export interface GetCommentResponse {
-    duration: string;
-    
+  following_pagination?: PagerResponse;
 
-        
-    comment: CommentResponse;
-    
+  member_pagination?: PagerResponse;
 
-        }
-    
+  notification_status?: NotificationStatusResponse;
+}
 
+export interface GetUserGroupResponse {
+  duration: string;
 
+  user_group?: UserGroupResponse;
+}
 
+export interface GoogleVisionConfig {
+  enabled?: boolean;
+}
 
-    export interface GetCommentsResponse {
-    duration: string;
-    
+export interface HarmConfig {
+  cooldown_period: number;
 
-        
-    /**
-     * Sort order used for the comments (first, last, top, best, controversial)
-     */
-    sort: string;
-    
+  severity: number;
 
-        
-    /**
-     * Threaded listing for the activity
-     */
-    comments: Array<ThreadedCommentResponse>;
-    
+  threshold: number;
 
-        
-    next?: string;
-    
+  action_sequences: ActionSequence[];
 
-        
-    prev?: string;
-    
+  harm_types: string[];
+}
 
-        }
-    
+export interface HealthCheckEvent {
+  connection_id: string;
 
+  created_at: Date;
 
+  custom: Record<string, any>;
 
+  type: string;
 
-    export interface GetConfigResponse {
-    duration: string;
-    
+  cid?: string;
 
-        
-    config?: ConfigResponse;
-    
+  received_at?: Date;
 
-        }
-    
+  me?: OwnUserResponse;
+}
 
+export interface ImageContentParameters {
+  label_operator?: string;
 
+  min_confidence?: number;
 
+  harm_labels?: string[];
+}
 
-    export interface GetFollowSuggestionsResponse {
-    duration: string;
-    
+export interface ImageData {
+  frames: string;
 
-        
-    /**
-     * List of suggested feeds to follow
-     */
-    suggestions: Array<FeedSuggestionResponse>;
-    
+  height: string;
 
-        
-    algorithm_used?: string;
-    
+  size: string;
 
-        }
-    
+  url: string;
 
+  width: string;
+}
 
+export interface ImageRuleParameters {
+  min_confidence?: number;
 
+  threshold?: number;
 
-    export interface GetOGResponse {
-    duration: string;
-    
+  time_window?: string;
 
-        
-    custom: Record<string, any>;
-    
+  harm_labels?: string[];
+}
 
-        
-    /**
-     * URL of detected video or audio
-     */
-    asset_url?: string;
-    
+export interface ImageSize {
+  /**
+   * Crop mode. One of: top, bottom, left, right, center
+   */
+  crop?: string;
 
-        
-    author_icon?: string;
-    
+  /**
+   * Target image height
+   */
+  height?: number;
 
-        
-    /**
-     * og:site
-     */
-    author_link?: string;
-    
+  /**
+   * Resize method. One of: clip, crop, scale, fill
+   */
+  resize?: string;
 
-        
-    /**
-     * og:site_name
-     */
-    author_name?: string;
-    
+  /**
+   * Target image width
+   */
+  width?: number;
+}
 
-        
-    color?: string;
-    
+export interface ImageUploadRequest {
+  file?: string;
 
-        
-    fallback?: string;
-    
+  /**
+   * field with JSON-encoded array of image size configurations
+   */
+  upload_sizes?: ImageSize[];
 
-        
-    footer?: string;
-    
+  user?: OnlyUserID;
+}
 
-        
-    footer_icon?: string;
-    
+export interface ImageUploadResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-        
-    /**
-     * URL of detected image
-     */
-    image_url?: string;
-    
+  file?: string;
 
-        
-    /**
-     * extracted url from the text
-     */
-    og_scrape_url?: string;
-    
+  thumb_url?: string;
 
-        
-    original_height?: number;
-    
+  /**
+   * Array of image size configurations
+   */
+  upload_sizes?: ImageSize[];
+}
 
-        
-    original_width?: number;
-    
+export interface Images {
+  fixed_height: ImageData;
 
-        
-    pretext?: string;
-    
+  fixed_height_downsampled: ImageData;
 
-        
-    /**
-     * og:description
-     */
-    text?: string;
-    
+  fixed_height_still: ImageData;
 
-        
-    /**
-     * URL of detected thumb image
-     */
-    thumb_url?: string;
-    
+  fixed_width: ImageData;
 
-        
-    /**
-     * og:title
-     */
-    title?: string;
-    
+  fixed_width_downsampled: ImageData;
 
-        
-    /**
-     * og:url
-     */
-    title_link?: string;
-    
+  fixed_width_still: ImageData;
 
-        
-    /**
-     * Attachment type, could be empty, image, audio or video
-     */
-    type?: string;
-    
+  original: ImageData;
+}
 
-        
-    actions?: Array<Action>;
-    
+export interface KeyframeRuleParameters {
+  min_confidence?: number;
 
-        
-    fields?: Array<Field>;
-    
+  threshold?: number;
 
-        
-    giphy?: Images;
-    
+  harm_labels?: string[];
+}
 
-        }
-    
+export interface LLMConfig {
+  enabled: boolean;
 
+  rules: LLMRule[];
 
+  app_context?: string;
 
+  async?: boolean;
 
-    export interface GetOrCreateFeedRequest {
-    id_around?: string;
-    
+  severity_descriptions?: Record<string, string>;
+}
 
-        
-    limit?: number;
-    
+export interface LLMRule {
+  action:
+    | 'flag'
+    | 'shadow'
+    | 'remove'
+    | 'bounce'
+    | 'bounce_flag'
+    | 'bounce_remove'
+    | 'keep';
 
-        
-    next?: string;
-    
+  description: string;
 
-        
-    prev?: string;
-    
+  label: string;
 
-        
-    view?: string;
-    
+  severity_rules: BodyguardSeverityRule[];
+}
 
-        
-    watch?: boolean;
-    
+export interface LabelThresholds {
+  /**
+   * Threshold for automatic message block
+   */
+  block?: number;
 
-        
-    data?: FeedInput;
-    
+  /**
+   * Threshold for automatic message flag
+   */
+  flag?: number;
+}
 
-        
-    enrichment_options?: EnrichmentOptions;
-    
+export interface ListBlockListResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-        
-    external_ranking?: Record<string, any>;
-    
+  blocklists: BlockListResponse[];
+}
 
-        
-    filter?: Record<string, any>;
-    
+export interface ListDevicesResponse {
+  duration: string;
 
-        
-    followers_pagination?: PagerRequest;
-    
+  /**
+   * List of devices
+   */
+  devices: DeviceResponse[];
+}
 
-        
-    following_pagination?: PagerRequest;
-    
+export interface ListUserGroupsResponse {
+  duration: string;
 
-        
-    friend_reactions_options?: FriendReactionsOptions;
-    
+  /**
+   * List of user groups
+   */
+  user_groups: UserGroupResponse[];
+}
 
-        
-    interest_weights?: Record<string, number>;
-    
+export interface Location {
+  /**
+   * Latitude coordinate
+   */
+  lat: number;
 
-        
-    member_pagination?: PagerRequest;
-    
+  /**
+   * Longitude coordinate
+   */
+  lng: number;
+}
 
-        }
-    
+export interface MarkActivityRequest {
+  /**
+   * Whether to mark all activities as read
+   */
+  mark_all_read?: boolean;
 
+  /**
+   * Whether to mark all activities as seen
+   */
+  mark_all_seen?: boolean;
 
+  /**
+   * List of activity IDs to mark as read
+   */
+  mark_read?: string[];
 
+  /**
+   * List of activity IDs to mark as seen
+   */
+  mark_seen?: string[];
 
-    export interface GetOrCreateFeedResponse {
-    created: boolean;
-    
+  /**
+   * List of activity IDs to mark as watched (for stories)
+   */
+  mark_watched?: string[];
+}
 
-        
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+export interface MarkReviewedRequestPayload {
+  /**
+   * Maximum content items to mark as reviewed
+   */
+  content_to_mark_as_reviewed_limit?: number;
 
-        
-    activities: Array<ActivityResponse>;
-    
+  /**
+   * Reason for the appeal decision
+   */
+  decision_reason?: string;
 
-        
-    aggregated_activities: Array<AggregatedActivityResponse>;
-    
+  /**
+   * Skip marking content as reviewed
+   */
+  disable_marking_content_as_reviewed?: boolean;
+}
 
-        
-    followers: Array<FollowResponse>;
-    
+export interface MembershipLevelResponse {
+  /**
+   * When the membership level was created
+   */
+  created_at: Date;
 
-        
-    following: Array<FollowResponse>;
-    
+  /**
+   * Unique identifier for the membership level
+   */
+  id: string;
 
-        
-    members: Array<FeedMemberResponse>;
-    
+  /**
+   * Display name for the membership level
+   */
+  name: string;
 
-        
-    pinned_activities: Array<ActivityPinResponse>;
-    
+  /**
+   * Priority level
+   */
+  priority: number;
 
-        
-    feed: FeedResponse;
-    
+  /**
+   * When the membership level was last updated
+   */
+  updated_at: Date;
 
-        
-    next?: string;
-    
+  /**
+   * Activity tags this membership level gives access to
+   */
+  tags: string[];
 
-        
-    prev?: string;
-    
+  /**
+   * Description of the membership level
+   */
+  description?: string;
 
-        
-    followers_pagination?: PagerResponse;
-    
+  /**
+   * Custom data for the membership level
+   */
+  custom?: Record<string, any>;
+}
 
-        
-    following_pagination?: PagerResponse;
-    
+export interface MessageResponse {
+  /**
+   * Channel unique identifier in <type>:<id> format
+   */
+  cid: string;
 
-        
-    member_pagination?: PagerResponse;
-    
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    notification_status?: NotificationStatusResponse;
-    
+  deleted_reply_count: number;
 
-        }
-    
+  /**
+   * Contains HTML markup of the message. Can only be set when using server-side API
+   */
+  html: string;
 
+  /**
+   * Message ID is unique string identifier of the message
+   */
+  id: string;
 
+  /**
+   * Whether the message mentioned the channel tag
+   */
+  mentioned_channel: boolean;
 
+  /**
+   * Whether the message mentioned online users with @here tag
+   */
+  mentioned_here: boolean;
 
-    export interface GetUserGroupResponse {
-    duration: string;
-    
+  /**
+   * Whether message is pinned or not
+   */
+  pinned: boolean;
 
-        
-    user_group?: UserGroupResponse;
-    
+  /**
+   * Number of replies to this message
+   */
+  reply_count: number;
 
-        }
-    
+  /**
+   * Whether the message was shadowed or not
+   */
+  shadowed: boolean;
 
+  /**
+   * Whether message is silent or not
+   */
+  silent: boolean;
 
+  /**
+   * Text of the message. Should be empty if `mml` is provided
+   */
+  text: string;
 
+  /**
+   * Contains type of the message. One of: regular, ephemeral, error, reply, system, deleted
+   */
+  type: string;
 
-    export interface GoogleVisionConfig {
-    enabled?: boolean;
-    
+  /**
+   * Date/time of the last update
+   */
+  updated_at: Date;
 
-        }
-    
+  /**
+   * Array of message attachments
+   */
+  attachments: Attachment[];
 
+  /**
+   * List of 10 latest reactions to this message
+   */
+  latest_reactions: ReactionResponse[];
 
+  /**
+   * List of mentioned users
+   */
+  mentioned_users: UserResponse[];
 
+  /**
+   * List of 10 latest reactions of authenticated user to this message
+   */
+  own_reactions: ReactionResponse[];
 
-    export interface HarmConfig {
-    cooldown_period: number;
-    
+  /**
+   * A list of user ids that have restricted visibility to the message, if the list is not empty, the message is only visible to the users in the list
+   */
+  restricted_visibility: string[];
 
-        
-    severity: number;
-    
+  custom: Record<string, any>;
 
-        
-    threshold: number;
-    
+  /**
+   * An object containing number of reactions of each type. Key: reaction type (string), value: number of reactions (int)
+   */
+  reaction_counts: Record<string, number>;
 
-        
-    action_sequences: Array<ActionSequence>;
-    
+  /**
+   * An object containing scores of reactions of each type. Key: reaction type (string), value: total score of reactions (int)
+   */
+  reaction_scores: Record<string, number>;
 
-        
-    harm_types: Array<string>;
-    
+  user: UserResponse;
 
-        }
-    
+  /**
+   * Contains provided slash command
+   */
+  command?: string;
 
+  /**
+   * Date/time of deletion
+   */
+  deleted_at?: Date;
 
+  deleted_for_me?: boolean;
 
+  message_text_updated_at?: Date;
 
-    export interface HealthCheckEvent {
-    connection_id: string;
-    
+  /**
+   * Should be empty if `text` is provided. Can only be set when using server-side API
+   */
+  mml?: string;
 
-        
-    created_at: Date;
-    
+  /**
+   * ID of parent message (thread)
+   */
+  parent_id?: string;
 
-        
-    custom: Record<string, any>;
-    
+  /**
+   * Date when pinned message expires
+   */
+  pin_expires?: Date;
 
-        
-    type: string;
-    
+  /**
+   * Date when message got pinned
+   */
+  pinned_at?: Date;
 
-        
-    cid?: string;
-    
+  /**
+   * Identifier of the poll to include in the message
+   */
+  poll_id?: string;
 
-        
-    received_at?: Date;
-    
+  quoted_message_id?: string;
 
-        
-    me?: OwnUserResponse;
-    
+  /**
+   * Whether thread reply should be shown in the channel as well
+   */
+  show_in_channel?: boolean;
 
-        }
-    
+  /**
+   * List of user group IDs mentioned in the message. Group members who are also channel members will receive push notifications based on their push preferences. Max 10 groups
+   */
+  mentioned_group_ids?: string[];
 
+  /**
+   * List of roles mentioned in the message (e.g. admin, channel_moderator, custom roles). Members with matching roles will receive push notifications based on their push preferences. Max 10 roles
+   */
+  mentioned_roles?: string[];
 
+  /**
+   * List of users who participate in thread
+   */
+  thread_participants?: UserResponse[];
 
+  draft?: DraftResponse;
 
-    export interface ImageContentParameters {
-    label_operator?: string;
-    
+  /**
+   * Object with translations. Key `language` contains the original language key. Other keys contain translations
+   */
+  i18n?: Record<string, string>;
 
-        
-    min_confidence?: number;
-    
+  /**
+   * Contains image moderation information
+   */
+  image_labels?: Record<string, string[]>;
 
-        
-    harm_labels?: Array<string>;
-    
+  member?: ChannelMemberResponse;
 
-        }
-    
+  moderation?: ModerationV2Response;
 
+  pinned_by?: UserResponse;
 
+  poll?: PollResponseData;
 
+  quoted_message?: MessageResponse;
 
-    export interface ImageData {
-    frames: string;
-    
+  reaction_groups?: Record<string, ReactionGroupResponse>;
 
-        
-    height: string;
-    
+  reminder?: ReminderResponseData;
 
-        
-    size: string;
-    
+  shared_location?: SharedLocationResponseData;
+}
 
-        
-    url: string;
-    
+export interface ModerationActionConfigResponse {
+  /**
+   * The action to take
+   */
+  action: string;
 
-        
-    width: string;
-    
+  /**
+   * Description of what this action does
+   */
+  description: string;
 
-        }
-    
+  /**
+   * Type of entity this action applies to
+   */
+  entity_type: string;
 
+  /**
+   * Icon for the dashboard
+   */
+  icon: string;
 
+  /**
+   * Display order (lower numbers shown first)
+   */
+  order: number;
 
+  id?: string;
 
-    export interface ImageRuleParameters {
-    min_confidence?: number;
-    
+  /**
+   * Queue type this action config belongs to
+   */
+  queue_type?: string;
 
-        
-    threshold?: number;
-    
+  /**
+   * Custom data for the action
+   */
+  custom?: Record<string, any>;
+}
 
-        
-    time_window?: string;
-    
+export interface ModerationCustomActionEvent {
+  /**
+   * The ID of the custom action that was executed
+   */
+  action_id: string;
 
-        
-    harm_labels?: Array<string>;
-    
+  created_at: Date;
 
-        }
-    
+  custom: Record<string, any>;
 
+  review_queue_item: ReviewQueueItemResponse;
 
+  type: string;
 
+  received_at?: Date;
 
-    export interface ImageSize {
-    /**
-     * Crop mode. One of: top, bottom, left, right, center
-     */
-    crop?: string;
-    
+  /**
+   * Additional options passed to the custom action
+   */
+  action_options?: Record<string, any>;
 
-        
-    /**
-     * Target image height
-     */
-    height?: number;
-    
+  message?: MessageResponse;
+}
 
-        
-    /**
-     * Resize method. One of: clip, crop, scale, fill
-     */
-    resize?: string;
-    
+export interface ModerationFlagResponse {
+  created_at: Date;
 
-        
-    /**
-     * Target image width
-     */
-    width?: number;
-    
+  entity_id: string;
 
-        }
-    
+  entity_type: string;
 
+  type: string;
 
+  updated_at: Date;
 
+  user_id: string;
 
-    export interface ImageUploadRequest {
-    file?: string;
-    
+  result: Array<Record<string, any>>;
 
-        
-    /**
-     * field with JSON-encoded array of image size configurations
-     */
-    upload_sizes?: Array<ImageSize>;
-    
+  entity_creator_id?: string;
 
-        
-    user?: OnlyUserID;
-    
+  reason?: string;
 
-        }
-    
+  review_queue_item_id?: string;
 
+  labels?: string[];
 
+  custom?: Record<string, any>;
 
+  moderation_payload?: ModerationPayloadResponse;
 
-    export interface ImageUploadResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  review_queue_item?: ReviewQueueItemResponse;
 
-        
-    file?: string;
-    
+  user?: UserResponse;
+}
 
-        
-    thumb_url?: string;
-    
+export interface ModerationFlaggedEvent {
+  /**
+   * The type of content that was flagged
+   */
+  content_type: string;
 
-        
-    /**
-     * Array of image size configurations
-     */
-    upload_sizes?: Array<ImageSize>;
-    
+  created_at: Date;
 
-        }
-    
+  /**
+   * The ID of the flagged content
+   */
+  object_id: string;
 
+  custom: Record<string, any>;
 
+  type: string;
 
+  received_at?: Date;
+}
 
-    export interface Images {
-    fixed_height: ImageData;
-    
+export interface ModerationMarkReviewedEvent {
+  created_at: Date;
 
-        
-    fixed_height_downsampled: ImageData;
-    
+  custom: Record<string, any>;
 
-        
-    fixed_height_still: ImageData;
-    
+  item: ReviewQueueItemResponse;
 
-        
-    fixed_width: ImageData;
-    
+  type: string;
 
-        
-    fixed_width_downsampled: ImageData;
-    
+  received_at?: Date;
 
-        
-    fixed_width_still: ImageData;
-    
+  message?: MessageResponse;
+}
 
-        
-    original: ImageData;
-    
+export interface ModerationPayload {
+  images?: string[];
 
-        }
-    
+  texts?: string[];
 
+  videos?: string[];
 
+  custom?: Record<string, any>;
+}
 
+export interface ModerationPayloadResponse {
+  /**
+   * Image URLs to moderate
+   */
+  images?: string[];
 
-    export interface KeyframeRuleParameters {
-    min_confidence?: number;
-    
+  /**
+   * Text content to moderate
+   */
+  texts?: string[];
 
-        
-    threshold?: number;
-    
+  /**
+   * Video URLs to moderate
+   */
+  videos?: string[];
 
-        
-    harm_labels?: Array<string>;
-    
+  /**
+   * Custom data for moderation
+   */
+  custom?: Record<string, any>;
+}
 
-        }
-    
+export interface ModerationV2Response {
+  action: string;
 
+  original_text: string;
 
+  blocklist_matched?: string;
 
+  platform_circumvented?: boolean;
 
-    export interface LLMConfig {
-    enabled: boolean;
-    
+  semantic_filter_matched?: string;
 
-        
-    rules: Array<LLMRule>;
-    
+  blocklists_matched?: string[];
 
-        
-    app_context?: string;
-    
+  image_harms?: string[];
 
-        
-    async?: boolean;
-    
+  text_harms?: string[];
+}
 
-        
-    severity_descriptions?: Record<string, string>;
-    
+export interface MuteRequest {
+  /**
+   * User IDs to mute (if multiple users)
+   */
+  target_ids: string[];
 
-        }
-    
+  /**
+   * Duration of mute in minutes
+   */
+  timeout?: number;
+}
 
+export interface MuteResponse {
+  duration: string;
 
+  /**
+   * Object with mutes (if multiple users were muted)
+   */
+  mutes?: UserMuteResponse[];
 
+  /**
+   * A list of users that can't be found. Common cause for this is deleted users
+   */
+  non_existing_users?: string[];
 
-    export interface LLMRule {
-    
-        action:| "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" | "keep" ;
+  own_user?: OwnUserResponse;
+}
 
-        
-    description: string;
-    
+export interface NotificationComment {
+  comment: string;
 
-        
-    label: string;
-    
+  id: string;
 
-        
-    severity_rules: Array<BodyguardSeverityRule>;
-    
+  user_id: string;
 
-        }
-    
+  attachments?: Attachment[];
+}
 
+export interface NotificationConfig {
+  deduplication_window?: string;
 
+  track_read?: boolean;
 
+  track_seen?: boolean;
+}
 
-    export interface LabelThresholds {
-    /**
-     * Threshold for automatic message block
-     */
-    block?: number;
-    
+export interface NotificationContext {
+  target?: NotificationTarget;
 
-        
-    /**
-     * Threshold for automatic message flag
-     */
-    flag?: number;
-    
+  trigger?: NotificationTrigger;
+}
 
-        }
-    
+export interface NotificationFeedUpdatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
+  /**
+   * The ID of the feed
+   */
+  fid: string;
 
+  custom: Record<string, any>;
 
+  /**
+   * The type of event: "feeds.notification_feed.updated" in this case
+   */
+  type: string;
 
-    export interface ListBlockListResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  feed_visibility?: string;
 
-        
-    blocklists: Array<BlockListResponse>;
-    
+  received_at?: Date;
 
-        }
-    
+  /**
+   * Aggregated activities for notification feeds
+   */
+  aggregated_activities?: AggregatedActivityResponse[];
 
+  notification_status?: NotificationStatusResponse;
 
+  user?: UserResponseCommonFields;
+}
 
+export interface NotificationParentActivity {
+  id: string;
 
-    export interface ListDevicesResponse {
-    duration: string;
-    
+  text?: string;
 
-        
-    /**
-     * List of devices
-     */
-    devices: Array<DeviceResponse>;
-    
+  type?: string;
 
-        }
-    
+  user_id?: string;
 
+  attachments?: Attachment[];
+}
 
+export interface NotificationStatusResponse {
+  /**
+   * Number of unread notifications
+   */
+  unread: number;
 
+  /**
+   * Number of unseen notifications
+   */
+  unseen: number;
 
-    export interface ListUserGroupsResponse {
-    duration: string;
-    
+  /**
+   * When notifications were last read
+   */
+  last_read_at?: Date;
 
-        
-    /**
-     * List of user groups
-     */
-    user_groups: Array<UserGroupResponse>;
-    
+  /**
+   * When notifications were last seen
+   */
+  last_seen_at?: Date;
 
-        }
-    
+  /**
+   * Deprecated: use is_read on each activity/group instead. IDs of activities that have been read. Capped at ~101 entries for aggregated feeds.
+   */
+  read_activities?: string[];
 
+  /**
+   * Deprecated: use is_seen on each activity/group instead. IDs of activities that have been seen. Capped at ~101 entries for aggregated feeds.
+   */
+  seen_activities?: string[];
+}
 
+export interface NotificationTarget {
+  /**
+   * The ID of the target (activity ID or user ID)
+   */
+  id: string;
 
+  /**
+   * The name of the target user (for user targets like follows)
+   */
+  name?: string;
 
-    export interface Location {
-    /**
-     * Latitude coordinate
-     */
-    lat: number;
-    
+  /**
+   * The text content of the target activity (for activity targets)
+   */
+  text?: string;
 
-        
-    /**
-     * Longitude coordinate
-     */
-    lng: number;
-    
+  /**
+   * The type of the target activity (for activity targets)
+   */
+  type?: string;
 
-        }
-    
+  /**
+   * The ID of the user who created the target activity (for activity targets)
+   */
+  user_id?: string;
 
+  /**
+   * Attachments on the target activity (for activity targets)
+   */
+  attachments?: Attachment[];
 
+  comment?: NotificationComment;
 
+  /**
+   * Custom data from the target activity
+   */
+  custom?: Record<string, any>;
 
-    export interface MarkActivityRequest {
-    /**
-     * Whether to mark all activities as read
-     */
-    mark_all_read?: boolean;
-    
+  parent_activity?: NotificationParentActivity;
+}
 
-        
-    /**
-     * Whether to mark all activities as seen
-     */
-    mark_all_seen?: boolean;
-    
+export interface NotificationTrigger {
+  /**
+   * Human-readable text describing the notification
+   */
+  text: string;
 
-        
-    /**
-     * List of activity IDs to mark as read
-     */
-    mark_read?: Array<string>;
-    
+  /**
+   * The type of notification (mention, reaction, comment, follow, etc.)
+   */
+  type: string;
 
-        
-    /**
-     * List of activity IDs to mark as seen
-     */
-    mark_seen?: Array<string>;
-    
+  comment?: NotificationComment;
 
-        
-    /**
-     * List of activity IDs to mark as watched (for stories)
-     */
-    mark_watched?: Array<string>;
-    
+  /**
+   * Custom data from the trigger object (comment, reaction, etc.)
+   */
+  custom?: Record<string, any>;
+}
 
-        }
-    
+export interface OCRRule {
+  action:
+    | 'flag'
+    | 'shadow'
+    | 'remove'
+    | 'bounce'
+    | 'bounce_flag'
+    | 'bounce_remove';
 
+  label: string;
+}
 
+export interface OnlyUserID {
+  id: string;
+}
 
+export interface OwnBatchRequest {
+  /**
+   * List of feed IDs to get own fields for
+   */
+  feeds: string[];
 
-    export interface MarkReviewedRequestPayload {
-    /**
-     * Maximum content items to mark as reviewed
-     */
-    content_to_mark_as_reviewed_limit?: number;
-    
+  /**
+   * Optional list of specific fields to return. If not specified, all fields (own_follows, own_followings, own_capabilities, own_membership) are returned
+   */
+  fields?: string[];
+}
 
-        
-    /**
-     * Reason for the appeal decision
-     */
-    decision_reason?: string;
-    
+export interface OwnBatchResponse {
+  duration: string;
 
-        
-    /**
-     * Skip marking content as reviewed
-     */
-    disable_marking_content_as_reviewed?: boolean;
-    
+  /**
+   * Map of feed ID to own fields data
+   */
+  data: Record<string, FeedOwnData>;
+}
 
-        }
-    
+export interface OwnUserResponse {
+  banned: boolean;
 
+  created_at: Date;
 
+  id: string;
 
+  invisible: boolean;
 
-    export interface MembershipLevelResponse {
-    /**
-     * When the membership level was created
-     */
-    created_at: Date;
-    
+  language: string;
 
-        
-    /**
-     * Unique identifier for the membership level
-     */
-    id: string;
-    
+  online: boolean;
 
-        
-    /**
-     * Display name for the membership level
-     */
-    name: string;
-    
+  role: string;
 
-        
-    /**
-     * Priority level
-     */
-    priority: number;
-    
+  total_unread_count: number;
 
-        
-    /**
-     * When the membership level was last updated
-     */
-    updated_at: Date;
-    
+  unread_channels: number;
 
-        
-    /**
-     * Activity tags this membership level gives access to
-     */
-    tags: Array<string>;
-    
+  unread_count: number;
 
-        
-    /**
-     * Description of the membership level
-     */
-    description?: string;
-    
+  unread_threads: number;
 
-        
-    /**
-     * Custom data for the membership level
-     */
-    custom?: Record<string, any>;
-    
+  updated_at: Date;
 
-        }
-    
+  channel_mutes: ChannelMute[];
 
+  devices: DeviceResponse[];
 
+  mutes: UserMuteResponse[];
 
+  teams: string[];
 
-    export interface MessageResponse {
-    /**
-     * Channel unique identifier in <type>:<id> format
-     */
-    cid: string;
-    
+  custom: Record<string, any>;
 
-        
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  avg_response_time?: number;
 
-        
-    deleted_reply_count: number;
-    
+  deactivated_at?: Date;
 
-        
-    /**
-     * Contains HTML markup of the message. Can only be set when using server-side API
-     */
-    html: string;
-    
+  deleted_at?: Date;
 
-        
-    /**
-     * Message ID is unique string identifier of the message
-     */
-    id: string;
-    
+  image?: string;
 
-        
-    /**
-     * Whether the message mentioned the channel tag
-     */
-    mentioned_channel: boolean;
-    
+  last_active?: Date;
 
-        
-    /**
-     * Whether the message mentioned online users with @here tag
-     */
-    mentioned_here: boolean;
-    
+  name?: string;
 
-        
-    /**
-     * Whether message is pinned or not
-     */
-    pinned: boolean;
-    
+  revoke_tokens_issued_before?: Date;
 
-        
-    /**
-     * Number of replies to this message
-     */
-    reply_count: number;
-    
+  blocked_user_ids?: string[];
 
-        
-    /**
-     * Whether the message was shadowed or not
-     */
-    shadowed: boolean;
-    
+  latest_hidden_channels?: string[];
 
-        
-    /**
-     * Whether message is silent or not
-     */
-    silent: boolean;
-    
+  privacy_settings?: PrivacySettingsResponse;
 
-        
-    /**
-     * Text of the message. Should be empty if `mml` is provided
-     */
-    text: string;
-    
+  push_preferences?: PushPreferencesResponse;
 
-        
-    /**
-     * Contains type of the message. One of: regular, ephemeral, error, reply, system, deleted
-     */
-    type: string;
-    
+  teams_role?: Record<string, string>;
 
-        
-    /**
-     * Date/time of the last update
-     */
-    updated_at: Date;
-    
+  total_unread_count_by_team?: Record<string, number>;
+}
 
-        
-    /**
-     * Array of message attachments
-     */
-    attachments: Array<Attachment>;
-    
+export interface PagerRequest {
+  limit?: number;
 
-        
-    /**
-     * List of 10 latest reactions to this message
-     */
-    latest_reactions: Array<ReactionResponse>;
-    
+  next?: string;
 
-        
-    /**
-     * List of mentioned users
-     */
-    mentioned_users: Array<UserResponse>;
-    
+  prev?: string;
+}
 
-        
-    /**
-     * List of 10 latest reactions of authenticated user to this message
-     */
-    own_reactions: Array<ReactionResponse>;
-    
+export interface PagerResponse {
+  next?: string;
 
-        
-    /**
-     * A list of user ids that have restricted visibility to the message, if the list is not empty, the message is only visible to the users in the list
-     */
-    restricted_visibility: Array<string>;
-    
+  prev?: string;
+}
 
-        
-    custom: Record<string, any>;
-    
+export interface PinActivityRequest {
+  /**
+   * If true, enriches the activity's current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+   */
+  enrich_own_fields?: boolean;
+}
 
-        
-    /**
-     * An object containing number of reactions of each type. Key: reaction type (string), value: number of reactions (int)
-     */
-    reaction_counts: Record<string, number>;
-    
+export interface PinActivityResponse {
+  /**
+   * When the activity was pinned
+   */
+  created_at: Date;
 
-        
-    /**
-     * An object containing scores of reactions of each type. Key: reaction type (string), value: total score of reactions (int)
-     */
-    reaction_scores: Record<string, number>;
-    
+  duration: string;
 
-        
-    user: UserResponse;
-    
+  /**
+   * Fully qualified ID of the feed the activity was pinned to
+   */
+  feed: string;
 
-        
-    /**
-     * Contains provided slash command
-     */
-    command?: string;
-    
+  /**
+   * ID of the user who pinned the activity
+   */
+  user_id: string;
 
-        
-    /**
-     * Date/time of deletion
-     */
-    deleted_at?: Date;
-    
+  activity: ActivityResponse;
+}
 
-        
-    deleted_for_me?: boolean;
-    
+export interface PollClosedFeedEvent {
+  created_at: Date;
 
-        
-    message_text_updated_at?: Date;
-    
+  fid: string;
 
-        
-    /**
-     * Should be empty if `text` is provided. Can only be set when using server-side API
-     */
-    mml?: string;
-    
+  custom: Record<string, any>;
 
-        
-    /**
-     * ID of parent message (thread)
-     */
-    parent_id?: string;
-    
+  poll: PollResponseData;
 
-        
-    /**
-     * Date when pinned message expires
-     */
-    pin_expires?: Date;
-    
+  type: string;
 
-        
-    /**
-     * Date when message got pinned
-     */
-    pinned_at?: Date;
-    
+  feed_visibility?: string;
 
-        
-    /**
-     * Identifier of the poll to include in the message
-     */
-    poll_id?: string;
-    
+  received_at?: Date;
+}
 
-        
-    quoted_message_id?: string;
-    
+export interface PollDeletedFeedEvent {
+  created_at: Date;
 
-        
-    /**
-     * Whether thread reply should be shown in the channel as well
-     */
-    show_in_channel?: boolean;
-    
+  fid: string;
 
-        
-    /**
-     * List of user group IDs mentioned in the message. Group members who are also channel members will receive push notifications based on their push preferences. Max 10 groups
-     */
-    mentioned_group_ids?: Array<string>;
-    
+  custom: Record<string, any>;
 
-        
-    /**
-     * List of roles mentioned in the message (e.g. admin, channel_moderator, custom roles). Members with matching roles will receive push notifications based on their push preferences. Max 10 roles
-     */
-    mentioned_roles?: Array<string>;
-    
+  poll: PollResponseData;
 
-        
-    /**
-     * List of users who participate in thread
-     */
-    thread_participants?: Array<UserResponse>;
-    
+  type: string;
 
-        
-    draft?: DraftResponse;
-    
+  feed_visibility?: string;
 
-        
-    /**
-     * Object with translations. Key `language` contains the original language key. Other keys contain translations
-     */
-    i18n?: Record<string, string>;
-    
+  received_at?: Date;
+}
 
-        
-    /**
-     * Contains image moderation information
-     */
-    image_labels?: Record<string, Array<string>>;
-    
+export interface PollOptionInput {
+  text?: string;
 
-        
-    member?: ChannelMemberResponse;
-    
+  custom?: Record<string, any>;
+}
 
-        
-    moderation?: ModerationV2Response;
-    
+export interface PollOptionRequest {
+  id: string;
 
-        
-    pinned_by?: UserResponse;
-    
+  text?: string;
 
-        
-    poll?: PollResponseData;
-    
+  custom?: Record<string, any>;
+}
 
-        
-    quoted_message?: MessageResponse;
-    
+export interface PollOptionResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-        
-    reaction_groups?: Record<string, ReactionGroupResponse>;
-    
+  poll_option: PollOptionResponseData;
+}
 
-        
-    reminder?: ReminderResponseData;
-    
+export interface PollOptionResponseData {
+  id: string;
 
-        
-    shared_location?: SharedLocationResponseData;
-    
+  text: string;
 
-        }
-    
+  custom: Record<string, any>;
+}
 
+export interface PollResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
+  poll: PollResponseData;
+}
 
+export interface PollResponseData {
+  allow_answers: boolean;
 
-    export interface ModerationActionConfigResponse {
-    /**
-     * The action to take
-     */
-    action: string;
-    
+  allow_user_suggested_options: boolean;
 
-        
-    /**
-     * Description of what this action does
-     */
-    description: string;
-    
+  answers_count: number;
 
-        
-    /**
-     * Type of entity this action applies to
-     */
-    entity_type: string;
-    
+  created_at: Date;
 
-        
-    /**
-     * Icon for the dashboard
-     */
-    icon: string;
-    
+  created_by_id: string;
 
-        
-    /**
-     * Display order (lower numbers shown first)
-     */
-    order: number;
-    
+  description: string;
 
-        
-    id?: string;
-    
+  enforce_unique_vote: boolean;
 
-        
-    /**
-     * Queue type this action config belongs to
-     */
-    queue_type?: string;
-    
+  id: string;
 
-        
-    /**
-     * Custom data for the action
-     */
-    custom?: Record<string, any>;
-    
+  name: string;
 
-        }
-    
+  updated_at: Date;
 
+  vote_count: number;
 
+  voting_visibility: string;
 
+  latest_answers: PollVoteResponseData[];
 
-    export interface ModerationCustomActionEvent {
-    /**
-     * The ID of the custom action that was executed
-     */
-    action_id: string;
-    
+  options: PollOptionResponseData[];
 
-        
-    created_at: Date;
-    
+  own_votes: PollVoteResponseData[];
 
-        
-    custom: Record<string, any>;
-    
+  custom: Record<string, any>;
 
-        
-    review_queue_item: ReviewQueueItemResponse;
-    
+  latest_votes_by_option: Record<string, PollVoteResponseData[]>;
 
-        
-    type: string;
-    
+  vote_counts_by_option: Record<string, number>;
 
-        
-    received_at?: Date;
-    
+  is_closed?: boolean;
 
-        
-    /**
-     * Additional options passed to the custom action
-     */
-    action_options?: Record<string, any>;
-    
+  max_votes_allowed?: number;
 
-        
-    message?: MessageResponse;
-    
+  created_by?: UserResponse;
+}
 
-        }
-    
+export interface PollUpdatedFeedEvent {
+  created_at: Date;
 
+  fid: string;
 
+  custom: Record<string, any>;
 
+  poll: PollResponseData;
 
-    export interface ModerationFlagResponse {
-    created_at: Date;
-    
+  type: string;
 
-        
-    entity_id: string;
-    
+  feed_visibility?: string;
 
-        
-    entity_type: string;
-    
+  received_at?: Date;
+}
 
-        
-    type: string;
-    
+export interface PollVoteCastedFeedEvent {
+  created_at: Date;
 
-        
-    updated_at: Date;
-    
+  fid: string;
 
-        
-    user_id: string;
-    
+  custom: Record<string, any>;
 
-        
-    result: Array<Record<string, any>>;
-    
+  poll: PollResponseData;
 
-        
-    entity_creator_id?: string;
-    
+  poll_vote: PollVoteResponseData;
 
-        
-    reason?: string;
-    
+  type: string;
 
-        
-    review_queue_item_id?: string;
-    
+  feed_visibility?: string;
 
-        
-    labels?: Array<string>;
-    
+  received_at?: Date;
+}
 
-        
-    custom?: Record<string, any>;
-    
+export interface PollVoteChangedFeedEvent {
+  created_at: Date;
 
-        
-    moderation_payload?: ModerationPayloadResponse;
-    
+  fid: string;
 
-        
-    review_queue_item?: ReviewQueueItemResponse;
-    
+  custom: Record<string, any>;
 
-        
-    user?: UserResponse;
-    
+  poll: PollResponseData;
 
-        }
-    
+  poll_vote: PollVoteResponseData;
 
+  type: string;
 
+  feed_visibility?: string;
 
+  received_at?: Date;
+}
 
-    export interface ModerationFlaggedEvent {
-    /**
-     * The type of content that was flagged
-     */
-    content_type: string;
-    
+export interface PollVoteRemovedFeedEvent {
+  created_at: Date;
 
-        
-    created_at: Date;
-    
+  fid: string;
 
-        
-    /**
-     * The ID of the flagged content
-     */
-    object_id: string;
-    
+  custom: Record<string, any>;
 
-        
-    custom: Record<string, any>;
-    
+  poll: PollResponseData;
 
-        
-    type: string;
-    
+  poll_vote: PollVoteResponseData;
 
-        
-    received_at?: Date;
-    
+  type: string;
 
-        }
-    
+  feed_visibility?: string;
 
+  received_at?: Date;
+}
 
+export interface PollVoteResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
+  poll?: PollResponseData;
 
-    export interface ModerationMarkReviewedEvent {
-    created_at: Date;
-    
+  vote?: PollVoteResponseData;
+}
 
-        
-    custom: Record<string, any>;
-    
+export interface PollVoteResponseData {
+  created_at: Date;
 
-        
-    item: ReviewQueueItemResponse;
-    
+  id: string;
 
-        
-    type: string;
-    
+  option_id: string;
 
-        
-    received_at?: Date;
-    
+  poll_id: string;
 
-        
-    message?: MessageResponse;
-    
+  updated_at: Date;
 
-        }
-    
+  answer_text?: string;
 
+  is_answer?: boolean;
 
+  user_id?: string;
 
+  user?: UserResponse;
+}
 
-    export interface ModerationPayload {
-    images?: Array<string>;
-    
+export interface PollVotesResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-        
-    texts?: Array<string>;
-    
+  /**
+   * Poll votes
+   */
+  votes: PollVoteResponseData[];
 
-        
-    videos?: Array<string>;
-    
+  next?: string;
 
-        
-    custom?: Record<string, any>;
-    
+  prev?: string;
+}
 
-        }
-    
+export interface PrivacySettingsResponse {
+  delivery_receipts?: DeliveryReceiptsResponse;
 
+  read_receipts?: ReadReceiptsResponse;
 
+  typing_indicators?: TypingIndicatorsResponse;
+}
 
+export interface PushNotificationConfig {
+  enable_push?: boolean;
 
-    export interface ModerationPayloadResponse {
-    /**
-     * Image URLs to moderate
-     */
-    images?: Array<string>;
-    
+  push_types?: string[];
+}
 
-        
-    /**
-     * Text content to moderate
-     */
-    texts?: Array<string>;
-    
+export interface PushPreferenceInput {
+  /**
+   * Set the level of call push notifications for the user. One of: all, none, default
+   */
 
-        
-    /**
-     * Video URLs to moderate
-     */
-    videos?: Array<string>;
-    
+  call_level?: 'all' | 'none' | 'default';
 
-        
-    /**
-     * Custom data for moderation
-     */
-    custom?: Record<string, any>;
-    
+  /**
+   * Set the push preferences for a specific channel. If empty it sets the default for the user
+   */
+  channel_cid?: string;
 
-        }
-    
+  /**
+   * Set the level of chat push notifications for the user. Note: "mentions" is deprecated in favor of "direct_mentions". One of: all, mentions, direct_mentions, all_mentions, none, default
+   */
 
+  chat_level?:
+    | 'all'
+    | 'mentions'
+    | 'direct_mentions'
+    | 'all_mentions'
+    | 'none'
+    | 'default';
 
+  /**
+   * Disable push notifications till a certain time
+   */
+  disabled_until?: Date;
 
+  /**
+   * Set the level of feeds push notifications for the user. One of: all, none, default
+   */
 
-    export interface ModerationV2Response {
-    action: string;
-    
+  feeds_level?: 'all' | 'none' | 'default';
 
-        
-    original_text: string;
-    
+  /**
+   * Remove the disabled until time. (IE stop snoozing notifications)
+   */
+  remove_disable?: boolean;
 
-        
-    blocklist_matched?: string;
-    
+  /**
+   * The user id for which to set the push preferences. Required when using server side auths, defaults to current user with client side auth.
+   */
+  user_id?: string;
 
-        
-    platform_circumvented?: boolean;
-    
+  chat_preferences?: ChatPreferencesInput;
 
-        
-    semantic_filter_matched?: string;
-    
+  feeds_preferences?: FeedsPreferences;
+}
 
-        
-    blocklists_matched?: Array<string>;
-    
+export interface PushPreferencesResponse {
+  call_level?: string;
 
-        
-    image_harms?: Array<string>;
-    
+  chat_level?: string;
 
-        
-    text_harms?: Array<string>;
-    
+  disabled_until?: Date;
 
-        }
-    
+  feeds_level?: string;
 
+  chat_preferences?: ChatPreferencesResponse;
 
+  feeds_preferences?: FeedsPreferencesResponse;
+}
 
+export interface QueryActivitiesRequest {
+  enrich_own_fields?: boolean;
 
-    export interface MuteRequest {
-    /**
-     * User IDs to mute (if multiple users)
-     */
-    target_ids: Array<string>;
-    
+  /**
+   * When true, include soft-deleted activities in the result.
+   */
+  include_soft_deleted_activities?: boolean;
 
-        
-    /**
-     * Duration of mute in minutes
-     */
-    timeout?: number;
-    
+  limit?: number;
 
-        }
-    
+  next?: string;
 
+  prev?: string;
 
+  /**
+   * Sorting parameters for the query
+   */
+  sort?: SortParamRequest[];
 
+  /**
+   * Filters to apply to the query. Supports location-based queries with 'near' and 'within_bounds' operators.
+   */
+  filter?: Record<string, any>;
+}
 
-    export interface MuteResponse {
-    duration: string;
-    
+export interface QueryActivitiesResponse {
+  duration: string;
 
-        
-    /**
-     * Object with mutes (if multiple users were muted)
-     */
-    mutes?: Array<UserMuteResponse>;
-    
+  /**
+   * List of activities matching the query
+   */
+  activities: ActivityResponse[];
 
-        
-    /**
-     * A list of users that can't be found. Common cause for this is deleted users
-     */
-    non_existing_users?: Array<string>;
-    
+  /**
+   * Cursor for next page
+   */
+  next?: string;
 
-        
-    own_user?: OwnUserResponse;
-    
+  /**
+   * Cursor for previous page
+   */
+  prev?: string;
+}
 
-        }
-    
+export interface QueryActivityReactionsRequest {
+  limit?: number;
 
+  next?: string;
 
+  prev?: string;
 
+  sort?: SortParamRequest[];
 
-    export interface NotificationComment {
-    comment: string;
-    
+  filter?: Record<string, any>;
+}
 
-        
-    id: string;
-    
+export interface QueryActivityReactionsResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-        
-    user_id: string;
-    
+  reactions: FeedsReactionResponse[];
 
-        
-    attachments?: Array<Attachment>;
-    
+  next?: string;
 
-        }
-    
+  prev?: string;
+}
 
+export interface QueryAppealsRequest {
+  limit?: number;
 
+  next?: string;
 
+  prev?: string;
 
-    export interface NotificationConfig {
-    deduplication_window?: string;
-    
+  /**
+   * Sorting parameters for appeals
+   */
+  sort?: SortParamRequest[];
 
-        
-    track_read?: boolean;
-    
+  /**
+   * Filter conditions for appeals
+   */
+  filter?: Record<string, any>;
+}
 
-        
-    track_seen?: boolean;
-    
+export interface QueryAppealsResponse {
+  duration: string;
 
-        }
-    
+  /**
+   * List of Appeal Items
+   */
+  items: AppealItemResponse[];
 
+  next?: string;
 
+  prev?: string;
+}
 
+export interface QueryBookmarkFoldersRequest {
+  limit?: number;
 
-    export interface NotificationContext {
-    target?: NotificationTarget;
-    
+  next?: string;
 
-        
-    trigger?: NotificationTrigger;
-    
+  prev?: string;
 
-        }
-    
+  /**
+   * Sorting parameters for the query
+   */
+  sort?: SortParamRequest[];
 
+  /**
+   * Filters to apply to the query
+   */
+  filter?: Record<string, any>;
+}
 
+export interface QueryBookmarkFoldersResponse {
+  duration: string;
 
+  /**
+   * List of bookmark folders matching the query
+   */
+  bookmark_folders: BookmarkFolderResponse[];
 
-    export interface NotificationFeedUpdatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+  /**
+   * Cursor for next page
+   */
+  next?: string;
 
-        
-    /**
-     * The ID of the feed
-     */
-    fid: string;
-    
+  /**
+   * Cursor for previous page
+   */
+  prev?: string;
+}
 
-        
-    custom: Record<string, any>;
-    
+export interface QueryBookmarksRequest {
+  enrich_own_fields?: boolean;
 
-        
-    /**
-     * The type of event: "feeds.notification_feed.updated" in this case
-     */
-    type: string;
-    
+  limit?: number;
 
-        
-    feed_visibility?: string;
-    
+  next?: string;
 
-        
-    received_at?: Date;
-    
+  prev?: string;
 
-        
-    /**
-     * Aggregated activities for notification feeds
-     */
-    aggregated_activities?: Array<AggregatedActivityResponse>;
-    
+  /**
+   * Sorting parameters for the query
+   */
+  sort?: SortParamRequest[];
 
-        
-    notification_status?: NotificationStatusResponse;
-    
+  /**
+   * Filters to apply to the query
+   */
+  filter?: Record<string, any>;
+}
 
-        
-    user?: UserResponseCommonFields;
-    
+export interface QueryBookmarksResponse {
+  duration: string;
 
-        }
-    
+  /**
+   * List of bookmarks matching the query
+   */
+  bookmarks: BookmarkResponse[];
 
+  /**
+   * Cursor for next page
+   */
+  next?: string;
 
+  /**
+   * Cursor for previous page
+   */
+  prev?: string;
+}
 
+export interface QueryCollectionsRequest {
+  limit?: number;
 
-    export interface NotificationParentActivity {
-    id: string;
-    
+  next?: string;
 
-        
-    text?: string;
-    
+  prev?: string;
 
-        
-    type?: string;
-    
+  /**
+   * Sorting parameters for the query
+   */
+  sort?: SortParamRequest[];
 
-        
-    user_id?: string;
-    
+  /**
+   * Filters to apply to the query
+   */
+  filter?: Record<string, any>;
+}
 
-        
-    attachments?: Array<Attachment>;
-    
+export interface QueryCollectionsResponse {
+  duration: string;
 
-        }
-    
+  /**
+   * List of collections matching the query
+   */
+  collections: CollectionResponse[];
 
+  /**
+   * Cursor for next page
+   */
+  next?: string;
 
+  /**
+   * Cursor for previous page
+   */
+  prev?: string;
+}
 
+export interface QueryCommentReactionsRequest {
+  limit?: number;
 
-    export interface NotificationStatusResponse {
-    /**
-     * Number of unread notifications
-     */
-    unread: number;
-    
+  next?: string;
 
-        
-    /**
-     * Number of unseen notifications
-     */
-    unseen: number;
-    
+  prev?: string;
 
-        
-    /**
-     * When notifications were last read
-     */
-    last_read_at?: Date;
-    
+  sort?: SortParamRequest[];
 
-        
-    /**
-     * When notifications were last seen
-     */
-    last_seen_at?: Date;
-    
+  filter?: Record<string, any>;
+}
 
-        
-    /**
-     * Deprecated: use is_read on each activity/group instead. IDs of activities that have been read. Capped at ~101 entries for aggregated feeds.
-     */
-    read_activities?: Array<string>;
-    
+export interface QueryCommentReactionsResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-        
-    /**
-     * Deprecated: use is_seen on each activity/group instead. IDs of activities that have been seen. Capped at ~101 entries for aggregated feeds.
-     */
-    seen_activities?: Array<string>;
-    
+  reactions: FeedsReactionResponse[];
 
-        }
-    
+  next?: string;
 
+  prev?: string;
+}
 
+export interface QueryCommentsRequest {
+  /**
+   * Filter to apply to the query
+   */
+  filter: Record<string, any>;
 
+  /**
+   * Returns the comment with the specified ID along with surrounding comments for context
+   */
+  id_around?: string;
 
-    export interface NotificationTarget {
-    /**
-     * The ID of the target (activity ID or user ID)
-     */
-    id: string;
-    
+  /**
+   * Maximum number of comments to return
+   */
+  limit?: number;
 
-        
-    /**
-     * The name of the target user (for user targets like follows)
-     */
-    name?: string;
-    
+  next?: string;
 
-        
-    /**
-     * The text content of the target activity (for activity targets)
-     */
-    text?: string;
-    
+  prev?: string;
 
-        
-    /**
-     * The type of the target activity (for activity targets)
-     */
-    type?: string;
-    
+  /**
+   * Array of sort parameters
+   */
 
-        
-    /**
-     * The ID of the user who created the target activity (for activity targets)
-     */
-    user_id?: string;
-    
+  sort?: 'first' | 'last' | 'top' | 'best' | 'controversial';
+}
 
-        
-    /**
-     * Attachments on the target activity (for activity targets)
-     */
-    attachments?: Array<Attachment>;
-    
+export interface QueryCommentsResponse {
+  duration: string;
 
-        
-    comment?: NotificationComment;
-    
+  /**
+   * List of comments matching the query
+   */
+  comments: CommentResponse[];
 
-        
-    /**
-     * Custom data from the target activity
-     */
-    custom?: Record<string, any>;
-    
+  /**
+   * Cursor for next page
+   */
+  next?: string;
 
-        
-    parent_activity?: NotificationParentActivity;
-    
+  /**
+   * Cursor for previous page
+   */
+  prev?: string;
+}
 
-        }
-    
+export interface QueryFeedMembersRequest {
+  limit?: number;
 
+  next?: string;
 
+  prev?: string;
 
+  /**
+   * Sort parameters for the query
+   */
+  sort?: SortParamRequest[];
 
-    export interface NotificationTrigger {
-    /**
-     * Human-readable text describing the notification
-     */
-    text: string;
-    
+  /**
+   * Filter parameters for the query
+   */
+  filter?: Record<string, any>;
+}
 
-        
-    /**
-     * The type of notification (mention, reaction, comment, follow, etc.)
-     */
-    type: string;
-    
+export interface QueryFeedMembersResponse {
+  duration: string;
 
-        
-    comment?: NotificationComment;
-    
+  /**
+   * List of feed members
+   */
+  members: FeedMemberResponse[];
 
-        
-    /**
-     * Custom data from the trigger object (comment, reaction, etc.)
-     */
-    custom?: Record<string, any>;
-    
+  /**
+   * Cursor for next page
+   */
+  next?: string;
 
-        }
-    
+  /**
+   * Cursor for previous page
+   */
+  prev?: string;
+}
 
+export interface QueryFeedsRequest {
+  enrich_own_fields?: boolean;
 
+  limit?: number;
 
+  next?: string;
 
-    export interface OCRRule {
-    
-        action:| "flag" | "shadow" | "remove" | "bounce" | "bounce_flag" | "bounce_remove" ;
+  prev?: string;
 
-        
-    label: string;
-    
+  /**
+   * Whether to subscribe to realtime updates
+   */
+  watch?: boolean;
 
-        }
-    
+  /**
+   * Sorting parameters for the query
+   */
+  sort?: SortParamRequest[];
 
+  /**
+   * Filters to apply to the query
+   */
+  filter?: Record<string, any>;
+}
 
+export interface QueryFeedsResponse {
+  duration: string;
 
+  /**
+   * List of feeds matching the query
+   */
+  feeds: FeedResponse[];
 
-    export interface OnlyUserID {
-    id: string;
-    
+  /**
+   * Cursor for next page
+   */
+  next?: string;
 
-        }
-    
+  /**
+   * Cursor for previous page
+   */
+  prev?: string;
+}
 
+export interface QueryFollowsRequest {
+  limit?: number;
 
+  next?: string;
 
+  prev?: string;
 
-    export interface OwnBatchRequest {
-    /**
-     * List of feed IDs to get own fields for
-     */
-    feeds: Array<string>;
-    
+  /**
+   * Sorting parameters for the query
+   */
+  sort?: SortParamRequest[];
 
-        
-    /**
-     * Optional list of specific fields to return. If not specified, all fields (own_follows, own_followings, own_capabilities, own_membership) are returned
-     */
-    fields?: Array<string>;
-    
+  /**
+   * Filters to apply to the query
+   */
+  filter?: Record<string, any>;
+}
 
-        }
-    
+export interface QueryFollowsResponse {
+  duration: string;
 
+  /**
+   * List of follow relationships matching the query
+   */
+  follows: FollowResponse[];
 
+  /**
+   * Cursor for next page
+   */
+  next?: string;
 
+  /**
+   * Cursor for previous page
+   */
+  prev?: string;
+}
 
-    export interface OwnBatchResponse {
-    duration: string;
-    
+export interface QueryModerationConfigsRequest {
+  limit?: number;
 
-        
-    /**
-     * Map of feed ID to own fields data
-     */
-    data: Record<string, FeedOwnData>;
-    
+  next?: string;
 
-        }
-    
+  prev?: string;
 
+  /**
+   * Sorting parameters for the results
+   */
+  sort?: SortParamRequest[];
 
+  /**
+   * Filter conditions for moderation configs
+   */
+  filter?: Record<string, any>;
+}
 
+export interface QueryModerationConfigsResponse {
+  duration: string;
 
-    export interface OwnUserResponse {
-    banned: boolean;
-    
+  /**
+   * List of moderation configurations
+   */
+  configs: ConfigResponse[];
 
-        
-    created_at: Date;
-    
+  next?: string;
 
-        
-    id: string;
-    
+  prev?: string;
+}
 
-        
-    invisible: boolean;
-    
+export interface QueryPinnedActivitiesRequest {
+  enrich_own_fields?: boolean;
 
-        
-    language: string;
-    
+  limit?: number;
 
-        
-    online: boolean;
-    
+  next?: string;
 
-        
-    role: string;
-    
+  prev?: string;
 
-        
-    total_unread_count: number;
-    
+  /**
+   * Sorting parameters for the query
+   */
+  sort?: SortParamRequest[];
 
-        
-    unread_channels: number;
-    
+  /**
+   * Filters to apply to the query
+   */
+  filter?: Record<string, any>;
+}
 
-        
-    unread_count: number;
-    
+export interface QueryPinnedActivitiesResponse {
+  duration: string;
 
-        
-    unread_threads: number;
-    
+  /**
+   * List of pinned activities matching the query
+   */
+  pinned_activities: ActivityPinResponse[];
 
-        
-    updated_at: Date;
-    
+  /**
+   * Cursor for next page
+   */
+  next?: string;
 
-        
-    channel_mutes: Array<ChannelMute>;
-    
+  /**
+   * Cursor for previous page
+   */
+  prev?: string;
+}
 
-        
-    devices: Array<DeviceResponse>;
-    
+export interface QueryPollVotesRequest {
+  limit?: number;
 
-        
-    mutes: Array<UserMuteResponse>;
-    
+  next?: string;
 
-        
-    teams: Array<string>;
-    
+  prev?: string;
 
-        
-    custom: Record<string, any>;
-    
+  /**
+   * Array of sort parameters
+   */
+  sort?: SortParamRequest[];
 
-        
-    avg_response_time?: number;
-    
+  /**
+   * Filter to apply to the query
+   */
+  filter?: Record<string, any>;
+}
 
-        
-    deactivated_at?: Date;
-    
+export interface QueryPollsRequest {
+  limit?: number;
 
-        
-    deleted_at?: Date;
-    
+  next?: string;
 
-        
-    image?: string;
-    
+  prev?: string;
 
-        
-    last_active?: Date;
-    
+  /**
+   * Array of sort parameters
+   */
+  sort?: SortParamRequest[];
 
-        
-    name?: string;
-    
+  /**
+   * Filter to apply to the query
+   */
+  filter?: Record<string, any>;
+}
 
-        
-    revoke_tokens_issued_before?: Date;
-    
+export interface QueryPollsResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-        
-    blocked_user_ids?: Array<string>;
-    
+  /**
+   * Polls data returned by the query
+   */
+  polls: PollResponseData[];
 
-        
-    latest_hidden_channels?: Array<string>;
-    
+  next?: string;
 
-        
-    privacy_settings?: PrivacySettingsResponse;
-    
+  prev?: string;
+}
 
-        
-    push_preferences?: PushPreferencesResponse;
-    
+export interface QueryReviewQueueRequest {
+  exclude_default_action_config?: boolean;
 
-        
-    teams_role?: Record<string, string>;
-    
+  limit?: number;
 
-        
-    total_unread_count_by_team?: Record<string, number>;
-    
+  /**
+   * Number of items to lock (1-25)
+   */
+  lock_count?: number;
 
-        }
-    
+  /**
+   * Duration for which items should be locked
+   */
+  lock_duration?: number;
 
+  /**
+   * Whether to lock items for review (true), unlock items (false), or just fetch (nil)
+   */
+  lock_items?: boolean;
 
+  next?: string;
 
+  prev?: string;
 
-    export interface PagerRequest {
-    limit?: number;
-    
+  /**
+   * Whether to return only statistics
+   */
+  stats_only?: boolean;
 
-        
-    next?: string;
-    
+  /**
+   * Sorting parameters for the results
+   */
+  sort?: SortParamRequest[];
 
-        
-    prev?: string;
-    
+  /**
+   * Filter conditions for review queue items
+   */
+  filter?: Record<string, any>;
+}
 
-        }
-    
+export interface QueryReviewQueueResponse {
+  duration: string;
 
+  /**
+   * List of review queue items
+   */
+  items: ReviewQueueItemResponse[];
 
+  /**
+   * Configuration for moderation actions
+   */
+  action_config: Record<string, ModerationActionConfigResponse[]>;
 
+  /**
+   * Statistics about the review queue
+   */
+  stats: Record<string, any>;
 
-    export interface PagerResponse {
-    next?: string;
-    
+  next?: string;
 
-        
-    prev?: string;
-    
+  prev?: string;
 
-        }
-    
+  default_action_config?: Record<string, ModerationActionConfigResponse[]>;
 
+  filter_config?: FilterConfigResponse;
+}
 
+export interface QueryUsersPayload {
+  /**
+   * Filter conditions to apply to the query
+   */
+  filter_conditions: Record<string, any>;
 
+  include_deactivated_users?: boolean;
 
-    export interface PinActivityRequest {
-    /**
-     * If true, enriches the activity's current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-     */
-    enrich_own_fields?: boolean;
-    
+  limit?: number;
 
-        }
-    
+  offset?: number;
 
+  presence?: boolean;
 
+  /**
+   * Array of sort parameters
+   */
+  sort?: SortParamRequest[];
+}
 
+export interface QueryUsersResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-    export interface PinActivityResponse {
-    /**
-     * When the activity was pinned
-     */
-    created_at: Date;
-    
+  /**
+   * Array of users as result of filters applied.
+   */
+  users: FullUserResponse[];
+}
 
-        
-    duration: string;
-    
+export interface RankingConfig {
+  score?: string;
 
-        
-    /**
-     * Fully qualified ID of the feed the activity was pinned to
-     */
-    feed: string;
-    
+  type?: string;
 
-        
-    /**
-     * ID of the user who pinned the activity
-     */
-    user_id: string;
-    
+  defaults?: Record<string, any>;
 
-        
-    activity: ActivityResponse;
-    
+  functions?: Record<string, DecayFunctionConfig>;
+}
 
-        }
-    
+export interface Reaction {
+  activity_id: string;
 
+  created_at: Date;
 
+  kind: string;
 
+  updated_at: Date;
 
-    export interface PollClosedFeedEvent {
-    created_at: Date;
-    
+  user_id: string;
 
-        
-    fid: string;
-    
+  deleted_at?: Date;
 
-        
-    custom: Record<string, any>;
-    
+  id?: string;
 
-        
-    poll: PollResponseData;
-    
+  parent?: string;
 
-        
-    type: string;
-    
+  score?: number;
 
-        
-    feed_visibility?: string;
-    
+  target_feeds?: string[];
 
-        
-    received_at?: Date;
-    
+  children_counts?: Record<string, any>;
 
-        }
-    
+  data?: Record<string, any>;
 
+  latest_children?: Record<string, Reaction[]>;
 
+  moderation?: Record<string, any>;
 
+  own_children?: Record<string, Reaction[]>;
 
-    export interface PollDeletedFeedEvent {
-    created_at: Date;
-    
+  target_feeds_extra_data?: Record<string, any>;
 
-        
-    fid: string;
-    
+  user?: User;
+}
 
-        
-    custom: Record<string, any>;
-    
+export interface ReactionGroupResponse {
+  /**
+   * Count is the number of reactions of this type.
+   */
+  count: number;
 
-        
-    poll: PollResponseData;
-    
+  /**
+   * FirstReactionAt is the time of the first reaction of this type. This is the same also if all reaction of this type are deleted, because if someone will react again with the same type, will be preserved the sorting.
+   */
+  first_reaction_at: Date;
 
-        
-    type: string;
-    
+  /**
+   * LastReactionAt is the time of the last reaction of this type.
+   */
+  last_reaction_at: Date;
 
-        
-    feed_visibility?: string;
-    
+  /**
+   * SumScores is the sum of all scores of reactions of this type. Medium allows you to clap articles more than once and shows the sum of all claps from all users. For example, you can send `clap` x5 using `score: 5`.
+   */
+  sum_scores: number;
 
-        
-    received_at?: Date;
-    
+  /**
+   * The most recent users who reacted with this type, ordered by most recent first.
+   */
+  latest_reactions_by: ReactionGroupUserResponse[];
+}
 
-        }
-    
+export interface ReactionGroupUserResponse {
+  /**
+   * The time when the user reacted.
+   */
+  created_at: Date;
 
+  /**
+   * The ID of the user who reacted.
+   */
+  user_id: string;
 
+  user?: UserResponse;
+}
 
+export interface ReactionResponse {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-    export interface PollOptionInput {
-    text?: string;
-    
+  /**
+   * Message ID
+   */
+  message_id: string;
 
-        
-    custom?: Record<string, any>;
-    
+  /**
+   * Score of the reaction
+   */
+  score: number;
 
-        }
-    
+  /**
+   * Type of reaction
+   */
+  type: string;
 
+  /**
+   * Date/time of the last update
+   */
+  updated_at: Date;
 
+  /**
+   * User ID
+   */
+  user_id: string;
 
+  /**
+   * Custom data for this object
+   */
+  custom: Record<string, any>;
 
-    export interface PollOptionRequest {
-    id: string;
-    
+  user: UserResponse;
+}
 
-        
-    text?: string;
-    
+export interface ReadCollectionsResponse {
+  duration: string;
 
-        
-    custom?: Record<string, any>;
-    
+  /**
+   * List of collections matching the references
+   */
+  collections: CollectionResponse[];
+}
 
-        }
-    
+export interface ReadReceiptsResponse {
+  enabled: boolean;
+}
 
+export interface RejectAppealRequestPayload {
+  /**
+   * Reason for rejecting the appeal
+   */
+  decision_reason: string;
+}
 
+export interface RejectFeedMemberInviteRequest {}
 
+export interface RejectFeedMemberInviteResponse {
+  duration: string;
 
-    export interface PollOptionResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  member: FeedMemberResponse;
+}
 
-        
-    poll_option: PollOptionResponseData;
-    
+export interface RejectFollowRequest {
+  /**
+   * Fully qualified ID of the source feed
+   */
+  source: string;
 
-        }
-    
+  /**
+   * Fully qualified ID of the target feed
+   */
+  target: string;
+}
 
+export interface RejectFollowResponse {
+  duration: string;
 
+  follow: FollowResponse;
+}
 
+export interface ReminderResponseData {
+  channel_cid: string;
 
-    export interface PollOptionResponseData {
-    id: string;
-    
+  created_at: Date;
 
-        
-    text: string;
-    
+  message_id: string;
 
-        
-    custom: Record<string, any>;
-    
+  updated_at: Date;
 
-        }
-    
+  user_id: string;
 
+  remind_at?: Date;
 
+  channel?: ChannelResponse;
 
+  message?: MessageResponse;
 
-    export interface PollResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  user?: UserResponse;
+}
 
-        
-    poll: PollResponseData;
-    
+export interface RemoveUserGroupMembersRequest {
+  /**
+   * List of user IDs to remove
+   */
+  member_ids: string[];
 
-        }
-    
+  team_id?: string;
+}
 
+export interface RemoveUserGroupMembersResponse {
+  duration: string;
 
+  user_group?: UserGroupResponse;
+}
 
+export interface RepliesMeta {
+  /**
+   * True if the subtree was cut because the requested depth was reached.
+   */
+  depth_truncated: boolean;
 
-    export interface PollResponseData {
-    allow_answers: boolean;
-    
+  /**
+   * True if more siblings exist in the database.
+   */
+  has_more: boolean;
 
-        
-    allow_user_suggested_options: boolean;
-    
+  /**
+   * Number of unread siblings that match current filters.
+   */
+  remaining: number;
 
-        
-    answers_count: number;
-    
+  /**
+   * Opaque cursor to request the next page of siblings.
+   */
+  next_cursor?: string;
+}
 
-        
-    created_at: Date;
-    
+export interface Response {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
+}
 
-        
-    created_by_id: string;
-    
+export interface RestoreActionRequestPayload {
+  /**
+   * Reason for the appeal decision
+   */
+  decision_reason?: string;
+}
 
-        
-    description: string;
-    
+export interface RestoreActivityRequest {}
 
-        
-    enforce_unique_vote: boolean;
-    
+export interface RestoreActivityResponse {
+  duration: string;
 
-        
-    id: string;
-    
+  activity: ActivityResponse;
+}
 
-        
-    name: string;
-    
+export interface RestoreCommentRequest {}
 
-        
-    updated_at: Date;
-    
+export interface RestoreCommentResponse {
+  duration: string;
 
-        
-    vote_count: number;
-    
+  activity: ActivityResponse;
 
-        
-    voting_visibility: string;
-    
+  comment: CommentResponse;
+}
 
-        
-    latest_answers: Array<PollVoteResponseData>;
-    
+export interface ReviewQueueItemResponse {
+  /**
+   * AI-determined text severity
+   */
+  ai_text_severity: string;
 
-        
-    options: Array<PollOptionResponseData>;
-    
+  /**
+   * When the item was created
+   */
+  created_at: Date;
 
-        
-    own_votes: Array<PollVoteResponseData>;
-    
+  /**
+   * ID of the entity being reviewed
+   */
+  entity_id: string;
 
-        
-    custom: Record<string, any>;
-    
+  /**
+   * Type of entity being reviewed
+   */
+  entity_type: string;
 
-        
-    latest_votes_by_option: Record<string, Array<PollVoteResponseData>>;
-    
+  /**
+   * Whether the item has been escalated
+   */
+  escalated: boolean;
 
-        
-    vote_counts_by_option: Record<string, number>;
-    
+  flags_count: number;
 
-        
-    is_closed?: boolean;
-    
+  /**
+   * Unique identifier of the review queue item
+   */
+  id: string;
 
-        
-    max_votes_allowed?: number;
-    
+  latest_moderator_action: string;
 
-        
-    created_by?: UserResponse;
-    
+  /**
+   * Suggested moderation action
+   */
+  recommended_action: string;
 
-        }
-    
+  /**
+   * ID of the moderator who reviewed the item
+   */
+  reviewed_by: string;
 
+  /**
+   * Severity level of the content
+   */
+  severity: number;
 
+  /**
+   * Current status of the review
+   */
+  status: string;
 
+  /**
+   * When the item was last updated
+   */
+  updated_at: Date;
 
-    export interface PollUpdatedFeedEvent {
-    created_at: Date;
-    
+  /**
+   * Moderation actions taken
+   */
+  actions: ActionLogResponse[];
 
-        
-    fid: string;
-    
+  /**
+   * Associated ban records
+   */
+  bans: BanInfoResponse[];
 
-        
-    custom: Record<string, any>;
-    
+  /**
+   * Associated flag records
+   */
+  flags: ModerationFlagResponse[];
 
-        
-    poll: PollResponseData;
-    
+  /**
+   * Detected languages in the content
+   */
+  languages: string[];
 
-        
-    type: string;
-    
+  /**
+   * When the review was completed
+   */
+  completed_at?: Date;
 
-        
-    feed_visibility?: string;
-    
+  config_key?: string;
 
-        
-    received_at?: Date;
-    
+  /**
+   * ID of who created the entity
+   */
+  entity_creator_id?: string;
 
-        }
-    
+  /**
+   * When the item was escalated
+   */
+  escalated_at?: Date;
 
+  /**
+   * ID of the moderator who escalated the item
+   */
+  escalated_by?: string;
 
+  /**
+   * When the item was reviewed
+   */
+  reviewed_at?: Date;
 
+  /**
+   * Teams associated with this item
+   */
+  teams?: string[];
 
-    export interface PollVoteCastedFeedEvent {
-    created_at: Date;
-    
+  activity?: EnrichedActivity;
 
-        
-    fid: string;
-    
+  appeal?: AppealItemResponse;
 
-        
-    custom: Record<string, any>;
-    
+  assigned_to?: UserResponse;
 
-        
-    poll: PollResponseData;
-    
+  call?: CallResponse;
 
-        
-    poll_vote: PollVoteResponseData;
-    
+  entity_creator?: EntityCreatorResponse;
 
-        
-    type: string;
-    
+  escalation_metadata?: EscalationMetadata;
 
-        
-    feed_visibility?: string;
-    
+  feeds_v2_activity?: EnrichedActivity;
 
-        
-    received_at?: Date;
-    
+  feeds_v2_reaction?: Reaction;
 
-        }
-    
+  feeds_v3_activity?: FeedsV3ActivityResponse;
 
+  feeds_v3_comment?: FeedsV3CommentResponse;
 
+  message?: ChatMessageResponse;
 
+  moderation_payload?: ModerationPayloadResponse;
 
-    export interface PollVoteChangedFeedEvent {
-    created_at: Date;
-    
+  reaction?: Reaction;
+}
 
-        
-    fid: string;
-    
+export interface RuleBuilderAction {
+  skip_inbox?: boolean;
 
-        
-    custom: Record<string, any>;
-    
+  type?:
+    | 'ban_user'
+    | 'flag_user'
+    | 'flag_content'
+    | 'block_content'
+    | 'shadow_content'
+    | 'bounce_flag_content'
+    | 'bounce_content'
+    | 'bounce_remove_content'
+    | 'mute_video'
+    | 'mute_audio'
+    | 'blur'
+    | 'call_blur'
+    | 'end_call'
+    | 'kick_user'
+    | 'warning'
+    | 'call_warning'
+    | 'webhook_only';
 
-        
-    poll: PollResponseData;
-    
+  ban_options?: BanOptions;
 
-        
-    poll_vote: PollVoteResponseData;
-    
+  call_options?: CallActionOptions;
 
-        
-    type: string;
-    
+  flag_user_options?: FlagUserOptions;
+}
 
-        
-    feed_visibility?: string;
-    
+export interface RuleBuilderCondition {
+  confidence?: number;
 
-        
-    received_at?: Date;
-    
+  type?: string;
 
-        }
-    
+  call_custom_property_params?: CallCustomPropertyParameters;
 
+  call_type_rule_params?: CallTypeRuleParameters;
 
+  call_violation_count_params?: CallViolationCountParameters;
 
+  channel_message_count_rule_params?: ChannelMessageCountRuleParameters;
 
-    export interface PollVoteRemovedFeedEvent {
-    created_at: Date;
-    
+  closed_caption_rule_params?: ClosedCaptionRuleParameters;
 
-        
-    fid: string;
-    
+  content_count_rule_params?: ContentCountRuleParameters;
 
-        
-    custom: Record<string, any>;
-    
+  content_flag_count_rule_params?: FlagCountRuleParameters;
 
-        
-    poll: PollResponseData;
-    
+  image_content_params?: ImageContentParameters;
 
-        
-    poll_vote: PollVoteResponseData;
-    
+  image_rule_params?: ImageRuleParameters;
 
-        
-    type: string;
-    
+  keyframe_rule_params?: KeyframeRuleParameters;
 
-        
-    feed_visibility?: string;
-    
+  text_content_params?: TextContentParameters;
 
-        
-    received_at?: Date;
-    
+  text_rule_params?: TextRuleParameters;
 
-        }
-    
+  user_created_within_params?: UserCreatedWithinParameters;
 
+  user_custom_property_params?: UserCustomPropertyParameters;
 
+  user_flag_count_rule_params?: FlagCountRuleParameters;
 
+  user_identical_content_count_params?: UserIdenticalContentCountParameters;
 
-    export interface PollVoteResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  user_role_params?: UserRoleParameters;
 
-        
-    poll?: PollResponseData;
-    
+  user_rule_params?: UserRuleParameters;
 
-        
-    vote?: PollVoteResponseData;
-    
+  video_content_params?: VideoContentParameters;
 
-        }
-    
+  video_rule_params?: VideoRuleParameters;
+}
 
+export interface RuleBuilderConditionGroup {
+  logic?: string;
 
+  conditions?: RuleBuilderCondition[];
+}
 
+export interface RuleBuilderConfig {
+  async?: boolean;
 
-    export interface PollVoteResponseData {
-    created_at: Date;
-    
+  rules?: RuleBuilderRule[];
+}
 
-        
-    id: string;
-    
+export interface RuleBuilderRule {
+  rule_type: string;
 
-        
-    option_id: string;
-    
+  cooldown_period?: string;
 
-        
-    poll_id: string;
-    
+  id?: string;
 
-        
-    updated_at: Date;
-    
+  logic?: string;
 
-        
-    answer_text?: string;
-    
+  action_sequences?: CallRuleActionSequence[];
 
-        
-    is_answer?: boolean;
-    
+  conditions?: RuleBuilderCondition[];
 
-        
-    user_id?: string;
-    
+  groups?: RuleBuilderConditionGroup[];
 
-        
-    user?: UserResponse;
-    
+  action?: RuleBuilderAction;
+}
 
-        }
-    
+export interface SearchUserGroupsResponse {
+  duration: string;
 
+  /**
+   * List of matching user groups
+   */
+  user_groups: UserGroupResponse[];
+}
 
+export interface ShadowBlockActionRequestPayload {
+  /**
+   * Reason for shadow blocking
+   */
+  reason?: string;
+}
 
+export interface SharedLocationResponse {
+  /**
+   * Channel CID
+   */
+  channel_cid: string;
 
-    export interface PollVotesResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    /**
-     * Poll votes
-     */
-    votes: Array<PollVoteResponseData>;
-    
+  /**
+   * Device ID that created the live location
+   */
+  created_by_device_id: string;
 
-        
-    next?: string;
-    
+  duration: string;
 
-        
-    prev?: string;
-    
+  /**
+   * Latitude coordinate
+   */
+  latitude: number;
 
-        }
-    
+  /**
+   * Longitude coordinate
+   */
+  longitude: number;
 
+  /**
+   * Message ID
+   */
+  message_id: string;
 
+  /**
+   * Date/time of the last update
+   */
+  updated_at: Date;
 
+  /**
+   * User ID
+   */
+  user_id: string;
 
-    export interface PrivacySettingsResponse {
-    delivery_receipts?: DeliveryReceiptsResponse;
-    
+  /**
+   * Time when the live location expires
+   */
+  end_at?: Date;
 
-        
-    read_receipts?: ReadReceiptsResponse;
-    
+  channel?: ChannelResponse;
 
-        
-    typing_indicators?: TypingIndicatorsResponse;
-    
+  message?: MessageResponse;
+}
 
-        }
-    
+export interface SharedLocationResponseData {
+  channel_cid: string;
 
+  created_at: Date;
 
+  created_by_device_id: string;
 
+  latitude: number;
 
-    export interface PushNotificationConfig {
-    enable_push?: boolean;
-    
+  longitude: number;
 
-        
-    push_types?: Array<string>;
-    
+  message_id: string;
 
-        }
-    
+  updated_at: Date;
 
+  user_id: string;
 
+  end_at?: Date;
 
+  channel?: ChannelResponse;
 
-    export interface PushPreferenceInput {
-    /**
-     * Set the level of call push notifications for the user. One of: all, none, default
-     */
-    
-        call_level?:| "all" | "none" | "default" ;
+  message?: MessageResponse;
+}
 
-        
-    /**
-     * Set the push preferences for a specific channel. If empty it sets the default for the user
-     */
-    channel_cid?: string;
-    
+export interface SharedLocationsResponse {
+  duration: string;
 
-        
-    /**
-     * Set the level of chat push notifications for the user. Note: "mentions" is deprecated in favor of "direct_mentions". One of: all, mentions, direct_mentions, all_mentions, none, default
-     */
-    
-        chat_level?:| "all" | "mentions" | "direct_mentions" | "all_mentions" | "none" | "default" ;
+  active_live_locations: SharedLocationResponseData[];
+}
 
-        
-    /**
-     * Disable push notifications till a certain time
-     */
-    disabled_until?: Date;
-    
+export interface SingleFollowResponse {
+  duration: string;
 
-        
-    /**
-     * Set the level of feeds push notifications for the user. One of: all, none, default
-     */
-    
-        feeds_level?:| "all" | "none" | "default" ;
+  follow: FollowResponse;
 
-        
-    /**
-     * Remove the disabled until time. (IE stop snoozing notifications)
-     */
-    remove_disable?: boolean;
-    
+  /**
+   * Whether a notification activity was successfully created
+   */
+  notification_created?: boolean;
+}
 
-        
-    /**
-     * The user id for which to set the push preferences. Required when using server side auths, defaults to current user with client side auth.
-     */
-    user_id?: string;
-    
+export interface SortParam {
+  direction: number;
 
-        
-    chat_preferences?: ChatPreferencesInput;
-    
+  field: string;
 
-        
-    feeds_preferences?: FeedsPreferences;
-    
+  type: string;
+}
 
-        }
-    
+export interface SortParamRequest {
+  /**
+   * Direction of sorting, 1 for Ascending, -1 for Descending, default is 1. One of: -1, 1
+   */
+  direction?: number;
 
+  /**
+   * Name of field to sort by
+   */
+  field?: string;
 
+  /**
+   * Type of field to sort by. Empty string or omitted means string type (default). One of: number, boolean
+   */
+  type?: string;
+}
 
+export interface StoriesConfig {
+  skip_watched?: boolean;
 
-    export interface PushPreferencesResponse {
-    call_level?: string;
-    
+  track_watched?: boolean;
+}
 
-        
-    chat_level?: string;
-    
+export interface StoriesFeedUpdatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    disabled_until?: Date;
-    
+  /**
+   * The ID of the feed
+   */
+  fid: string;
 
-        
-    feeds_level?: string;
-    
+  custom: Record<string, any>;
 
-        
-    chat_preferences?: ChatPreferencesResponse;
-    
+  /**
+   * The type of event: "feeds.stories_feed.updated" in this case
+   */
+  type: string;
 
-        
-    feeds_preferences?: FeedsPreferencesResponse;
-    
+  feed_visibility?: string;
 
-        }
-    
+  received_at?: Date;
 
+  /**
+   * Individual activities for stories feeds
+   */
+  activities?: ActivityResponse[];
 
+  /**
+   * Aggregated activities for stories feeds
+   */
+  aggregated_activities?: AggregatedActivityResponse[];
 
+  user?: UserResponseCommonFields;
+}
 
-    export interface QueryActivitiesRequest {
-    enrich_own_fields?: boolean;
-    
+export interface SubmitActionRequest {
+  /**
+   * Type of moderation action to perform. One of: mark_reviewed, delete_message, delete_activity, delete_comment, delete_reaction, ban, custom, unban, restore, delete_user, unblock, block, shadow_block, unmask, kick_user, end_call, escalate, de_escalate
+   */
 
-        
-    /**
-     * When true, include soft-deleted activities in the result.
-     */
-    include_soft_deleted_activities?: boolean;
-    
+  action_type:
+    | 'flag'
+    | 'mark_reviewed'
+    | 'delete_message'
+    | 'delete_activity'
+    | 'delete_comment'
+    | 'delete_reaction'
+    | 'ban'
+    | 'custom'
+    | 'unban'
+    | 'restore'
+    | 'delete_user'
+    | 'unblock'
+    | 'block'
+    | 'shadow_block'
+    | 'unmask'
+    | 'kick_user'
+    | 'end_call'
+    | 'reject_appeal'
+    | 'escalate'
+    | 'de_escalate'
+    | 'bypass';
 
-        
-    limit?: number;
-    
+  /**
+   * UUID of the appeal to act on (required for reject_appeal, optional for other actions)
+   */
+  appeal_id?: string;
 
-        
-    next?: string;
-    
+  /**
+   * UUID of the review queue item to act on
+   */
+  item_id?: string;
 
-        
-    prev?: string;
-    
+  ban?: BanActionRequestPayload;
 
-        
-    /**
-     * Sorting parameters for the query
-     */
-    sort?: Array<SortParamRequest>;
-    
+  block?: BlockActionRequestPayload;
 
-        
-    /**
-     * Filters to apply to the query. Supports location-based queries with 'near' and 'within_bounds' operators.
-     */
-    filter?: Record<string, any>;
-    
+  bypass?: BypassActionRequest;
 
-        }
-    
+  custom?: CustomActionRequestPayload;
 
+  delete_activity?: DeleteActivityRequestPayload;
 
+  delete_comment?: DeleteCommentRequestPayload;
 
+  delete_message?: DeleteMessageRequestPayload;
 
-    export interface QueryActivitiesResponse {
-    duration: string;
-    
+  delete_reaction?: DeleteReactionRequestPayload;
 
-        
-    /**
-     * List of activities matching the query
-     */
-    activities: Array<ActivityResponse>;
-    
+  delete_user?: DeleteUserRequestPayload;
 
-        
-    /**
-     * Cursor for next page
-     */
-    next?: string;
-    
+  escalate?: EscalatePayload;
 
-        
-    /**
-     * Cursor for previous page
-     */
-    prev?: string;
-    
+  flag?: FlagRequest;
 
-        }
-    
+  mark_reviewed?: MarkReviewedRequestPayload;
 
+  reject_appeal?: RejectAppealRequestPayload;
 
+  restore?: RestoreActionRequestPayload;
 
+  shadow_block?: ShadowBlockActionRequestPayload;
 
-    export interface QueryActivityReactionsRequest {
-    limit?: number;
-    
+  unban?: UnbanActionRequestPayload;
 
-        
-    next?: string;
-    
+  unblock?: UnblockActionRequestPayload;
+}
 
-        
-    prev?: string;
-    
+export interface SubmitActionResponse {
+  duration: string;
 
-        
-    sort?: Array<SortParamRequest>;
-    
+  appeal_item?: AppealItemResponse;
 
-        
-    filter?: Record<string, any>;
-    
+  item?: ReviewQueueItemResponse;
+}
 
-        }
-    
+export interface TextContentParameters {
+  contains_url?: boolean;
 
+  label_operator?: string;
 
+  severity?: string;
 
+  blocklist_match?: string[];
 
-    export interface QueryActivityReactionsResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  harm_labels?: string[];
 
-        
-    reactions: Array<FeedsReactionResponse>;
-    
+  llm_harm_labels?: Record<string, string>;
+}
 
-        
-    next?: string;
-    
+export interface TextRuleParameters {
+  contains_url?: boolean;
 
-        
-    prev?: string;
-    
+  semantic_filter_min_threshold?: number;
 
-        }
-    
+  severity?: string;
 
+  threshold?: number;
 
+  time_window?: string;
 
+  blocklist_match?: string[];
 
-    export interface QueryAppealsRequest {
-    limit?: number;
-    
+  harm_labels?: string[];
 
-        
-    next?: string;
-    
+  semantic_filter_names?: string[];
 
-        
-    prev?: string;
-    
+  llm_harm_labels?: Record<string, string>;
+}
 
-        
-    /**
-     * Sorting parameters for appeals
-     */
-    sort?: Array<SortParamRequest>;
-    
+export interface ThreadedCommentResponse {
+  bookmark_count: number;
 
-        
-    /**
-     * Filter conditions for appeals
-     */
-    filter?: Record<string, any>;
-    
+  confidence_score: number;
 
-        }
-    
+  created_at: Date;
 
+  downvote_count: number;
 
+  id: string;
 
+  object_id: string;
 
-    export interface QueryAppealsResponse {
-    duration: string;
-    
+  object_type: string;
 
-        
-    /**
-     * List of Appeal Items
-     */
-    items: Array<AppealItemResponse>;
-    
+  reaction_count: number;
 
-        
-    next?: string;
-    
+  reply_count: number;
 
-        
-    prev?: string;
-    
+  score: number;
 
-        }
-    
+  /**
+   * Status of the comment. One of: active, deleted, removed, hidden
+   */
 
+  status: 'active' | 'deleted' | 'removed' | 'hidden' | 'shadow_blocked';
 
+  updated_at: Date;
 
+  upvote_count: number;
 
-    export interface QueryBookmarkFoldersRequest {
-    limit?: number;
-    
+  mentioned_users: UserResponse[];
 
-        
-    next?: string;
-    
+  own_reactions: FeedsReactionResponse[];
 
-        
-    prev?: string;
-    
+  user: UserResponse;
 
-        
-    /**
-     * Sorting parameters for the query
-     */
-    sort?: Array<SortParamRequest>;
-    
+  controversy_score?: number;
 
-        
-    /**
-     * Filters to apply to the query
-     */
-    filter?: Record<string, any>;
-    
+  deleted_at?: Date;
 
-        }
-    
+  edited_at?: Date;
 
+  parent_id?: string;
 
+  text?: string;
 
+  attachments?: Attachment[];
 
-    export interface QueryBookmarkFoldersResponse {
-    duration: string;
-    
+  latest_reactions?: FeedsReactionResponse[];
 
-        
-    /**
-     * List of bookmark folders matching the query
-     */
-    bookmark_folders: Array<BookmarkFolderResponse>;
-    
+  /**
+   * Slice of nested comments (may be empty).
+   */
+  replies?: ThreadedCommentResponse[];
 
-        
-    /**
-     * Cursor for next page
-     */
-    next?: string;
-    
+  custom?: Record<string, any>;
 
-        
-    /**
-     * Cursor for previous page
-     */
-    prev?: string;
-    
+  meta?: RepliesMeta;
 
-        }
-    
+  moderation?: ModerationV2Response;
 
+  reaction_groups?: Record<string, FeedsReactionGroupResponse>;
+}
 
+export interface Thresholds {
+  explicit?: LabelThresholds;
 
+  spam?: LabelThresholds;
 
-    export interface QueryBookmarksRequest {
-    enrich_own_fields?: boolean;
-    
+  toxic?: LabelThresholds;
+}
 
-        
-    limit?: number;
-    
+export interface Time {}
 
-        
-    next?: string;
-    
+export interface TrackActivityMetricsEvent {
+  /**
+   * The ID of the activity to track the metric for
+   */
+  activity_id: string;
 
-        
-    prev?: string;
-    
+  /**
+   * The metric name (e.g. views, clicks, impressions). Alphanumeric and underscores only.
+   */
+  metric: string;
 
-        
-    /**
-     * Sorting parameters for the query
-     */
-    sort?: Array<SortParamRequest>;
-    
+  /**
+   * The amount to increment (positive) or decrement (negative). Defaults to 1. The absolute value counts against rate limits.
+   */
+  delta?: number;
+}
 
-        
-    /**
-     * Filters to apply to the query
-     */
-    filter?: Record<string, any>;
-    
+export interface TrackActivityMetricsEventResult {
+  /**
+   * The activity ID from the request
+   */
+  activity_id: string;
 
-        }
-    
+  /**
+   * Whether the metric was counted (false if rate-limited)
+   */
+  allowed: boolean;
 
+  /**
+   * The metric name from the request
+   */
+  metric: string;
 
+  /**
+   * Error message if processing failed
+   */
+  error?: string;
+}
 
+export interface TrackActivityMetricsRequest {
+  /**
+   * List of metric events to track (max 100 per request)
+   */
+  events: TrackActivityMetricsEvent[];
+}
 
-    export interface QueryBookmarksResponse {
-    duration: string;
-    
+export interface TrackActivityMetricsResponse {
+  duration: string;
 
-        
-    /**
-     * List of bookmarks matching the query
-     */
-    bookmarks: Array<BookmarkResponse>;
-    
+  /**
+   * Results for each event in the request, in the same order
+   */
+  results: TrackActivityMetricsEventResult[];
+}
 
-        
-    /**
-     * Cursor for next page
-     */
-    next?: string;
-    
+export interface TypingIndicatorsResponse {
+  enabled: boolean;
+}
 
-        
-    /**
-     * Cursor for previous page
-     */
-    prev?: string;
-    
+export interface UnbanActionRequestPayload {
+  /**
+   * Channel CID for channel-specific unban
+   */
+  channel_cid?: string;
 
-        }
-    
+  /**
+   * Reason for the appeal decision
+   */
+  decision_reason?: string;
 
+  /**
+   * Also remove the future channels ban for this user
+   */
+  remove_future_channels_ban?: boolean;
+}
 
+export interface UnblockActionRequestPayload {
+  /**
+   * Reason for the appeal decision
+   */
+  decision_reason?: string;
+}
 
+export interface UnblockUsersRequest {
+  blocked_user_id: string;
+}
 
-    export interface QueryCollectionsRequest {
-    limit?: number;
-    
+export interface UnblockUsersResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
+}
 
-        
-    next?: string;
-    
+export interface UnfollowBatchRequest {
+  /**
+   * List of follow relationships to remove, each with optional keep_history
+   */
+  follows: UnfollowPair[];
 
-        
-    prev?: string;
-    
+  /**
+   * Whether to delete the corresponding notification activity (default: false)
+   */
+  delete_notification_activity?: boolean;
 
-        
-    /**
-     * Sorting parameters for the query
-     */
-    sort?: Array<SortParamRequest>;
-    
+  /**
+   * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+   */
+  enrich_own_fields?: boolean;
+}
 
-        
-    /**
-     * Filters to apply to the query
-     */
-    filter?: Record<string, any>;
-    
+export interface UnfollowBatchResponse {
+  duration: string;
 
-        }
-    
+  /**
+   * List of follow relationships that were removed
+   */
+  follows: FollowResponse[];
+}
 
+export interface UnfollowPair {
+  /**
+   * Fully qualified ID of the source feed
+   */
+  source: string;
 
+  /**
+   * Fully qualified ID of the target feed
+   */
+  target: string;
 
+  /**
+   * When true, activities from the unfollowed feed will remain in the source feed's timeline (default: false)
+   */
+  keep_history?: boolean;
+}
 
-    export interface QueryCollectionsResponse {
-    duration: string;
-    
+export interface UnfollowResponse {
+  duration: string;
 
-        
-    /**
-     * List of collections matching the query
-     */
-    collections: Array<CollectionResponse>;
-    
+  follow: FollowResponse;
+}
 
-        
-    /**
-     * Cursor for next page
-     */
-    next?: string;
-    
+export interface UnpinActivityResponse {
+  duration: string;
 
-        
-    /**
-     * Cursor for previous page
-     */
-    prev?: string;
-    
+  /**
+   * Fully qualified ID of the feed the activity was unpinned from
+   */
+  feed: string;
 
-        }
-    
+  /**
+   * ID of the user who unpinned the activity
+   */
+  user_id: string;
 
+  activity: ActivityResponse;
+}
 
+export interface UpdateActivityPartialRequest {
+  /**
+   * @deprecated
+   * Whether to copy custom data to the notification activity (only applies when handle_mention_notifications creates notifications) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+   */
+  copy_custom_to_notification?: boolean;
 
+  /**
+   * If true, enriches the activity's current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+   */
+  enrich_own_fields?: boolean;
 
-    export interface QueryCommentReactionsRequest {
-    limit?: number;
-    
+  /**
+   * If true, creates notification activities for newly mentioned users and deletes notifications for users no longer mentioned
+   */
+  handle_mention_notifications?: boolean;
 
-        
-    next?: string;
-    
+  /**
+   * If true, runs activity processors on the updated activity. Processors will only run if the activity text and/or attachments are changed. Defaults to false.
+   */
+  run_activity_processors?: boolean;
 
-        
-    prev?: string;
-    
+  /**
+   * List of field names to remove. Supported fields: 'custom', 'visibility_tag', 'location', 'expires_at', 'filter_tags', 'interest_tags', 'attachments', 'poll_id', 'mentioned_user_ids', 'search_data'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
+   */
+  unset?: string[];
 
-        
-    sort?: Array<SortParamRequest>;
-    
+  /**
+   * Map of field names to new values. Supported fields: 'text', 'attachments', 'custom', 'visibility', 'visibility_tag', 'restrict_replies' (values: 'everyone', 'people_i_follow', 'nobody'), 'location', 'expires_at', 'filter_tags', 'interest_tags', 'poll_id', 'feeds', 'mentioned_user_ids', 'search_data'. For custom fields, use dot-notation (e.g., 'custom.field_name')
+   */
+  set?: Record<string, any>;
+}
 
-        
-    filter?: Record<string, any>;
-    
+export interface UpdateActivityPartialResponse {
+  duration: string;
 
-        }
-    
+  activity: ActivityResponse;
+}
 
+export interface UpdateActivityRequest {
+  /**
+   * @deprecated
+   * Whether to copy custom data to the notification activity (only applies when handle_mention_notifications creates notifications) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+   */
+  copy_custom_to_notification?: boolean;
 
+  /**
+   * If true, enriches the activity's current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+   */
+  enrich_own_fields?: boolean;
 
+  /**
+   * Time when the activity will expire
+   */
+  expires_at?: Date;
 
-    export interface QueryCommentReactionsResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  /**
+   * If true, creates notification activities for newly mentioned users and deletes notifications for users no longer mentioned
+   */
+  handle_mention_notifications?: boolean;
 
-        
-    reactions: Array<FeedsReactionResponse>;
-    
+  /**
+   * Poll ID
+   */
+  poll_id?: string;
 
-        
-    next?: string;
-    
+  /**
+   * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
+   */
 
-        
-    prev?: string;
-    
+  restrict_replies?: 'everyone' | 'people_i_follow' | 'nobody';
 
-        }
-    
+  /**
+   * If true, runs activity processors on the updated activity. Processors will only run if the activity text and/or attachments are changed. Defaults to false.
+   */
+  run_activity_processors?: boolean;
 
+  /**
+   * Whether to skip URL enrichment for the activity
+   */
+  skip_enrich_url?: boolean;
 
+  /**
+   * The text content of the activity
+   */
+  text?: string;
 
+  /**
+   * Visibility setting for the activity
+   */
 
-    export interface QueryCommentsRequest {
-    /**
-     * Filter to apply to the query
-     */
-    filter: Record<string, any>;
-    
+  visibility?: 'public' | 'private' | 'tag';
 
-        
-    /**
-     * Returns the comment with the specified ID along with surrounding comments for context
-     */
-    id_around?: string;
-    
+  /**
+   * If visibility is 'tag', this is the tag name and is required
+   */
+  visibility_tag?: string;
 
-        
-    /**
-     * Maximum number of comments to return
-     */
-    limit?: number;
-    
+  /**
+   * List of attachments for the activity
+   */
+  attachments?: Attachment[];
 
-        
-    next?: string;
-    
+  /**
+   * Collections that this activity references
+   */
+  collection_refs?: string[];
 
-        
-    prev?: string;
-    
+  /**
+   * List of feeds the activity is present in
+   */
+  feeds?: string[];
 
-        
-    /**
-     * Array of sort parameters
-     */
-    
-        sort?:| "first" | "last" | "top" | "best" | "controversial" ;
+  /**
+   * Tags used for filtering the activity
+   */
+  filter_tags?: string[];
 
-        }
-    
+  /**
+   * Tags indicating interest categories
+   */
+  interest_tags?: string[];
 
+  /**
+   * List of user IDs mentioned in the activity
+   */
+  mentioned_user_ids?: string[];
 
+  /**
+   * Custom data for the activity
+   */
+  custom?: Record<string, any>;
 
+  location?: Location;
 
-    export interface QueryCommentsResponse {
-    duration: string;
-    
+  /**
+   * Additional data for search indexing
+   */
+  search_data?: Record<string, any>;
+}
 
-        
-    /**
-     * List of comments matching the query
-     */
-    comments: Array<CommentResponse>;
-    
+export interface UpdateActivityResponse {
+  duration: string;
 
-        
-    /**
-     * Cursor for next page
-     */
-    next?: string;
-    
+  activity: ActivityResponse;
+}
 
-        
-    /**
-     * Cursor for previous page
-     */
-    prev?: string;
-    
+export interface UpdateBlockListRequest {
+  is_leet_check_enabled?: boolean;
 
-        }
-    
+  is_plural_check_enabled?: boolean;
 
+  team?: string;
 
+  /**
+   * List of words to block
+   */
+  words?: string[];
+}
 
+export interface UpdateBlockListResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-    export interface QueryFeedMembersRequest {
-    limit?: number;
-    
+  blocklist?: BlockListResponse;
+}
 
-        
-    next?: string;
-    
+export interface UpdateBookmarkFolderRequest {
+  /**
+   * Name of the folder
+   */
+  name?: string;
 
-        
-    prev?: string;
-    
+  /**
+   * Custom data for the folder
+   */
+  custom?: Record<string, any>;
+}
 
-        
-    /**
-     * Sort parameters for the query
-     */
-    sort?: Array<SortParamRequest>;
-    
+export interface UpdateBookmarkFolderResponse {
+  duration: string;
 
-        
-    /**
-     * Filter parameters for the query
-     */
-    filter?: Record<string, any>;
-    
+  bookmark_folder: BookmarkFolderResponse;
+}
 
-        }
-    
+export interface UpdateBookmarkRequest {
+  /**
+   * ID of the folder containing the bookmark
+   */
+  folder_id?: string;
 
+  /**
+   * Move the bookmark to this folder (empty string removes the folder)
+   */
+  new_folder_id?: string;
 
+  /**
+   * Custom data for the bookmark
+   */
+  custom?: Record<string, any>;
 
+  new_folder?: AddFolderRequest;
+}
 
-    export interface QueryFeedMembersResponse {
-    duration: string;
-    
+export interface UpdateBookmarkResponse {
+  duration: string;
 
-        
-    /**
-     * List of feed members
-     */
-    members: Array<FeedMemberResponse>;
-    
+  bookmark: BookmarkResponse;
+}
 
-        
-    /**
-     * Cursor for next page
-     */
-    next?: string;
-    
+export interface UpdateCollectionRequest {
+  /**
+   * Unique identifier for the collection within its name
+   */
+  id: string;
 
-        
-    /**
-     * Cursor for previous page
-     */
-    prev?: string;
-    
+  /**
+   * Name/type of the collection
+   */
+  name: string;
 
-        }
-    
+  /**
+   * Custom data for the collection (required, must contain at least one key)
+   */
+  custom: Record<string, any>;
+}
 
+export interface UpdateCollectionsRequest {
+  /**
+   * List of collections to update (only custom data is updatable)
+   */
+  collections: UpdateCollectionRequest[];
+}
 
+export interface UpdateCollectionsResponse {
+  duration: string;
 
+  /**
+   * List of updated collections
+   */
+  collections: CollectionResponse[];
+}
 
-    export interface QueryFeedsRequest {
-    enrich_own_fields?: boolean;
-    
+export interface UpdateCommentBookmarkRequest {
+  /**
+   * ID of the folder containing the bookmark
+   */
+  folder_id?: string;
 
-        
-    limit?: number;
-    
+  /**
+   * Move the bookmark to this folder (empty string removes the folder)
+   */
+  new_folder_id?: string;
 
-        
-    next?: string;
-    
+  /**
+   * Custom data for the bookmark
+   */
+  custom?: Record<string, any>;
 
-        
-    prev?: string;
-    
+  new_folder?: AddFolderRequest;
+}
 
-        
-    /**
-     * Whether to subscribe to realtime updates
-     */
-    watch?: boolean;
-    
+export interface UpdateCommentBookmarkResponse {
+  duration: string;
 
-        
-    /**
-     * Sorting parameters for the query
-     */
-    sort?: Array<SortParamRequest>;
-    
+  bookmark: BookmarkResponse;
+}
 
-        
-    /**
-     * Filters to apply to the query
-     */
-    filter?: Record<string, any>;
-    
+export interface UpdateCommentPartialRequest {
+  /**
+   * @deprecated
+   * Whether to copy custom data to notification activities Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+   */
+  copy_custom_to_notification?: boolean;
 
-        }
-    
+  /**
+   * Whether to handle mention notification changes
+   */
+  handle_mention_notifications?: boolean;
 
+  /**
+   * Whether to skip URL enrichment
+   */
+  skip_enrich_url?: boolean;
 
+  /**
+   * Whether to skip push notifications
+   */
+  skip_push?: boolean;
 
+  /**
+   * List of field names to remove. Supported fields: 'custom', 'attachments', 'mentioned_user_ids', 'status'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
+   */
+  unset?: string[];
 
-    export interface QueryFeedsResponse {
-    duration: string;
-    
+  /**
+   * Map of field names to new values. Supported fields: 'text', 'attachments', 'custom', 'mentioned_user_ids', 'status'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
+   */
+  set?: Record<string, any>;
+}
 
-        
-    /**
-     * List of feeds matching the query
-     */
-    feeds: Array<FeedResponse>;
-    
+export interface UpdateCommentPartialResponse {
+  duration: string;
 
-        
-    /**
-     * Cursor for next page
-     */
-    next?: string;
-    
+  comment: CommentResponse;
+}
 
-        
-    /**
-     * Cursor for previous page
-     */
-    prev?: string;
-    
+export interface UpdateCommentRequest {
+  /**
+   * Updated text content of the comment
+   */
+  comment?: string;
 
-        }
-    
+  /**
+   * @deprecated
+   * Whether to copy custom data to the notification activity (only applies when handle_mention_notifications creates notifications) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+   */
+  copy_custom_to_notification?: boolean;
 
+  /**
+   * If true, creates notification activities for newly mentioned users and deletes notifications for users no longer mentioned
+   */
+  handle_mention_notifications?: boolean;
 
+  /**
+   * Whether to skip URL enrichment for this comment
+   */
+  skip_enrich_url?: boolean;
 
+  skip_push?: boolean;
 
-    export interface QueryFollowsRequest {
-    limit?: number;
-    
+  /**
+   * Updated media attachments for the comment. Providing this field will replace all existing attachments.
+   */
+  attachments?: Attachment[];
 
-        
-    next?: string;
-    
+  /**
+   * List of user IDs mentioned in the comment
+   */
+  mentioned_user_ids?: string[];
 
-        
-    prev?: string;
-    
+  /**
+   * Updated custom data for the comment
+   */
+  custom?: Record<string, any>;
+}
 
-        
-    /**
-     * Sorting parameters for the query
-     */
-    sort?: Array<SortParamRequest>;
-    
+export interface UpdateCommentResponse {
+  duration: string;
 
-        
-    /**
-     * Filters to apply to the query
-     */
-    filter?: Record<string, any>;
-    
+  comment: CommentResponse;
+}
 
-        }
-    
+export interface UpdateFeedMembersRequest {
+  /**
+   * Type of update operation to perform. One of: upsert, remove, set
+   */
 
+  operation: 'upsert' | 'remove' | 'set';
 
+  limit?: number;
 
+  next?: string;
 
-    export interface QueryFollowsResponse {
-    duration: string;
-    
+  prev?: string;
 
-        
-    /**
-     * List of follow relationships matching the query
-     */
-    follows: Array<FollowResponse>;
-    
+  /**
+   * List of members to upsert, remove, or set
+   */
+  members?: FeedMemberRequest[];
+}
 
-        
-    /**
-     * Cursor for next page
-     */
-    next?: string;
-    
+export interface UpdateFeedMembersResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-        
-    /**
-     * Cursor for previous page
-     */
-    prev?: string;
-    
+  added: FeedMemberResponse[];
 
-        }
-    
+  removed_ids: string[];
 
+  updated: FeedMemberResponse[];
+}
 
+export interface UpdateFeedRequest {
+  /**
+   * If true, removes the geographic location from the feed
+   */
+  clear_location?: boolean;
 
+  /**
+   * Description of the feed
+   */
+  description?: string;
 
-    export interface QueryModerationConfigsRequest {
-    limit?: number;
-    
+  /**
+   * If true, enriches the feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+   */
+  enrich_own_fields?: boolean;
 
-        
-    next?: string;
-    
+  /**
+   * Name of the feed
+   */
+  name?: string;
 
-        
-    prev?: string;
-    
+  /**
+   * Tags used for filtering feeds
+   */
+  filter_tags?: string[];
 
-        
-    /**
-     * Sorting parameters for the results
-     */
-    sort?: Array<SortParamRequest>;
-    
+  /**
+   * Custom data for the feed
+   */
+  custom?: Record<string, any>;
 
-        
-    /**
-     * Filter conditions for moderation configs
-     */
-    filter?: Record<string, any>;
-    
+  location?: Location;
+}
 
-        }
-    
+export interface UpdateFeedResponse {
+  duration: string;
 
+  feed: FeedResponse;
+}
 
+export interface UpdateFollowRequest {
+  /**
+   * Fully qualified ID of the source feed
+   */
+  source: string;
 
+  /**
+   * Fully qualified ID of the target feed
+   */
+  target: string;
 
-    export interface QueryModerationConfigsResponse {
-    duration: string;
-    
+  /**
+   * Maximum number of historical activities to copy from the target feed when the follow is first materialized. Not set = unlimited (default). 0 = copy nothing. Range: 0-1000.
+   */
+  activity_copy_limit?: number;
 
-        
-    /**
-     * List of moderation configurations
-     */
-    configs: Array<ConfigResponse>;
-    
+  /**
+   * @deprecated
+   * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
+   */
+  copy_custom_to_notification?: boolean;
 
-        
-    next?: string;
-    
+  /**
+   * Whether to create a notification activity for this follow
+   */
+  create_notification_activity?: boolean;
 
-        
-    prev?: string;
-    
+  /**
+   * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+   */
+  enrich_own_fields?: boolean;
 
-        }
-    
+  follower_role?: string;
 
+  /**
+   * Push preference for the follow relationship
+   */
 
+  push_preference?: 'all' | 'none';
 
+  /**
+   * Whether to skip push for this follow
+   */
+  skip_push?: boolean;
 
-    export interface QueryPinnedActivitiesRequest {
-    enrich_own_fields?: boolean;
-    
+  /**
+   * Custom data for the follow relationship
+   */
+  custom?: Record<string, any>;
+}
 
-        
-    limit?: number;
-    
+export interface UpdateFollowResponse {
+  duration: string;
 
-        
-    next?: string;
-    
+  follow: FollowResponse;
+}
 
-        
-    prev?: string;
-    
+export interface UpdateLiveLocationRequest {
+  /**
+   * Live location ID
+   */
+  message_id: string;
 
-        
-    /**
-     * Sorting parameters for the query
-     */
-    sort?: Array<SortParamRequest>;
-    
+  /**
+   * Time when the live location expires
+   */
+  end_at?: Date;
 
-        
-    /**
-     * Filters to apply to the query
-     */
-    filter?: Record<string, any>;
-    
+  /**
+   * Latitude coordinate
+   */
+  latitude?: number;
 
-        }
-    
+  /**
+   * Longitude coordinate
+   */
+  longitude?: number;
+}
 
+export interface UpdatePollOptionRequest {
+  /**
+   * Option ID
+   */
+  id: string;
 
+  /**
+   * Option text
+   */
+  text: string;
 
+  custom?: Record<string, any>;
+}
 
-    export interface QueryPinnedActivitiesResponse {
-    duration: string;
-    
+export interface UpdatePollPartialRequest {
+  /**
+   * Array of field names to unset
+   */
+  unset?: string[];
 
-        
-    /**
-     * List of pinned activities matching the query
-     */
-    pinned_activities: Array<ActivityPinResponse>;
-    
+  /**
+   * Sets new field values
+   */
+  set?: Record<string, any>;
+}
 
-        
-    /**
-     * Cursor for next page
-     */
-    next?: string;
-    
+export interface UpdatePollRequest {
+  /**
+   * Poll ID
+   */
+  id: string;
 
-        
-    /**
-     * Cursor for previous page
-     */
-    prev?: string;
-    
+  /**
+   * Poll name
+   */
+  name: string;
 
-        }
-    
+  /**
+   * Allow answers
+   */
+  allow_answers?: boolean;
 
+  /**
+   * Allow user suggested options
+   */
+  allow_user_suggested_options?: boolean;
 
+  /**
+   * Poll description
+   */
+  description?: string;
 
+  /**
+   * Enforce unique vote
+   */
+  enforce_unique_vote?: boolean;
 
-    export interface QueryPollVotesRequest {
-    limit?: number;
-    
+  /**
+   * Is closed
+   */
+  is_closed?: boolean;
 
-        
-    next?: string;
-    
+  /**
+   * Max votes allowed
+   */
+  max_votes_allowed?: number;
 
-        
-    prev?: string;
-    
+  /**
+   * Voting visibility
+   */
 
-        
-    /**
-     * Array of sort parameters
-     */
-    sort?: Array<SortParamRequest>;
-    
+  voting_visibility?: 'anonymous' | 'public';
 
-        
-    /**
-     * Filter to apply to the query
-     */
-    filter?: Record<string, any>;
-    
+  /**
+   * Poll options
+   */
+  options?: PollOptionRequest[];
 
-        }
-    
+  custom?: Record<string, any>;
+}
 
+export interface UpdateUserGroupRequest {
+  /**
+   * The new description for the group
+   */
+  description?: string;
 
+  /**
+   * The new name of the user group
+   */
+  name?: string;
 
+  team_id?: string;
+}
 
-    export interface QueryPollsRequest {
-    limit?: number;
-    
+export interface UpdateUserGroupResponse {
+  duration: string;
 
-        
-    next?: string;
-    
+  user_group?: UserGroupResponse;
+}
 
-        
-    prev?: string;
-    
+export interface UpdateUserPartialRequest {
+  /**
+   * User ID to update
+   */
+  id: string;
 
-        
-    /**
-     * Array of sort parameters
-     */
-    sort?: Array<SortParamRequest>;
-    
+  unset?: string[];
 
-        
-    /**
-     * Filter to apply to the query
-     */
-    filter?: Record<string, any>;
-    
+  set?: Record<string, any>;
+}
 
-        }
-    
+export interface UpdateUsersPartialRequest {
+  users: UpdateUserPartialRequest[];
+}
 
+export interface UpdateUsersRequest {
+  /**
+   * Object containing users
+   */
+  users: Record<string, UserRequest>;
+}
 
+export interface UpdateUsersResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
+  membership_deletion_task_id: string;
 
-    export interface QueryPollsResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  /**
+   * Object containing users
+   */
+  users: Record<string, FullUserResponse>;
+}
 
-        
-    /**
-     * Polls data returned by the query
-     */
-    polls: Array<PollResponseData>;
-    
+export interface UpsertActionConfigItem {
+  action: string;
 
-        
-    next?: string;
-    
+  entity_type: string;
 
-        
-    prev?: string;
-    
+  order: number;
 
-        }
-    
+  description?: string;
 
+  icon?: string;
 
+  id?: string;
 
+  queue_type?: string;
 
-    export interface QueryReviewQueueRequest {
-    exclude_default_action_config?: boolean;
-    
+  custom?: Record<string, any>;
+}
 
-        
-    limit?: number;
-    
+export interface UpsertActionConfigRequest {
+  /**
+   * The action to perform (e.g. ban, delete_message, custom)
+   */
+  action: string;
 
-        
-    /**
-     * Number of items to lock (1-25)
-     */
-    lock_count?: number;
-    
+  /**
+   * Type of entity this action applies to (e.g. stream:chat:v1:message)
+   */
+  entity_type: string;
 
-        
-    /**
-     * Duration for which items should be locked
-     */
-    lock_duration?: number;
-    
+  /**
+   * Display order in the dashboard (0–100, lower numbers shown first)
+   */
+  order: number;
 
-        
-    /**
-     * Whether to lock items for review (true), unlock items (false), or just fetch (nil)
-     */
-    lock_items?: boolean;
-    
+  /**
+   * Human-readable label for the dashboard button
+   */
+  description?: string;
 
-        
-    next?: string;
-    
+  /**
+   * Icon identifier for the dashboard button
+   */
+  icon?: string;
 
-        
-    prev?: string;
-    
+  /**
+   * UUID of an existing action config to update; omit to create a new record
+   */
+  id?: string;
 
-        
-    /**
-     * Whether to return only statistics
-     */
-    stats_only?: boolean;
-    
+  /**
+   * Queue this config belongs to; null means the default queue
+   */
+  queue_type?: string;
 
-        
-    /**
-     * Sorting parameters for the results
-     */
-    sort?: Array<SortParamRequest>;
-    
+  /**
+   * Action-specific parameters passed to the action handler
+   */
+  custom?: Record<string, any>;
+}
 
-        
-    /**
-     * Filter conditions for review queue items
-     */
-    filter?: Record<string, any>;
-    
+export interface UpsertActionConfigResponse {
+  duration: string;
 
-        }
-    
+  action_config?: ModerationActionConfigResponse;
+}
 
+export interface UpsertActivitiesRequest {
+  /**
+   * List of activities to create or update
+   */
+  activities: ActivityRequest[];
 
+  /**
+   * If true, enriches the activities' current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
+   */
+  enrich_own_fields?: boolean;
+}
 
+export interface UpsertActivitiesResponse {
+  duration: string;
 
-    export interface QueryReviewQueueResponse {
-    duration: string;
-    
+  /**
+   * List of created or updated activities
+   */
+  activities: ActivityResponse[];
 
-        
-    /**
-     * List of review queue items
-     */
-    items: Array<ReviewQueueItemResponse>;
-    
+  /**
+   * Total number of mention notification activities created for mentioned users across all activities
+   */
+  mention_notifications_created?: number;
+}
 
-        
-    /**
-     * Configuration for moderation actions
-     */
-    action_config: Record<string, Array<ModerationActionConfigResponse>>;
-    
+export interface UpsertConfigRequest {
+  /**
+   * Unique identifier for the moderation configuration
+   */
+  key: string;
 
-        
-    /**
-     * Statistics about the review queue
-     */
-    stats: Record<string, any>;
-    
+  /**
+   * Whether moderation should be performed asynchronously
+   */
+  async?: boolean;
 
-        
-    next?: string;
-    
+  /**
+   * Team associated with the configuration
+   */
+  team?: string;
 
-        
-    prev?: string;
-    
+  ai_image_config?: AIImageConfig;
 
-        
-    default_action_config?: Record<string, Array<ModerationActionConfigResponse>>;
-    
+  ai_text_config?: AITextConfig;
 
-        
-    filter_config?: FilterConfigResponse;
-    
+  ai_video_config?: AIVideoConfig;
 
-        }
-    
+  automod_platform_circumvention_config?: AutomodPlatformCircumventionConfig;
 
+  automod_semantic_filters_config?: AutomodSemanticFiltersConfig;
 
+  automod_toxicity_config?: AutomodToxicityConfig;
 
+  aws_rekognition_config?: AIImageConfig;
 
-    export interface QueryUsersPayload {
-    /**
-     * Filter conditions to apply to the query
-     */
-    filter_conditions: Record<string, any>;
-    
+  block_list_config?: BlockListConfig;
 
-        
-    include_deactivated_users?: boolean;
-    
+  bodyguard_config?: AITextConfig;
 
-        
-    limit?: number;
-    
+  google_vision_config?: GoogleVisionConfig;
 
-        
-    offset?: number;
-    
+  llm_config?: LLMConfig;
 
-        
-    presence?: boolean;
-    
+  rule_builder_config?: RuleBuilderConfig;
 
-        
-    /**
-     * Array of sort parameters
-     */
-    sort?: Array<SortParamRequest>;
-    
+  velocity_filter_config?: VelocityFilterConfig;
 
-        }
-    
+  video_call_rule_config?: VideoCallRuleConfig;
+}
 
+export interface UpsertConfigResponse {
+  duration: string;
 
+  config?: ConfigResponse;
+}
 
+export interface UpsertPushPreferencesRequest {
+  /**
+   * A list of push preferences for channels, calls, or the user.
+   */
+  preferences: PushPreferenceInput[];
+}
 
-    export interface QueryUsersResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+export interface UpsertPushPreferencesResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
 
-        
-    /**
-     * Array of users as result of filters applied.
-     */
-    users: Array<FullUserResponse>;
-    
+  /**
+   * The channel specific push notification preferences, only returned for channels you've edited.
+   */
+  user_channel_preferences: Record<
+    string,
+    Record<string, ChannelPushPreferencesResponse | null>
+  >;
 
-        }
-    
+  /**
+   * The user preferences, always returned regardless if you edited it
+   */
+  user_preferences: Record<string, PushPreferencesResponse>;
+}
 
+export interface User {
+  id: string;
 
+  data?: Record<string, any>;
+}
 
+export interface UserBannedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-    export interface RankingConfig {
-    score?: string;
-    
+  custom: Record<string, any>;
 
-        
-    type?: string;
-    
+  user: UserResponseCommonFields;
 
-        
-    defaults?: Record<string, any>;
-    
+  /**
+   * The type of event: "user.banned" in this case
+   */
+  type: string;
 
-        
-    functions?: Record<string, DecayFunctionConfig>;
-    
+  /**
+   * The ID of the channel where the target user was banned
+   */
+  channel_id?: string;
 
-        }
-    
+  channel_member_count?: number;
 
+  channel_message_count?: number;
 
+  /**
+   * The type of the channel where the target user was banned
+   */
+  channel_type?: string;
 
+  /**
+   * The CID of the channel where the target user was banned
+   */
+  cid?: string;
 
-    export interface Reaction {
-    activity_id: string;
-    
+  /**
+   * The expiration date of the ban
+   */
+  expiration?: Date;
 
-        
-    created_at: Date;
-    
+  /**
+   * The reason for the ban
+   */
+  reason?: string;
 
-        
-    kind: string;
-    
+  received_at?: Date;
 
-        
-    updated_at: Date;
-    
+  /**
+   * Whether the user was shadow banned
+   */
+  shadow?: boolean;
 
-        
-    user_id: string;
-    
+  /**
+   * The team of the channel where the target user was banned
+   */
+  team?: string;
 
-        
-    deleted_at?: Date;
-    
+  total_bans?: number;
 
-        
-    id?: string;
-    
+  channel_custom?: Record<string, any>;
 
-        
-    parent?: string;
-    
+  created_by?: UserResponseCommonFields;
+}
 
-        
-    score?: number;
-    
+export interface UserCreatedWithinParameters {
+  max_age?: string;
+}
 
-        
-    target_feeds?: Array<string>;
-    
+export interface UserCustomPropertyParameters {
+  operator?: string;
 
-        
-    children_counts?: Record<string, any>;
-    
+  property_key?: string;
+}
 
-        
-    data?: Record<string, any>;
-    
+export interface UserDeactivatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    latest_children?: Record<string, Array<Reaction>>;
-    
+  custom: Record<string, any>;
 
-        
-    moderation?: Record<string, any>;
-    
+  user: UserResponseCommonFields;
 
-        
-    own_children?: Record<string, Array<Reaction>>;
-    
+  /**
+   * The type of event: "user.deactivated" in this case
+   */
+  type: string;
 
-        
-    target_feeds_extra_data?: Record<string, any>;
-    
+  received_at?: Date;
 
-        
-    user?: User;
-    
+  created_by?: UserResponseCommonFields;
+}
 
-        }
-    
+export interface UserGroupMember {
+  app_pk: number;
 
+  created_at: Date;
 
+  group_id: string;
 
+  is_admin: boolean;
 
-    export interface ReactionGroupResponse {
-    /**
-     * Count is the number of reactions of this type.
-     */
-    count: number;
-    
+  user_id: string;
+}
 
-        
-    /**
-     * FirstReactionAt is the time of the first reaction of this type. This is the same also if all reaction of this type are deleted, because if someone will react again with the same type, will be preserved the sorting.
-     */
-    first_reaction_at: Date;
-    
+export interface UserGroupResponse {
+  created_at: Date;
 
-        
-    /**
-     * LastReactionAt is the time of the last reaction of this type.
-     */
-    last_reaction_at: Date;
-    
+  id: string;
 
-        
-    /**
-     * SumScores is the sum of all scores of reactions of this type. Medium allows you to clap articles more than once and shows the sum of all claps from all users. For example, you can send `clap` x5 using `score: 5`.
-     */
-    sum_scores: number;
-    
+  name: string;
 
-        
-    /**
-     * The most recent users who reacted with this type, ordered by most recent first.
-     */
-    latest_reactions_by: Array<ReactionGroupUserResponse>;
-    
+  updated_at: Date;
 
-        }
-    
+  created_by?: string;
 
+  description?: string;
 
+  team_id?: string;
 
+  members?: UserGroupMember[];
+}
 
-    export interface ReactionGroupUserResponse {
-    /**
-     * The time when the user reacted.
-     */
-    created_at: Date;
-    
+export interface UserIdenticalContentCountParameters {
+  threshold?: number;
 
-        
-    /**
-     * The ID of the user who reacted.
-     */
-    user_id: string;
-    
+  time_window?: string;
+}
 
-        
-    user?: UserResponse;
-    
+export interface UserMuteResponse {
+  created_at: Date;
 
-        }
-    
+  updated_at: Date;
 
+  expires?: Date;
 
+  target?: UserResponse;
 
+  user?: UserResponse;
+}
 
-    export interface ReactionResponse {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
+export interface UserReactivatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
-        
-    /**
-     * Message ID
-     */
-    message_id: string;
-    
+  custom: Record<string, any>;
 
-        
-    /**
-     * Score of the reaction
-     */
-    score: number;
-    
+  user: UserResponseCommonFields;
 
-        
-    /**
-     * Type of reaction
-     */
-    type: string;
-    
+  /**
+   * The type of event: "user.reactivated" in this case
+   */
+  type: string;
 
-        
-    /**
-     * Date/time of the last update
-     */
-    updated_at: Date;
-    
+  received_at?: Date;
 
-        
-    /**
-     * User ID
-     */
-    user_id: string;
-    
+  created_by?: UserResponseCommonFields;
+}
 
-        
-    /**
-     * Custom data for this object
-     */
-    custom: Record<string, any>;
-    
+export interface UserRequest {
+  /**
+   * User ID
+   */
+  id: string;
 
-        
-    user: UserResponse;
-    
+  /**
+   * User's profile image URL
+   */
+  image?: string;
 
-        }
-    
+  invisible?: boolean;
 
+  language?: string;
 
+  /**
+   * Optional name of user
+   */
+  name?: string;
 
+  /**
+   * Custom user data
+   */
+  custom?: Record<string, any>;
 
-    export interface ReadCollectionsResponse {
-    duration: string;
-    
+  privacy_settings?: PrivacySettingsResponse;
+}
 
-        
-    /**
-     * List of collections matching the references
-     */
-    collections: Array<CollectionResponse>;
-    
+export interface UserResponse {
+  /**
+   * Whether a user is banned or not
+   */
+  banned: boolean;
 
-        }
-    
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
+  /**
+   * Unique user identifier
+   */
+  id: string;
 
+  /**
+   * Preferred language of a user
+   */
+  language: string;
 
+  /**
+   * Whether a user online or not
+   */
+  online: boolean;
 
-    export interface ReadReceiptsResponse {
-    enabled: boolean;
-    
+  /**
+   * Determines the set of user permissions
+   */
+  role: string;
 
-        }
-    
+  /**
+   * Date/time of the last update
+   */
+  updated_at: Date;
 
+  blocked_user_ids: string[];
 
+  /**
+   * List of teams user is a part of
+   */
+  teams: string[];
 
+  /**
+   * Custom data for this object
+   */
+  custom: Record<string, any>;
 
-    export interface RejectAppealRequestPayload {
-    /**
-     * Reason for rejecting the appeal
-     */
-    decision_reason: string;
-    
+  avg_response_time?: number;
 
-        }
-    
+  /**
+   * Date of deactivation
+   */
+  deactivated_at?: Date;
 
+  /**
+   * Date/time of deletion
+   */
+  deleted_at?: Date;
 
+  image?: string;
 
+  /**
+   * Date of last activity
+   */
+  last_active?: Date;
 
-    export interface RejectFeedMemberInviteRequest {}
-    
+  /**
+   * Optional name of user
+   */
+  name?: string;
 
+  /**
+   * Revocation date for tokens
+   */
+  revoke_tokens_issued_before?: Date;
 
+  teams_role?: Record<string, string>;
+}
 
+export interface UserResponseCommonFields {
+  banned: boolean;
 
-    export interface RejectFeedMemberInviteResponse {
-    duration: string;
-    
+  created_at: Date;
 
-        
-    member: FeedMemberResponse;
-    
+  id: string;
 
-        }
-    
+  language: string;
 
+  online: boolean;
 
+  role: string;
 
+  updated_at: Date;
 
-    export interface RejectFollowRequest {
-    /**
-     * Fully qualified ID of the source feed
-     */
-    source: string;
-    
+  blocked_user_ids: string[];
 
-        
-    /**
-     * Fully qualified ID of the target feed
-     */
-    target: string;
-    
+  teams: string[];
 
-        }
-    
+  custom: Record<string, any>;
 
+  avg_response_time?: number;
 
+  deactivated_at?: Date;
 
+  deleted_at?: Date;
 
-    export interface RejectFollowResponse {
-    duration: string;
-    
+  image?: string;
 
-        
-    follow: FollowResponse;
-    
+  last_active?: Date;
 
-        }
-    
+  name?: string;
 
+  revoke_tokens_issued_before?: Date;
 
+  teams_role?: Record<string, string>;
+}
 
+export interface UserResponsePrivacyFields {
+  banned: boolean;
 
-    export interface ReminderResponseData {
-    channel_cid: string;
-    
+  created_at: Date;
 
-        
-    created_at: Date;
-    
+  id: string;
 
-        
-    message_id: string;
-    
+  language: string;
 
-        
-    updated_at: Date;
-    
+  online: boolean;
 
-        
-    user_id: string;
-    
+  role: string;
 
-        
-    remind_at?: Date;
-    
+  updated_at: Date;
 
-        
-    channel?: ChannelResponse;
-    
+  blocked_user_ids: string[];
 
-        
-    message?: MessageResponse;
-    
+  teams: string[];
 
-        
-    user?: UserResponse;
-    
+  custom: Record<string, any>;
 
-        }
-    
+  avg_response_time?: number;
 
+  deactivated_at?: Date;
 
+  deleted_at?: Date;
 
+  image?: string;
 
-    export interface RemoveUserGroupMembersRequest {
-    /**
-     * List of user IDs to remove
-     */
-    member_ids: Array<string>;
-    
+  invisible?: boolean;
 
-        
-    team_id?: string;
-    
+  last_active?: Date;
 
-        }
-    
+  name?: string;
 
+  revoke_tokens_issued_before?: Date;
 
+  privacy_settings?: PrivacySettingsResponse;
 
+  teams_role?: Record<string, string>;
+}
 
-    export interface RemoveUserGroupMembersResponse {
-    duration: string;
-    
+export interface UserRoleParameters {
+  operator?: string;
 
-        
-    user_group?: UserGroupResponse;
-    
+  role?: string;
+}
 
-        }
-    
+export interface UserRuleParameters {
+  max_age?: string;
+}
 
+export interface UserUnbannedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
+  custom: Record<string, any>;
 
+  user: UserResponseCommonFields;
 
-    export interface RepliesMeta {
-    /**
-     * True if the subtree was cut because the requested depth was reached.
-     */
-    depth_truncated: boolean;
-    
+  /**
+   * The type of event: "user.unbanned" in this case
+   */
+  type: string;
 
-        
-    /**
-     * True if more siblings exist in the database.
-     */
-    has_more: boolean;
-    
+  /**
+   * The ID of the channel where the target user was unbanned
+   */
+  channel_id?: string;
 
-        
-    /**
-     * Number of unread siblings that match current filters.
-     */
-    remaining: number;
-    
+  channel_member_count?: number;
 
-        
-    /**
-     * Opaque cursor to request the next page of siblings.
-     */
-    next_cursor?: string;
-    
+  channel_message_count?: number;
 
-        }
-    
+  /**
+   * The type of the channel where the target user was unbanned
+   */
+  channel_type?: string;
 
+  /**
+   * The CID of the channel where the target user was unbanned
+   */
+  cid?: string;
 
+  received_at?: Date;
 
+  /**
+   * Whether the target user was shadow unbanned
+   */
+  shadow?: boolean;
 
-    export interface Response {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
+  /**
+   * The team of the channel where the target user was unbanned
+   */
+  team?: string;
 
-        }
-    
+  channel_custom?: Record<string, any>;
 
+  created_by?: UserResponseCommonFields;
+}
 
+export interface UserUpdatedEvent {
+  /**
+   * Date/time of creation
+   */
+  created_at: Date;
 
+  custom: Record<string, any>;
 
-    export interface RestoreActionRequestPayload {
-    /**
-     * Reason for the appeal decision
-     */
-    decision_reason?: string;
-    
+  user: UserResponsePrivacyFields;
 
-        }
-    
+  /**
+   * The type of event: "user.updated" in this case
+   */
+  type: string;
 
+  received_at?: Date;
+}
 
+export interface VelocityFilterConfig {
+  advanced_filters: boolean;
 
+  cascading_actions: boolean;
 
-    export interface RestoreActivityRequest {}
-    
+  cids_per_user: number;
 
+  enabled: boolean;
 
+  first_message_only: boolean;
 
+  rules: VelocityFilterConfigRule[];
 
-    export interface RestoreActivityResponse {
-    duration: string;
-    
+  async?: boolean;
+}
 
-        
-    activity: ActivityResponse;
-    
+export interface VelocityFilterConfigRule {
+  action: 'flag' | 'shadow' | 'remove' | 'ban';
 
-        }
-    
+  ban_duration: number;
 
+  cascading_action: 'flag' | 'shadow' | 'remove' | 'ban';
 
+  cascading_threshold: number;
 
+  check_message_context: boolean;
 
-    export interface RestoreCommentRequest {}
-    
+  fast_spam_threshold: number;
 
+  fast_spam_ttl: number;
 
+  ip_ban: boolean;
 
+  probation_period: number;
 
-    export interface RestoreCommentResponse {
-    duration: string;
-    
+  shadow_ban: boolean;
 
-        
-    activity: ActivityResponse;
-    
+  slow_spam_threshold: number;
 
-        
-    comment: CommentResponse;
-    
+  slow_spam_ttl: number;
 
-        }
-    
+  url_only: boolean;
 
+  slow_spam_ban_duration?: number;
+}
 
+export interface VideoCallRuleConfig {
+  flag_all_labels: boolean;
 
+  flagged_labels: string[];
 
-    export interface ReviewQueueItemResponse {
-    /**
-     * AI-determined text severity
-     */
-    ai_text_severity: string;
-    
+  rules: HarmConfig[];
+}
 
-        
-    /**
-     * When the item was created
-     */
-    created_at: Date;
-    
+export interface VideoContentParameters {
+  label_operator?: string;
 
-        
-    /**
-     * ID of the entity being reviewed
-     */
-    entity_id: string;
-    
+  harm_labels?: string[];
+}
 
-        
-    /**
-     * Type of entity being reviewed
-     */
-    entity_type: string;
-    
+export interface VideoEndCallRequestPayload {}
 
-        
-    /**
-     * Whether the item has been escalated
-     */
-    escalated: boolean;
-    
+export interface VideoKickUserRequestPayload {}
 
-        
-    flags_count: number;
-    
+export interface VideoRuleParameters {
+  threshold?: number;
 
-        
-    /**
-     * Unique identifier of the review queue item
-     */
-    id: string;
-    
+  time_window?: string;
 
-        
-    latest_moderator_action: string;
-    
+  harm_labels?: string[];
+}
 
-        
-    /**
-     * Suggested moderation action
-     */
-    recommended_action: string;
-    
+export interface VoteData {
+  answer_text?: string;
 
-        
-    /**
-     * ID of the moderator who reviewed the item
-     */
-    reviewed_by: string;
-    
+  option_id?: string;
+}
 
-        
-    /**
-     * Severity level of the content
-     */
-    severity: number;
-    
+export interface WSAuthMessage {
+  /**
+   * JWT token for authentication
+   */
+  token: string;
 
-        
-    /**
-     * Current status of the review
-     */
-    status: string;
-    
+  user_details: ConnectUserDetailsRequest;
 
-        
-    /**
-     * When the item was last updated
-     */
-    updated_at: Date;
-    
+  /**
+   * List of products to subscribe to. One of: chat, video, feeds
+   */
+  products?: string[];
+}
 
-        
-    /**
-     * Moderation actions taken
-     */
-    actions: Array<ActionLogResponse>;
-    
+export type WSClientEvent =
+  | ({ type: 'app.updated' } & AppUpdatedEvent)
+  | ({ type: 'feeds.activity.added' } & ActivityAddedEvent)
+  | ({ type: 'feeds.activity.deleted' } & ActivityDeletedEvent)
+  | ({ type: 'feeds.activity.feedback' } & ActivityFeedbackEvent)
+  | ({ type: 'feeds.activity.marked' } & ActivityMarkEvent)
+  | ({ type: 'feeds.activity.pinned' } & ActivityPinnedEvent)
+  | ({ type: 'feeds.activity.reaction.added' } & ActivityReactionAddedEvent)
+  | ({ type: 'feeds.activity.reaction.deleted' } & ActivityReactionDeletedEvent)
+  | ({ type: 'feeds.activity.reaction.updated' } & ActivityReactionUpdatedEvent)
+  | ({
+      type: 'feeds.activity.removed_from_feed';
+    } & ActivityRemovedFromFeedEvent)
+  | ({ type: 'feeds.activity.restored' } & ActivityRestoredEvent)
+  | ({ type: 'feeds.activity.unpinned' } & ActivityUnpinnedEvent)
+  | ({ type: 'feeds.activity.updated' } & ActivityUpdatedEvent)
+  | ({ type: 'feeds.bookmark.added' } & BookmarkAddedEvent)
+  | ({ type: 'feeds.bookmark.deleted' } & BookmarkDeletedEvent)
+  | ({ type: 'feeds.bookmark.updated' } & BookmarkUpdatedEvent)
+  | ({ type: 'feeds.bookmark_folder.deleted' } & BookmarkFolderDeletedEvent)
+  | ({ type: 'feeds.bookmark_folder.updated' } & BookmarkFolderUpdatedEvent)
+  | ({ type: 'feeds.comment.added' } & CommentAddedEvent)
+  | ({ type: 'feeds.comment.deleted' } & CommentDeletedEvent)
+  | ({ type: 'feeds.comment.reaction.added' } & CommentReactionAddedEvent)
+  | ({ type: 'feeds.comment.reaction.deleted' } & CommentReactionDeletedEvent)
+  | ({ type: 'feeds.comment.reaction.updated' } & CommentReactionUpdatedEvent)
+  | ({ type: 'feeds.comment.restored' } & CommentRestoredEvent)
+  | ({ type: 'feeds.comment.updated' } & CommentUpdatedEvent)
+  | ({ type: 'feeds.feed.created' } & FeedCreatedEvent)
+  | ({ type: 'feeds.feed.deleted' } & FeedDeletedEvent)
+  | ({ type: 'feeds.feed.updated' } & FeedUpdatedEvent)
+  | ({ type: 'feeds.feed_group.changed' } & FeedGroupChangedEvent)
+  | ({ type: 'feeds.feed_group.deleted' } & FeedGroupDeletedEvent)
+  | ({ type: 'feeds.feed_group.restored' } & FeedGroupRestoredEvent)
+  | ({ type: 'feeds.feed_member.added' } & FeedMemberAddedEvent)
+  | ({ type: 'feeds.feed_member.removed' } & FeedMemberRemovedEvent)
+  | ({ type: 'feeds.feed_member.updated' } & FeedMemberUpdatedEvent)
+  | ({ type: 'feeds.follow.created' } & FollowCreatedEvent)
+  | ({ type: 'feeds.follow.deleted' } & FollowDeletedEvent)
+  | ({ type: 'feeds.follow.updated' } & FollowUpdatedEvent)
+  | ({ type: 'feeds.notification_feed.updated' } & NotificationFeedUpdatedEvent)
+  | ({ type: 'feeds.poll.closed' } & PollClosedFeedEvent)
+  | ({ type: 'feeds.poll.deleted' } & PollDeletedFeedEvent)
+  | ({ type: 'feeds.poll.updated' } & PollUpdatedFeedEvent)
+  | ({ type: 'feeds.poll.vote_casted' } & PollVoteCastedFeedEvent)
+  | ({ type: 'feeds.poll.vote_changed' } & PollVoteChangedFeedEvent)
+  | ({ type: 'feeds.poll.vote_removed' } & PollVoteRemovedFeedEvent)
+  | ({ type: 'feeds.stories_feed.updated' } & StoriesFeedUpdatedEvent)
+  | ({ type: 'health.check' } & HealthCheckEvent)
+  | ({ type: 'moderation.custom_action' } & ModerationCustomActionEvent)
+  | ({ type: 'moderation.flagged' } & ModerationFlaggedEvent)
+  | ({ type: 'moderation.mark_reviewed' } & ModerationMarkReviewedEvent)
+  | ({ type: 'user.banned' } & UserBannedEvent)
+  | ({ type: 'user.deactivated' } & UserDeactivatedEvent)
+  | ({ type: 'user.reactivated' } & UserReactivatedEvent)
+  | ({ type: 'user.unbanned' } & UserUnbannedEvent)
+  | ({ type: 'user.updated' } & UserUpdatedEvent);
 
-        
-    /**
-     * Associated ban records
-     */
-    bans: Array<BanInfoResponse>;
-    
-
-        
-    /**
-     * Associated flag records
-     */
-    flags: Array<ModerationFlagResponse>;
-    
-
-        
-    /**
-     * Detected languages in the content
-     */
-    languages: Array<string>;
-    
-
-        
-    /**
-     * When the review was completed
-     */
-    completed_at?: Date;
-    
-
-        
-    config_key?: string;
-    
-
-        
-    /**
-     * ID of who created the entity
-     */
-    entity_creator_id?: string;
-    
-
-        
-    /**
-     * When the item was escalated
-     */
-    escalated_at?: Date;
-    
-
-        
-    /**
-     * ID of the moderator who escalated the item
-     */
-    escalated_by?: string;
-    
-
-        
-    /**
-     * When the item was reviewed
-     */
-    reviewed_at?: Date;
-    
-
-        
-    /**
-     * Teams associated with this item
-     */
-    teams?: Array<string>;
-    
-
-        
-    activity?: EnrichedActivity;
-    
-
-        
-    appeal?: AppealItemResponse;
-    
-
-        
-    assigned_to?: UserResponse;
-    
-
-        
-    call?: CallResponse;
-    
-
-        
-    entity_creator?: EntityCreatorResponse;
-    
-
-        
-    escalation_metadata?: EscalationMetadata;
-    
-
-        
-    feeds_v2_activity?: EnrichedActivity;
-    
-
-        
-    feeds_v2_reaction?: Reaction;
-    
-
-        
-    feeds_v3_activity?: FeedsV3ActivityResponse;
-    
-
-        
-    feeds_v3_comment?: FeedsV3CommentResponse;
-    
-
-        
-    message?: ChatMessageResponse;
-    
-
-        
-    moderation_payload?: ModerationPayloadResponse;
-    
-
-        
-    reaction?: Reaction;
-    
-
-        }
-    
-
-
-
-
-    export interface RuleBuilderAction {
-    skip_inbox?: boolean;
-    
-
-        
-    
-        type?:| "ban_user" | "flag_user" | "flag_content" | "block_content" | "shadow_content" | "bounce_flag_content" | "bounce_content" | "bounce_remove_content" | "mute_video" | "mute_audio" | "blur" | "call_blur" | "end_call" | "kick_user" | "warning" | "call_warning" | "webhook_only" ;
-
-        
-    ban_options?: BanOptions;
-    
-
-        
-    call_options?: CallActionOptions;
-    
-
-        
-    flag_user_options?: FlagUserOptions;
-    
-
-        }
-    
-
-
-
-
-    export interface RuleBuilderCondition {
-    confidence?: number;
-    
-
-        
-    type?: string;
-    
-
-        
-    call_custom_property_params?: CallCustomPropertyParameters;
-    
-
-        
-    call_type_rule_params?: CallTypeRuleParameters;
-    
-
-        
-    call_violation_count_params?: CallViolationCountParameters;
-    
-
-        
-    channel_message_count_rule_params?: ChannelMessageCountRuleParameters;
-    
-
-        
-    closed_caption_rule_params?: ClosedCaptionRuleParameters;
-    
-
-        
-    content_count_rule_params?: ContentCountRuleParameters;
-    
-
-        
-    content_flag_count_rule_params?: FlagCountRuleParameters;
-    
-
-        
-    image_content_params?: ImageContentParameters;
-    
-
-        
-    image_rule_params?: ImageRuleParameters;
-    
-
-        
-    keyframe_rule_params?: KeyframeRuleParameters;
-    
-
-        
-    text_content_params?: TextContentParameters;
-    
-
-        
-    text_rule_params?: TextRuleParameters;
-    
-
-        
-    user_created_within_params?: UserCreatedWithinParameters;
-    
-
-        
-    user_custom_property_params?: UserCustomPropertyParameters;
-    
-
-        
-    user_flag_count_rule_params?: FlagCountRuleParameters;
-    
-
-        
-    user_identical_content_count_params?: UserIdenticalContentCountParameters;
-    
-
-        
-    user_role_params?: UserRoleParameters;
-    
-
-        
-    user_rule_params?: UserRuleParameters;
-    
-
-        
-    video_content_params?: VideoContentParameters;
-    
-
-        
-    video_rule_params?: VideoRuleParameters;
-    
-
-        }
-    
-
-
-
-
-    export interface RuleBuilderConditionGroup {
-    logic?: string;
-    
-
-        
-    conditions?: Array<RuleBuilderCondition>;
-    
-
-        }
-    
-
-
-
-
-    export interface RuleBuilderConfig {
-    async?: boolean;
-    
-
-        
-    rules?: Array<RuleBuilderRule>;
-    
-
-        }
-    
-
-
-
-
-    export interface RuleBuilderRule {
-    rule_type: string;
-    
-
-        
-    cooldown_period?: string;
-    
-
-        
-    id?: string;
-    
-
-        
-    logic?: string;
-    
-
-        
-    action_sequences?: Array<CallRuleActionSequence>;
-    
-
-        
-    conditions?: Array<RuleBuilderCondition>;
-    
-
-        
-    groups?: Array<RuleBuilderConditionGroup>;
-    
-
-        
-    action?: RuleBuilderAction;
-    
-
-        }
-    
-
-
-
-
-    export interface SearchUserGroupsResponse {
-    duration: string;
-    
-
-        
-    /**
-     * List of matching user groups
-     */
-    user_groups: Array<UserGroupResponse>;
-    
-
-        }
-    
-
-
-
-
-    export interface ShadowBlockActionRequestPayload {
-    /**
-     * Reason for shadow blocking
-     */
-    reason?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface SharedLocationResponse {
-    /**
-     * Channel CID
-     */
-    channel_cid: string;
-    
-
-        
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    /**
-     * Device ID that created the live location
-     */
-    created_by_device_id: string;
-    
-
-        
-    duration: string;
-    
-
-        
-    /**
-     * Latitude coordinate
-     */
-    latitude: number;
-    
-
-        
-    /**
-     * Longitude coordinate
-     */
-    longitude: number;
-    
-
-        
-    /**
-     * Message ID
-     */
-    message_id: string;
-    
-
-        
-    /**
-     * Date/time of the last update
-     */
-    updated_at: Date;
-    
-
-        
-    /**
-     * User ID
-     */
-    user_id: string;
-    
-
-        
-    /**
-     * Time when the live location expires
-     */
-    end_at?: Date;
-    
-
-        
-    channel?: ChannelResponse;
-    
-
-        
-    message?: MessageResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface SharedLocationResponseData {
-    channel_cid: string;
-    
-
-        
-    created_at: Date;
-    
-
-        
-    created_by_device_id: string;
-    
-
-        
-    latitude: number;
-    
-
-        
-    longitude: number;
-    
-
-        
-    message_id: string;
-    
-
-        
-    updated_at: Date;
-    
-
-        
-    user_id: string;
-    
-
-        
-    end_at?: Date;
-    
-
-        
-    channel?: ChannelResponse;
-    
-
-        
-    message?: MessageResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface SharedLocationsResponse {
-    duration: string;
-    
-
-        
-    active_live_locations: Array<SharedLocationResponseData>;
-    
-
-        }
-    
-
-
-
-
-    export interface SingleFollowResponse {
-    duration: string;
-    
-
-        
-    follow: FollowResponse;
-    
-
-        
-    /**
-     * Whether a notification activity was successfully created
-     */
-    notification_created?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface SortParam {
-    direction: number;
-    
-
-        
-    field: string;
-    
-
-        
-    type: string;
-    
-
-        }
-    
-
-
-
-
-    export interface SortParamRequest {
-    /**
-     * Direction of sorting, 1 for Ascending, -1 for Descending, default is 1. One of: -1, 1
-     */
-    direction?: number;
-    
-
-        
-    /**
-     * Name of field to sort by
-     */
-    field?: string;
-    
-
-        
-    /**
-     * Type of field to sort by. Empty string or omitted means string type (default). One of: number, boolean
-     */
-    type?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface StoriesConfig {
-    skip_watched?: boolean;
-    
-
-        
-    track_watched?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface StoriesFeedUpdatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    /**
-     * The ID of the feed
-     */
-    fid: string;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    /**
-     * The type of event: "feeds.stories_feed.updated" in this case
-     */
-    type: string;
-    
-
-        
-    feed_visibility?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    /**
-     * Individual activities for stories feeds
-     */
-    activities?: Array<ActivityResponse>;
-    
-
-        
-    /**
-     * Aggregated activities for stories feeds
-     */
-    aggregated_activities?: Array<AggregatedActivityResponse>;
-    
-
-        
-    user?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface SubmitActionRequest {
-    /**
-     * Type of moderation action to perform. One of: mark_reviewed, delete_message, delete_activity, delete_comment, delete_reaction, ban, custom, unban, restore, delete_user, unblock, block, shadow_block, unmask, kick_user, end_call, escalate, de_escalate
-     */
-    
-        action_type:| "flag" | "mark_reviewed" | "delete_message" | "delete_activity" | "delete_comment" | "delete_reaction" | "ban" | "custom" | "unban" | "restore" | "delete_user" | "unblock" | "block" | "shadow_block" | "unmask" | "kick_user" | "end_call" | "reject_appeal" | "escalate" | "de_escalate" | "bypass" ;
-
-        
-    /**
-     * UUID of the appeal to act on (required for reject_appeal, optional for other actions)
-     */
-    appeal_id?: string;
-    
-
-        
-    /**
-     * UUID of the review queue item to act on
-     */
-    item_id?: string;
-    
-
-        
-    ban?: BanActionRequestPayload;
-    
-
-        
-    block?: BlockActionRequestPayload;
-    
-
-        
-    bypass?: BypassActionRequest;
-    
-
-        
-    custom?: CustomActionRequestPayload;
-    
-
-        
-    delete_activity?: DeleteActivityRequestPayload;
-    
-
-        
-    delete_comment?: DeleteCommentRequestPayload;
-    
-
-        
-    delete_message?: DeleteMessageRequestPayload;
-    
-
-        
-    delete_reaction?: DeleteReactionRequestPayload;
-    
-
-        
-    delete_user?: DeleteUserRequestPayload;
-    
-
-        
-    escalate?: EscalatePayload;
-    
-
-        
-    flag?: FlagRequest;
-    
-
-        
-    mark_reviewed?: MarkReviewedRequestPayload;
-    
-
-        
-    reject_appeal?: RejectAppealRequestPayload;
-    
-
-        
-    restore?: RestoreActionRequestPayload;
-    
-
-        
-    shadow_block?: ShadowBlockActionRequestPayload;
-    
-
-        
-    unban?: UnbanActionRequestPayload;
-    
-
-        
-    unblock?: UnblockActionRequestPayload;
-    
-
-        }
-    
-
-
-
-
-    export interface SubmitActionResponse {
-    duration: string;
-    
-
-        
-    appeal_item?: AppealItemResponse;
-    
-
-        
-    item?: ReviewQueueItemResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface TextContentParameters {
-    contains_url?: boolean;
-    
-
-        
-    label_operator?: string;
-    
-
-        
-    severity?: string;
-    
-
-        
-    blocklist_match?: Array<string>;
-    
-
-        
-    harm_labels?: Array<string>;
-    
-
-        
-    llm_harm_labels?: Record<string, string>;
-    
-
-        }
-    
-
-
-
-
-    export interface TextRuleParameters {
-    contains_url?: boolean;
-    
-
-        
-    semantic_filter_min_threshold?: number;
-    
-
-        
-    severity?: string;
-    
-
-        
-    threshold?: number;
-    
-
-        
-    time_window?: string;
-    
-
-        
-    blocklist_match?: Array<string>;
-    
-
-        
-    harm_labels?: Array<string>;
-    
-
-        
-    semantic_filter_names?: Array<string>;
-    
-
-        
-    llm_harm_labels?: Record<string, string>;
-    
-
-        }
-    
-
-
-
-
-    export interface ThreadedCommentResponse {
-    bookmark_count: number;
-    
-
-        
-    confidence_score: number;
-    
-
-        
-    created_at: Date;
-    
-
-        
-    downvote_count: number;
-    
-
-        
-    id: string;
-    
-
-        
-    object_id: string;
-    
-
-        
-    object_type: string;
-    
-
-        
-    reaction_count: number;
-    
-
-        
-    reply_count: number;
-    
-
-        
-    score: number;
-    
-
-        
-    /**
-     * Status of the comment. One of: active, deleted, removed, hidden
-     */
-    
-        status:| "active" | "deleted" | "removed" | "hidden" | "shadow_blocked" ;
-
-        
-    updated_at: Date;
-    
-
-        
-    upvote_count: number;
-    
-
-        
-    mentioned_users: Array<UserResponse>;
-    
-
-        
-    own_reactions: Array<FeedsReactionResponse>;
-    
-
-        
-    user: UserResponse;
-    
-
-        
-    controversy_score?: number;
-    
-
-        
-    deleted_at?: Date;
-    
-
-        
-    edited_at?: Date;
-    
-
-        
-    parent_id?: string;
-    
-
-        
-    text?: string;
-    
-
-        
-    attachments?: Array<Attachment>;
-    
-
-        
-    latest_reactions?: Array<FeedsReactionResponse>;
-    
-
-        
-    /**
-     * Slice of nested comments (may be empty).
-     */
-    replies?: Array<ThreadedCommentResponse>;
-    
-
-        
-    custom?: Record<string, any>;
-    
-
-        
-    meta?: RepliesMeta;
-    
-
-        
-    moderation?: ModerationV2Response;
-    
-
-        
-    reaction_groups?: Record<string, FeedsReactionGroupResponse>;
-    
-
-        }
-    
-
-
-
-
-    export interface Thresholds {
-    explicit?: LabelThresholds;
-    
-
-        
-    spam?: LabelThresholds;
-    
-
-        
-    toxic?: LabelThresholds;
-    
-
-        }
-    
-
-
-
-
-    export interface Time {}
-    
-
-
-
-
-    export interface TrackActivityMetricsEvent {
-    /**
-     * The ID of the activity to track the metric for
-     */
-    activity_id: string;
-    
-
-        
-    /**
-     * The metric name (e.g. views, clicks, impressions). Alphanumeric and underscores only.
-     */
-    metric: string;
-    
-
-        
-    /**
-     * The amount to increment (positive) or decrement (negative). Defaults to 1. The absolute value counts against rate limits.
-     */
-    delta?: number;
-    
-
-        }
-    
-
-
-
-
-    export interface TrackActivityMetricsEventResult {
-    /**
-     * The activity ID from the request
-     */
-    activity_id: string;
-    
-
-        
-    /**
-     * Whether the metric was counted (false if rate-limited)
-     */
-    allowed: boolean;
-    
-
-        
-    /**
-     * The metric name from the request
-     */
-    metric: string;
-    
-
-        
-    /**
-     * Error message if processing failed
-     */
-    error?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface TrackActivityMetricsRequest {
-    /**
-     * List of metric events to track (max 100 per request)
-     */
-    events: Array<TrackActivityMetricsEvent>;
-    
-
-        }
-    
-
-
-
-
-    export interface TrackActivityMetricsResponse {
-    duration: string;
-    
-
-        
-    /**
-     * Results for each event in the request, in the same order
-     */
-    results: Array<TrackActivityMetricsEventResult>;
-    
-
-        }
-    
-
-
-
-
-    export interface TypingIndicatorsResponse {
-    enabled: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface UnbanActionRequestPayload {
-    /**
-     * Channel CID for channel-specific unban
-     */
-    channel_cid?: string;
-    
-
-        
-    /**
-     * Reason for the appeal decision
-     */
-    decision_reason?: string;
-    
-
-        
-    /**
-     * Also remove the future channels ban for this user
-     */
-    remove_future_channels_ban?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface UnblockActionRequestPayload {
-    /**
-     * Reason for the appeal decision
-     */
-    decision_reason?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface UnblockUsersRequest {
-    blocked_user_id: string;
-    
-
-        }
-    
-
-
-
-
-    export interface UnblockUsersResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
-
-        }
-    
-
-
-
-
-    export interface UnfollowBatchRequest {
-    /**
-     * List of follow relationships to remove, each with optional keep_history
-     */
-    follows: Array<UnfollowPair>;
-    
-
-        
-    /**
-     * Whether to delete the corresponding notification activity (default: false)
-     */
-    delete_notification_activity?: boolean;
-    
-
-        
-    /**
-     * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-     */
-    enrich_own_fields?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface UnfollowBatchResponse {
-    duration: string;
-    
-
-        
-    /**
-     * List of follow relationships that were removed
-     */
-    follows: Array<FollowResponse>;
-    
-
-        }
-    
-
-
-
-
-    export interface UnfollowPair {
-    /**
-     * Fully qualified ID of the source feed
-     */
-    source: string;
-    
-
-        
-    /**
-     * Fully qualified ID of the target feed
-     */
-    target: string;
-    
-
-        
-    /**
-     * When true, activities from the unfollowed feed will remain in the source feed's timeline (default: false)
-     */
-    keep_history?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface UnfollowResponse {
-    duration: string;
-    
-
-        
-    follow: FollowResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UnpinActivityResponse {
-    duration: string;
-    
-
-        
-    /**
-     * Fully qualified ID of the feed the activity was unpinned from
-     */
-    feed: string;
-    
-
-        
-    /**
-     * ID of the user who unpinned the activity
-     */
-    user_id: string;
-    
-
-        
-    activity: ActivityResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateActivityPartialRequest {
-    /**
-     * @deprecated
-     * Whether to copy custom data to the notification activity (only applies when handle_mention_notifications creates notifications) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-     */
-    copy_custom_to_notification?: boolean;
-    
-
-        
-    /**
-     * If true, enriches the activity's current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-     */
-    enrich_own_fields?: boolean;
-    
-
-        
-    /**
-     * If true, creates notification activities for newly mentioned users and deletes notifications for users no longer mentioned
-     */
-    handle_mention_notifications?: boolean;
-    
-
-        
-    /**
-     * If true, runs activity processors on the updated activity. Processors will only run if the activity text and/or attachments are changed. Defaults to false.
-     */
-    run_activity_processors?: boolean;
-    
-
-        
-    /**
-     * List of field names to remove. Supported fields: 'custom', 'visibility_tag', 'location', 'expires_at', 'filter_tags', 'interest_tags', 'attachments', 'poll_id', 'mentioned_user_ids', 'search_data'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
-     */
-    unset?: Array<string>;
-    
-
-        
-    /**
-     * Map of field names to new values. Supported fields: 'text', 'attachments', 'custom', 'visibility', 'visibility_tag', 'restrict_replies' (values: 'everyone', 'people_i_follow', 'nobody'), 'location', 'expires_at', 'filter_tags', 'interest_tags', 'poll_id', 'feeds', 'mentioned_user_ids', 'search_data'. For custom fields, use dot-notation (e.g., 'custom.field_name')
-     */
-    set?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateActivityPartialResponse {
-    duration: string;
-    
-
-        
-    activity: ActivityResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateActivityRequest {
-    /**
-     * @deprecated
-     * Whether to copy custom data to the notification activity (only applies when handle_mention_notifications creates notifications) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-     */
-    copy_custom_to_notification?: boolean;
-    
-
-        
-    /**
-     * If true, enriches the activity's current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-     */
-    enrich_own_fields?: boolean;
-    
-
-        
-    /**
-     * Time when the activity will expire
-     */
-    expires_at?: Date;
-    
-
-        
-    /**
-     * If true, creates notification activities for newly mentioned users and deletes notifications for users no longer mentioned
-     */
-    handle_mention_notifications?: boolean;
-    
-
-        
-    /**
-     * Poll ID
-     */
-    poll_id?: string;
-    
-
-        
-    /**
-     * Controls who can add comments/replies to this activity. One of: everyone, people_i_follow, nobody
-     */
-    
-        restrict_replies?:| "everyone" | "people_i_follow" | "nobody" ;
-
-        
-    /**
-     * If true, runs activity processors on the updated activity. Processors will only run if the activity text and/or attachments are changed. Defaults to false.
-     */
-    run_activity_processors?: boolean;
-    
-
-        
-    /**
-     * Whether to skip URL enrichment for the activity
-     */
-    skip_enrich_url?: boolean;
-    
-
-        
-    /**
-     * The text content of the activity
-     */
-    text?: string;
-    
-
-        
-    /**
-     * Visibility setting for the activity
-     */
-    
-        visibility?:| "public" | "private" | "tag" ;
-
-        
-    /**
-     * If visibility is 'tag', this is the tag name and is required
-     */
-    visibility_tag?: string;
-    
-
-        
-    /**
-     * List of attachments for the activity
-     */
-    attachments?: Array<Attachment>;
-    
-
-        
-    /**
-     * Collections that this activity references
-     */
-    collection_refs?: Array<string>;
-    
-
-        
-    /**
-     * List of feeds the activity is present in
-     */
-    feeds?: Array<string>;
-    
-
-        
-    /**
-     * Tags used for filtering the activity
-     */
-    filter_tags?: Array<string>;
-    
-
-        
-    /**
-     * Tags indicating interest categories
-     */
-    interest_tags?: Array<string>;
-    
-
-        
-    /**
-     * List of user IDs mentioned in the activity
-     */
-    mentioned_user_ids?: Array<string>;
-    
-
-        
-    /**
-     * Custom data for the activity
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    location?: Location;
-    
-
-        
-    /**
-     * Additional data for search indexing
-     */
-    search_data?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateActivityResponse {
-    duration: string;
-    
-
-        
-    activity: ActivityResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateBlockListRequest {
-    is_leet_check_enabled?: boolean;
-    
-
-        
-    is_plural_check_enabled?: boolean;
-    
-
-        
-    team?: string;
-    
-
-        
-    /**
-     * List of words to block
-     */
-    words?: Array<string>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateBlockListResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
-
-        
-    blocklist?: BlockListResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateBookmarkFolderRequest {
-    /**
-     * Name of the folder
-     */
-    name?: string;
-    
-
-        
-    /**
-     * Custom data for the folder
-     */
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateBookmarkFolderResponse {
-    duration: string;
-    
-
-        
-    bookmark_folder: BookmarkFolderResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateBookmarkRequest {
-    /**
-     * ID of the folder containing the bookmark
-     */
-    folder_id?: string;
-    
-
-        
-    /**
-     * Move the bookmark to this folder (empty string removes the folder)
-     */
-    new_folder_id?: string;
-    
-
-        
-    /**
-     * Custom data for the bookmark
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    new_folder?: AddFolderRequest;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateBookmarkResponse {
-    duration: string;
-    
-
-        
-    bookmark: BookmarkResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateCollectionRequest {
-    /**
-     * Unique identifier for the collection within its name
-     */
-    id: string;
-    
-
-        
-    /**
-     * Name/type of the collection
-     */
-    name: string;
-    
-
-        
-    /**
-     * Custom data for the collection (required, must contain at least one key)
-     */
-    custom: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateCollectionsRequest {
-    /**
-     * List of collections to update (only custom data is updatable)
-     */
-    collections: Array<UpdateCollectionRequest>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateCollectionsResponse {
-    duration: string;
-    
-
-        
-    /**
-     * List of updated collections
-     */
-    collections: Array<CollectionResponse>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateCommentBookmarkRequest {
-    /**
-     * ID of the folder containing the bookmark
-     */
-    folder_id?: string;
-    
-
-        
-    /**
-     * Move the bookmark to this folder (empty string removes the folder)
-     */
-    new_folder_id?: string;
-    
-
-        
-    /**
-     * Custom data for the bookmark
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    new_folder?: AddFolderRequest;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateCommentBookmarkResponse {
-    duration: string;
-    
-
-        
-    bookmark: BookmarkResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateCommentPartialRequest {
-    /**
-     * @deprecated
-     * Whether to copy custom data to notification activities Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-     */
-    copy_custom_to_notification?: boolean;
-    
-
-        
-    /**
-     * Whether to handle mention notification changes
-     */
-    handle_mention_notifications?: boolean;
-    
-
-        
-    /**
-     * Whether to skip URL enrichment
-     */
-    skip_enrich_url?: boolean;
-    
-
-        
-    /**
-     * Whether to skip push notifications
-     */
-    skip_push?: boolean;
-    
-
-        
-    /**
-     * List of field names to remove. Supported fields: 'custom', 'attachments', 'mentioned_user_ids', 'status'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
-     */
-    unset?: Array<string>;
-    
-
-        
-    /**
-     * Map of field names to new values. Supported fields: 'text', 'attachments', 'custom', 'mentioned_user_ids', 'status'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
-     */
-    set?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateCommentPartialResponse {
-    duration: string;
-    
-
-        
-    comment: CommentResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateCommentRequest {
-    /**
-     * Updated text content of the comment
-     */
-    comment?: string;
-    
-
-        
-    /**
-     * @deprecated
-     * Whether to copy custom data to the notification activity (only applies when handle_mention_notifications creates notifications) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-     */
-    copy_custom_to_notification?: boolean;
-    
-
-        
-    /**
-     * If true, creates notification activities for newly mentioned users and deletes notifications for users no longer mentioned
-     */
-    handle_mention_notifications?: boolean;
-    
-
-        
-    /**
-     * Whether to skip URL enrichment for this comment
-     */
-    skip_enrich_url?: boolean;
-    
-
-        
-    skip_push?: boolean;
-    
-
-        
-    /**
-     * Updated media attachments for the comment. Providing this field will replace all existing attachments.
-     */
-    attachments?: Array<Attachment>;
-    
-
-        
-    /**
-     * List of user IDs mentioned in the comment
-     */
-    mentioned_user_ids?: Array<string>;
-    
-
-        
-    /**
-     * Updated custom data for the comment
-     */
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateCommentResponse {
-    duration: string;
-    
-
-        
-    comment: CommentResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateFeedMembersRequest {
-    /**
-     * Type of update operation to perform. One of: upsert, remove, set
-     */
-    
-        operation:| "upsert" | "remove" | "set" ;
-
-        
-    limit?: number;
-    
-
-        
-    next?: string;
-    
-
-        
-    prev?: string;
-    
-
-        
-    /**
-     * List of members to upsert, remove, or set
-     */
-    members?: Array<FeedMemberRequest>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateFeedMembersResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
-
-        
-    added: Array<FeedMemberResponse>;
-    
-
-        
-    removed_ids: Array<string>;
-    
-
-        
-    updated: Array<FeedMemberResponse>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateFeedRequest {
-    /**
-     * If true, removes the geographic location from the feed
-     */
-    clear_location?: boolean;
-    
-
-        
-    /**
-     * Description of the feed
-     */
-    description?: string;
-    
-
-        
-    /**
-     * If true, enriches the feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-     */
-    enrich_own_fields?: boolean;
-    
-
-        
-    /**
-     * Name of the feed
-     */
-    name?: string;
-    
-
-        
-    /**
-     * Tags used for filtering feeds
-     */
-    filter_tags?: Array<string>;
-    
-
-        
-    /**
-     * Custom data for the feed
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    location?: Location;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateFeedResponse {
-    duration: string;
-    
-
-        
-    feed: FeedResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateFollowRequest {
-    /**
-     * Fully qualified ID of the source feed
-     */
-    source: string;
-    
-
-        
-    /**
-     * Fully qualified ID of the target feed
-     */
-    target: string;
-    
-
-        
-    /**
-     * Maximum number of historical activities to copy from the target feed when the follow is first materialized. Not set = unlimited (default). 0 = copy nothing. Range: 0-1000.
-     */
-    activity_copy_limit?: number;
-    
-
-        
-    /**
-     * @deprecated
-     * Whether to copy custom data to the notification activity (only applies when create_notification_activity is true) Deprecated: use notification_context.trigger.custom and notification_context.target.custom instead
-     */
-    copy_custom_to_notification?: boolean;
-    
-
-        
-    /**
-     * Whether to create a notification activity for this follow
-     */
-    create_notification_activity?: boolean;
-    
-
-        
-    /**
-     * If true, enriches the follow's source_feed and target_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-     */
-    enrich_own_fields?: boolean;
-    
-
-        
-    follower_role?: string;
-    
-
-        
-    /**
-     * Push preference for the follow relationship
-     */
-    
-        push_preference?:| "all" | "none" ;
-
-        
-    /**
-     * Whether to skip push for this follow
-     */
-    skip_push?: boolean;
-    
-
-        
-    /**
-     * Custom data for the follow relationship
-     */
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateFollowResponse {
-    duration: string;
-    
-
-        
-    follow: FollowResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateLiveLocationRequest {
-    /**
-     * Live location ID
-     */
-    message_id: string;
-    
-
-        
-    /**
-     * Time when the live location expires
-     */
-    end_at?: Date;
-    
-
-        
-    /**
-     * Latitude coordinate
-     */
-    latitude?: number;
-    
-
-        
-    /**
-     * Longitude coordinate
-     */
-    longitude?: number;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdatePollOptionRequest {
-    /**
-     * Option ID
-     */
-    id: string;
-    
-
-        
-    /**
-     * Option text
-     */
-    text: string;
-    
-
-        
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdatePollPartialRequest {
-    /**
-     * Array of field names to unset
-     */
-    unset?: Array<string>;
-    
-
-        
-    /**
-     * Sets new field values
-     */
-    set?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdatePollRequest {
-    /**
-     * Poll ID
-     */
-    id: string;
-    
-
-        
-    /**
-     * Poll name
-     */
-    name: string;
-    
-
-        
-    /**
-     * Allow answers
-     */
-    allow_answers?: boolean;
-    
-
-        
-    /**
-     * Allow user suggested options
-     */
-    allow_user_suggested_options?: boolean;
-    
-
-        
-    /**
-     * Poll description
-     */
-    description?: string;
-    
-
-        
-    /**
-     * Enforce unique vote
-     */
-    enforce_unique_vote?: boolean;
-    
-
-        
-    /**
-     * Is closed
-     */
-    is_closed?: boolean;
-    
-
-        
-    /**
-     * Max votes allowed
-     */
-    max_votes_allowed?: number;
-    
-
-        
-    /**
-     * Voting visibility
-     */
-    
-        voting_visibility?:| "anonymous" | "public" ;
-
-        
-    /**
-     * Poll options
-     */
-    options?: Array<PollOptionRequest>;
-    
-
-        
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateUserGroupRequest {
-    /**
-     * The new description for the group
-     */
-    description?: string;
-    
-
-        
-    /**
-     * The new name of the user group
-     */
-    name?: string;
-    
-
-        
-    team_id?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateUserGroupResponse {
-    duration: string;
-    
-
-        
-    user_group?: UserGroupResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateUserPartialRequest {
-    /**
-     * User ID to update
-     */
-    id: string;
-    
-
-        
-    unset?: Array<string>;
-    
-
-        
-    set?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateUsersPartialRequest {
-    users: Array<UpdateUserPartialRequest>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateUsersRequest {
-    /**
-     * Object containing users
-     */
-    users: Record<string, UserRequest>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpdateUsersResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
-
-        
-    membership_deletion_task_id: string;
-    
-
-        
-    /**
-     * Object containing users
-     */
-    users: Record<string, FullUserResponse>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpsertActionConfigItem {
-    action: string;
-    
-
-        
-    entity_type: string;
-    
-
-        
-    order: number;
-    
-
-        
-    description?: string;
-    
-
-        
-    icon?: string;
-    
-
-        
-    id?: string;
-    
-
-        
-    queue_type?: string;
-    
-
-        
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpsertActionConfigRequest {
-    /**
-     * The action to perform (e.g. ban, delete_message, custom)
-     */
-    action: string;
-    
-
-        
-    /**
-     * Type of entity this action applies to (e.g. stream:chat:v1:message)
-     */
-    entity_type: string;
-    
-
-        
-    /**
-     * Display order in the dashboard (0–100, lower numbers shown first)
-     */
-    order: number;
-    
-
-        
-    /**
-     * Human-readable label for the dashboard button
-     */
-    description?: string;
-    
-
-        
-    /**
-     * Icon identifier for the dashboard button
-     */
-    icon?: string;
-    
-
-        
-    /**
-     * UUID of an existing action config to update; omit to create a new record
-     */
-    id?: string;
-    
-
-        
-    /**
-     * Queue this config belongs to; null means the default queue
-     */
-    queue_type?: string;
-    
-
-        
-    /**
-     * Action-specific parameters passed to the action handler
-     */
-    custom?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpsertActionConfigResponse {
-    duration: string;
-    
-
-        
-    action_config?: ModerationActionConfigResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpsertActivitiesRequest {
-    /**
-     * List of activities to create or update
-     */
-    activities: Array<ActivityRequest>;
-    
-
-        
-    /**
-     * If true, enriches the activities' current_feed with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
-     */
-    enrich_own_fields?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface UpsertActivitiesResponse {
-    duration: string;
-    
-
-        
-    /**
-     * List of created or updated activities
-     */
-    activities: Array<ActivityResponse>;
-    
-
-        
-    /**
-     * Total number of mention notification activities created for mentioned users across all activities
-     */
-    mention_notifications_created?: number;
-    
-
-        }
-    
-
-
-
-
-    export interface UpsertConfigRequest {
-    /**
-     * Unique identifier for the moderation configuration
-     */
-    key: string;
-    
-
-        
-    /**
-     * Whether moderation should be performed asynchronously
-     */
-    async?: boolean;
-    
-
-        
-    /**
-     * Team associated with the configuration
-     */
-    team?: string;
-    
-
-        
-    ai_image_config?: AIImageConfig;
-    
-
-        
-    ai_text_config?: AITextConfig;
-    
-
-        
-    ai_video_config?: AIVideoConfig;
-    
-
-        
-    automod_platform_circumvention_config?: AutomodPlatformCircumventionConfig;
-    
-
-        
-    automod_semantic_filters_config?: AutomodSemanticFiltersConfig;
-    
-
-        
-    automod_toxicity_config?: AutomodToxicityConfig;
-    
-
-        
-    aws_rekognition_config?: AIImageConfig;
-    
-
-        
-    block_list_config?: BlockListConfig;
-    
-
-        
-    bodyguard_config?: AITextConfig;
-    
-
-        
-    google_vision_config?: GoogleVisionConfig;
-    
-
-        
-    llm_config?: LLMConfig;
-    
-
-        
-    rule_builder_config?: RuleBuilderConfig;
-    
-
-        
-    velocity_filter_config?: VelocityFilterConfig;
-    
-
-        
-    video_call_rule_config?: VideoCallRuleConfig;
-    
-
-        }
-    
-
-
-
-
-    export interface UpsertConfigResponse {
-    duration: string;
-    
-
-        
-    config?: ConfigResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UpsertPushPreferencesRequest {
-    /**
-     * A list of push preferences for channels, calls, or the user.
-     */
-    preferences: Array<PushPreferenceInput>;
-    
-
-        }
-    
-
-
-
-
-    export interface UpsertPushPreferencesResponse {
-    /**
-     * Duration of the request in milliseconds
-     */
-    duration: string;
-    
-
-        
-    /**
-     * The channel specific push notification preferences, only returned for channels you've edited.
-     */
-    user_channel_preferences: Record<string, Record<string, ChannelPushPreferencesResponse | null>>;
-    
-
-        
-    /**
-     * The user preferences, always returned regardless if you edited it
-     */
-    user_preferences: Record<string, PushPreferencesResponse>;
-    
-
-        }
-    
-
-
-
-
-    export interface User {
-    id: string;
-    
-
-        
-    data?: Record<string, any>;
-    
-
-        }
-    
-
-
-
-
-    export interface UserBannedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    user: UserResponseCommonFields;
-    
-
-        
-    /**
-     * The type of event: "user.banned" in this case
-     */
-    type: string;
-    
-
-        
-    /**
-     * The ID of the channel where the target user was banned
-     */
-    channel_id?: string;
-    
-
-        
-    channel_member_count?: number;
-    
-
-        
-    channel_message_count?: number;
-    
-
-        
-    /**
-     * The type of the channel where the target user was banned
-     */
-    channel_type?: string;
-    
-
-        
-    /**
-     * The CID of the channel where the target user was banned
-     */
-    cid?: string;
-    
-
-        
-    /**
-     * The expiration date of the ban
-     */
-    expiration?: Date;
-    
-
-        
-    /**
-     * The reason for the ban
-     */
-    reason?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    /**
-     * Whether the user was shadow banned
-     */
-    shadow?: boolean;
-    
-
-        
-    /**
-     * The team of the channel where the target user was banned
-     */
-    team?: string;
-    
-
-        
-    total_bans?: number;
-    
-
-        
-    channel_custom?: Record<string, any>;
-    
-
-        
-    created_by?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface UserCreatedWithinParameters {
-    max_age?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface UserCustomPropertyParameters {
-    operator?: string;
-    
-
-        
-    property_key?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface UserDeactivatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    user: UserResponseCommonFields;
-    
-
-        
-    /**
-     * The type of event: "user.deactivated" in this case
-     */
-    type: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    created_by?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface UserGroupMember {
-    app_pk: number;
-    
-
-        
-    created_at: Date;
-    
-
-        
-    group_id: string;
-    
-
-        
-    is_admin: boolean;
-    
-
-        
-    user_id: string;
-    
-
-        }
-    
-
-
-
-
-    export interface UserGroupResponse {
-    created_at: Date;
-    
-
-        
-    id: string;
-    
-
-        
-    name: string;
-    
-
-        
-    updated_at: Date;
-    
-
-        
-    created_by?: string;
-    
-
-        
-    description?: string;
-    
-
-        
-    team_id?: string;
-    
-
-        
-    members?: Array<UserGroupMember>;
-    
-
-        }
-    
-
-
-
-
-    export interface UserIdenticalContentCountParameters {
-    threshold?: number;
-    
-
-        
-    time_window?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface UserMuteResponse {
-    created_at: Date;
-    
-
-        
-    updated_at: Date;
-    
-
-        
-    expires?: Date;
-    
-
-        
-    target?: UserResponse;
-    
-
-        
-    user?: UserResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UserReactivatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    user: UserResponseCommonFields;
-    
-
-        
-    /**
-     * The type of event: "user.reactivated" in this case
-     */
-    type: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    created_by?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface UserRequest {
-    /**
-     * User ID
-     */
-    id: string;
-    
-
-        
-    /**
-     * User's profile image URL
-     */
-    image?: string;
-    
-
-        
-    invisible?: boolean;
-    
-
-        
-    language?: string;
-    
-
-        
-    /**
-     * Optional name of user
-     */
-    name?: string;
-    
-
-        
-    /**
-     * Custom user data
-     */
-    custom?: Record<string, any>;
-    
-
-        
-    privacy_settings?: PrivacySettingsResponse;
-    
-
-        }
-    
-
-
-
-
-    export interface UserResponse {
-    /**
-     * Whether a user is banned or not
-     */
-    banned: boolean;
-    
-
-        
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    /**
-     * Unique user identifier
-     */
-    id: string;
-    
-
-        
-    /**
-     * Preferred language of a user
-     */
-    language: string;
-    
-
-        
-    /**
-     * Whether a user online or not
-     */
-    online: boolean;
-    
-
-        
-    /**
-     * Determines the set of user permissions
-     */
-    role: string;
-    
-
-        
-    /**
-     * Date/time of the last update
-     */
-    updated_at: Date;
-    
-
-        
-    blocked_user_ids: Array<string>;
-    
-
-        
-    /**
-     * List of teams user is a part of
-     */
-    teams: Array<string>;
-    
-
-        
-    /**
-     * Custom data for this object
-     */
-    custom: Record<string, any>;
-    
-
-        
-    avg_response_time?: number;
-    
-
-        
-    /**
-     * Date of deactivation
-     */
-    deactivated_at?: Date;
-    
-
-        
-    /**
-     * Date/time of deletion
-     */
-    deleted_at?: Date;
-    
-
-        
-    image?: string;
-    
-
-        
-    /**
-     * Date of last activity
-     */
-    last_active?: Date;
-    
-
-        
-    /**
-     * Optional name of user
-     */
-    name?: string;
-    
-
-        
-    /**
-     * Revocation date for tokens
-     */
-    revoke_tokens_issued_before?: Date;
-    
-
-        
-    teams_role?: Record<string, string>;
-    
-
-        }
-    
-
-
-
-
-    export interface UserResponseCommonFields {
-    banned: boolean;
-    
-
-        
-    created_at: Date;
-    
-
-        
-    id: string;
-    
-
-        
-    language: string;
-    
-
-        
-    online: boolean;
-    
-
-        
-    role: string;
-    
-
-        
-    updated_at: Date;
-    
-
-        
-    blocked_user_ids: Array<string>;
-    
-
-        
-    teams: Array<string>;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    avg_response_time?: number;
-    
-
-        
-    deactivated_at?: Date;
-    
-
-        
-    deleted_at?: Date;
-    
-
-        
-    image?: string;
-    
-
-        
-    last_active?: Date;
-    
-
-        
-    name?: string;
-    
-
-        
-    revoke_tokens_issued_before?: Date;
-    
-
-        
-    teams_role?: Record<string, string>;
-    
-
-        }
-    
-
-
-
-
-    export interface UserResponsePrivacyFields {
-    banned: boolean;
-    
-
-        
-    created_at: Date;
-    
-
-        
-    id: string;
-    
-
-        
-    language: string;
-    
-
-        
-    online: boolean;
-    
-
-        
-    role: string;
-    
-
-        
-    updated_at: Date;
-    
-
-        
-    blocked_user_ids: Array<string>;
-    
-
-        
-    teams: Array<string>;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    avg_response_time?: number;
-    
-
-        
-    deactivated_at?: Date;
-    
-
-        
-    deleted_at?: Date;
-    
-
-        
-    image?: string;
-    
-
-        
-    invisible?: boolean;
-    
-
-        
-    last_active?: Date;
-    
-
-        
-    name?: string;
-    
-
-        
-    revoke_tokens_issued_before?: Date;
-    
-
-        
-    privacy_settings?: PrivacySettingsResponse;
-    
-
-        
-    teams_role?: Record<string, string>;
-    
-
-        }
-    
-
-
-
-
-    export interface UserRoleParameters {
-    operator?: string;
-    
-
-        
-    role?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface UserRuleParameters {
-    max_age?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface UserUnbannedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    user: UserResponseCommonFields;
-    
-
-        
-    /**
-     * The type of event: "user.unbanned" in this case
-     */
-    type: string;
-    
-
-        
-    /**
-     * The ID of the channel where the target user was unbanned
-     */
-    channel_id?: string;
-    
-
-        
-    channel_member_count?: number;
-    
-
-        
-    channel_message_count?: number;
-    
-
-        
-    /**
-     * The type of the channel where the target user was unbanned
-     */
-    channel_type?: string;
-    
-
-        
-    /**
-     * The CID of the channel where the target user was unbanned
-     */
-    cid?: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        
-    /**
-     * Whether the target user was shadow unbanned
-     */
-    shadow?: boolean;
-    
-
-        
-    /**
-     * The team of the channel where the target user was unbanned
-     */
-    team?: string;
-    
-
-        
-    channel_custom?: Record<string, any>;
-    
-
-        
-    created_by?: UserResponseCommonFields;
-    
-
-        }
-    
-
-
-
-
-    export interface UserUpdatedEvent {
-    /**
-     * Date/time of creation
-     */
-    created_at: Date;
-    
-
-        
-    custom: Record<string, any>;
-    
-
-        
-    user: UserResponsePrivacyFields;
-    
-
-        
-    /**
-     * The type of event: "user.updated" in this case
-     */
-    type: string;
-    
-
-        
-    received_at?: Date;
-    
-
-        }
-    
-
-
-
-
-    export interface VelocityFilterConfig {
-    advanced_filters: boolean;
-    
-
-        
-    cascading_actions: boolean;
-    
-
-        
-    cids_per_user: number;
-    
-
-        
-    enabled: boolean;
-    
-
-        
-    first_message_only: boolean;
-    
-
-        
-    rules: Array<VelocityFilterConfigRule>;
-    
-
-        
-    async?: boolean;
-    
-
-        }
-    
-
-
-
-
-    export interface VelocityFilterConfigRule {
-    
-        action:| "flag" | "shadow" | "remove" | "ban" ;
-
-        
-    ban_duration: number;
-    
-
-        
-    
-        cascading_action:| "flag" | "shadow" | "remove" | "ban" ;
-
-        
-    cascading_threshold: number;
-    
-
-        
-    check_message_context: boolean;
-    
-
-        
-    fast_spam_threshold: number;
-    
-
-        
-    fast_spam_ttl: number;
-    
-
-        
-    ip_ban: boolean;
-    
-
-        
-    probation_period: number;
-    
-
-        
-    shadow_ban: boolean;
-    
-
-        
-    slow_spam_threshold: number;
-    
-
-        
-    slow_spam_ttl: number;
-    
-
-        
-    url_only: boolean;
-    
-
-        
-    slow_spam_ban_duration?: number;
-    
-
-        }
-    
-
-
-
-
-    export interface VideoCallRuleConfig {
-    flag_all_labels: boolean;
-    
-
-        
-    flagged_labels: Array<string>;
-    
-
-        
-    rules: Array<HarmConfig>;
-    
-
-        }
-    
-
-
-
-
-    export interface VideoContentParameters {
-    label_operator?: string;
-    
-
-        
-    harm_labels?: Array<string>;
-    
-
-        }
-    
-
-
-
-
-    export interface VideoEndCallRequestPayload {}
-    
-
-
-
-
-    export interface VideoKickUserRequestPayload {}
-    
-
-
-
-
-    export interface VideoRuleParameters {
-    threshold?: number;
-    
-
-        
-    time_window?: string;
-    
-
-        
-    harm_labels?: Array<string>;
-    
-
-        }
-    
-
-
-
-
-    export interface VoteData {
-    answer_text?: string;
-    
-
-        
-    option_id?: string;
-    
-
-        }
-    
-
-
-
-
-    export interface WSAuthMessage {
-    /**
-     * JWT token for authentication
-     */
-    token: string;
-    
-
-        
-    user_details: ConnectUserDetailsRequest;
-    
-
-        
-    /**
-     * List of products to subscribe to. One of: chat, video, feeds
-     */
-    products?: Array<string>;
-    
-
-        }
-    
-
-
-
-
-    export type WSClientEvent =
-        
-            | ({ type: 'app.updated' } & AppUpdatedEvent )
-        
-            | ({ type: 'feeds.activity.added' } & ActivityAddedEvent )
-        
-            | ({ type: 'feeds.activity.deleted' } & ActivityDeletedEvent )
-        
-            | ({ type: 'feeds.activity.feedback' } & ActivityFeedbackEvent )
-        
-            | ({ type: 'feeds.activity.marked' } & ActivityMarkEvent )
-        
-            | ({ type: 'feeds.activity.pinned' } & ActivityPinnedEvent )
-        
-            | ({ type: 'feeds.activity.reaction.added' } & ActivityReactionAddedEvent )
-        
-            | ({ type: 'feeds.activity.reaction.deleted' } & ActivityReactionDeletedEvent )
-        
-            | ({ type: 'feeds.activity.reaction.updated' } & ActivityReactionUpdatedEvent )
-        
-            | ({ type: 'feeds.activity.removed_from_feed' } & ActivityRemovedFromFeedEvent )
-        
-            | ({ type: 'feeds.activity.restored' } & ActivityRestoredEvent )
-        
-            | ({ type: 'feeds.activity.unpinned' } & ActivityUnpinnedEvent )
-        
-            | ({ type: 'feeds.activity.updated' } & ActivityUpdatedEvent )
-        
-            | ({ type: 'feeds.bookmark.added' } & BookmarkAddedEvent )
-        
-            | ({ type: 'feeds.bookmark.deleted' } & BookmarkDeletedEvent )
-        
-            | ({ type: 'feeds.bookmark.updated' } & BookmarkUpdatedEvent )
-        
-            | ({ type: 'feeds.bookmark_folder.deleted' } & BookmarkFolderDeletedEvent )
-        
-            | ({ type: 'feeds.bookmark_folder.updated' } & BookmarkFolderUpdatedEvent )
-        
-            | ({ type: 'feeds.comment.added' } & CommentAddedEvent )
-        
-            | ({ type: 'feeds.comment.deleted' } & CommentDeletedEvent )
-        
-            | ({ type: 'feeds.comment.reaction.added' } & CommentReactionAddedEvent )
-        
-            | ({ type: 'feeds.comment.reaction.deleted' } & CommentReactionDeletedEvent )
-        
-            | ({ type: 'feeds.comment.reaction.updated' } & CommentReactionUpdatedEvent )
-        
-            | ({ type: 'feeds.comment.restored' } & CommentRestoredEvent )
-        
-            | ({ type: 'feeds.comment.updated' } & CommentUpdatedEvent )
-        
-            | ({ type: 'feeds.feed.created' } & FeedCreatedEvent )
-        
-            | ({ type: 'feeds.feed.deleted' } & FeedDeletedEvent )
-        
-            | ({ type: 'feeds.feed.updated' } & FeedUpdatedEvent )
-        
-            | ({ type: 'feeds.feed_group.changed' } & FeedGroupChangedEvent )
-        
-            | ({ type: 'feeds.feed_group.deleted' } & FeedGroupDeletedEvent )
-        
-            | ({ type: 'feeds.feed_group.restored' } & FeedGroupRestoredEvent )
-        
-            | ({ type: 'feeds.feed_member.added' } & FeedMemberAddedEvent )
-        
-            | ({ type: 'feeds.feed_member.removed' } & FeedMemberRemovedEvent )
-        
-            | ({ type: 'feeds.feed_member.updated' } & FeedMemberUpdatedEvent )
-        
-            | ({ type: 'feeds.follow.created' } & FollowCreatedEvent )
-        
-            | ({ type: 'feeds.follow.deleted' } & FollowDeletedEvent )
-        
-            | ({ type: 'feeds.follow.updated' } & FollowUpdatedEvent )
-        
-            | ({ type: 'feeds.notification_feed.updated' } & NotificationFeedUpdatedEvent )
-        
-            | ({ type: 'feeds.poll.closed' } & PollClosedFeedEvent )
-        
-            | ({ type: 'feeds.poll.deleted' } & PollDeletedFeedEvent )
-        
-            | ({ type: 'feeds.poll.updated' } & PollUpdatedFeedEvent )
-        
-            | ({ type: 'feeds.poll.vote_casted' } & PollVoteCastedFeedEvent )
-        
-            | ({ type: 'feeds.poll.vote_changed' } & PollVoteChangedFeedEvent )
-        
-            | ({ type: 'feeds.poll.vote_removed' } & PollVoteRemovedFeedEvent )
-        
-            | ({ type: 'feeds.stories_feed.updated' } & StoriesFeedUpdatedEvent )
-        
-            | ({ type: 'health.check' } & HealthCheckEvent )
-        
-            | ({ type: 'moderation.custom_action' } & ModerationCustomActionEvent )
-        
-            | ({ type: 'moderation.flagged' } & ModerationFlaggedEvent )
-        
-            | ({ type: 'moderation.mark_reviewed' } & ModerationMarkReviewedEvent )
-        
-            | ({ type: 'user.banned' } & UserBannedEvent )
-        
-            | ({ type: 'user.deactivated' } & UserDeactivatedEvent )
-        
-            | ({ type: 'user.reactivated' } & UserReactivatedEvent )
-        
-            | ({ type: 'user.unbanned' } & UserUnbannedEvent )
-        
-            | ({ type: 'user.updated' } & UserUpdatedEvent )
-        
-
-
-
-
-
-    export type WSEvent =
-        
-            | ({ type: 'app.updated' } & AppUpdatedEvent )
-        
-            | ({ type: 'feeds.activity.added' } & ActivityAddedEvent )
-        
-            | ({ type: 'feeds.activity.deleted' } & ActivityDeletedEvent )
-        
-            | ({ type: 'feeds.activity.feedback' } & ActivityFeedbackEvent )
-        
-            | ({ type: 'feeds.activity.marked' } & ActivityMarkEvent )
-        
-            | ({ type: 'feeds.activity.pinned' } & ActivityPinnedEvent )
-        
-            | ({ type: 'feeds.activity.reaction.added' } & ActivityReactionAddedEvent )
-        
-            | ({ type: 'feeds.activity.reaction.deleted' } & ActivityReactionDeletedEvent )
-        
-            | ({ type: 'feeds.activity.reaction.updated' } & ActivityReactionUpdatedEvent )
-        
-            | ({ type: 'feeds.activity.removed_from_feed' } & ActivityRemovedFromFeedEvent )
-        
-            | ({ type: 'feeds.activity.restored' } & ActivityRestoredEvent )
-        
-            | ({ type: 'feeds.activity.unpinned' } & ActivityUnpinnedEvent )
-        
-            | ({ type: 'feeds.activity.updated' } & ActivityUpdatedEvent )
-        
-            | ({ type: 'feeds.bookmark.added' } & BookmarkAddedEvent )
-        
-            | ({ type: 'feeds.bookmark.deleted' } & BookmarkDeletedEvent )
-        
-            | ({ type: 'feeds.bookmark.updated' } & BookmarkUpdatedEvent )
-        
-            | ({ type: 'feeds.bookmark_folder.deleted' } & BookmarkFolderDeletedEvent )
-        
-            | ({ type: 'feeds.bookmark_folder.updated' } & BookmarkFolderUpdatedEvent )
-        
-            | ({ type: 'feeds.comment.added' } & CommentAddedEvent )
-        
-            | ({ type: 'feeds.comment.deleted' } & CommentDeletedEvent )
-        
-            | ({ type: 'feeds.comment.reaction.added' } & CommentReactionAddedEvent )
-        
-            | ({ type: 'feeds.comment.reaction.deleted' } & CommentReactionDeletedEvent )
-        
-            | ({ type: 'feeds.comment.reaction.updated' } & CommentReactionUpdatedEvent )
-        
-            | ({ type: 'feeds.comment.restored' } & CommentRestoredEvent )
-        
-            | ({ type: 'feeds.comment.updated' } & CommentUpdatedEvent )
-        
-            | ({ type: 'feeds.feed.created' } & FeedCreatedEvent )
-        
-            | ({ type: 'feeds.feed.deleted' } & FeedDeletedEvent )
-        
-            | ({ type: 'feeds.feed.updated' } & FeedUpdatedEvent )
-        
-            | ({ type: 'feeds.feed_group.changed' } & FeedGroupChangedEvent )
-        
-            | ({ type: 'feeds.feed_group.deleted' } & FeedGroupDeletedEvent )
-        
-            | ({ type: 'feeds.feed_group.restored' } & FeedGroupRestoredEvent )
-        
-            | ({ type: 'feeds.feed_member.added' } & FeedMemberAddedEvent )
-        
-            | ({ type: 'feeds.feed_member.removed' } & FeedMemberRemovedEvent )
-        
-            | ({ type: 'feeds.feed_member.updated' } & FeedMemberUpdatedEvent )
-        
-            | ({ type: 'feeds.follow.created' } & FollowCreatedEvent )
-        
-            | ({ type: 'feeds.follow.deleted' } & FollowDeletedEvent )
-        
-            | ({ type: 'feeds.follow.updated' } & FollowUpdatedEvent )
-        
-            | ({ type: 'feeds.notification_feed.updated' } & NotificationFeedUpdatedEvent )
-        
-            | ({ type: 'feeds.poll.closed' } & PollClosedFeedEvent )
-        
-            | ({ type: 'feeds.poll.deleted' } & PollDeletedFeedEvent )
-        
-            | ({ type: 'feeds.poll.updated' } & PollUpdatedFeedEvent )
-        
-            | ({ type: 'feeds.poll.vote_casted' } & PollVoteCastedFeedEvent )
-        
-            | ({ type: 'feeds.poll.vote_changed' } & PollVoteChangedFeedEvent )
-        
-            | ({ type: 'feeds.poll.vote_removed' } & PollVoteRemovedFeedEvent )
-        
-            | ({ type: 'feeds.stories_feed.updated' } & StoriesFeedUpdatedEvent )
-        
-            | ({ type: 'health.check' } & HealthCheckEvent )
-        
-            | ({ type: 'moderation.custom_action' } & ModerationCustomActionEvent )
-        
-            | ({ type: 'moderation.flagged' } & ModerationFlaggedEvent )
-        
-            | ({ type: 'moderation.mark_reviewed' } & ModerationMarkReviewedEvent )
-        
-            | ({ type: 'user.banned' } & UserBannedEvent )
-        
-            | ({ type: 'user.deactivated' } & UserDeactivatedEvent )
-        
-            | ({ type: 'user.reactivated' } & UserReactivatedEvent )
-        
-            | ({ type: 'user.unbanned' } & UserUnbannedEvent )
-        
-            | ({ type: 'user.updated' } & UserUpdatedEvent )
-        
-
-
-
-
-
-
-
-
-
-
+export type WSEvent =
+  | ({ type: 'app.updated' } & AppUpdatedEvent)
+  | ({ type: 'feeds.activity.added' } & ActivityAddedEvent)
+  | ({ type: 'feeds.activity.deleted' } & ActivityDeletedEvent)
+  | ({ type: 'feeds.activity.feedback' } & ActivityFeedbackEvent)
+  | ({ type: 'feeds.activity.marked' } & ActivityMarkEvent)
+  | ({ type: 'feeds.activity.pinned' } & ActivityPinnedEvent)
+  | ({ type: 'feeds.activity.reaction.added' } & ActivityReactionAddedEvent)
+  | ({ type: 'feeds.activity.reaction.deleted' } & ActivityReactionDeletedEvent)
+  | ({ type: 'feeds.activity.reaction.updated' } & ActivityReactionUpdatedEvent)
+  | ({
+      type: 'feeds.activity.removed_from_feed';
+    } & ActivityRemovedFromFeedEvent)
+  | ({ type: 'feeds.activity.restored' } & ActivityRestoredEvent)
+  | ({ type: 'feeds.activity.unpinned' } & ActivityUnpinnedEvent)
+  | ({ type: 'feeds.activity.updated' } & ActivityUpdatedEvent)
+  | ({ type: 'feeds.bookmark.added' } & BookmarkAddedEvent)
+  | ({ type: 'feeds.bookmark.deleted' } & BookmarkDeletedEvent)
+  | ({ type: 'feeds.bookmark.updated' } & BookmarkUpdatedEvent)
+  | ({ type: 'feeds.bookmark_folder.deleted' } & BookmarkFolderDeletedEvent)
+  | ({ type: 'feeds.bookmark_folder.updated' } & BookmarkFolderUpdatedEvent)
+  | ({ type: 'feeds.comment.added' } & CommentAddedEvent)
+  | ({ type: 'feeds.comment.deleted' } & CommentDeletedEvent)
+  | ({ type: 'feeds.comment.reaction.added' } & CommentReactionAddedEvent)
+  | ({ type: 'feeds.comment.reaction.deleted' } & CommentReactionDeletedEvent)
+  | ({ type: 'feeds.comment.reaction.updated' } & CommentReactionUpdatedEvent)
+  | ({ type: 'feeds.comment.restored' } & CommentRestoredEvent)
+  | ({ type: 'feeds.comment.updated' } & CommentUpdatedEvent)
+  | ({ type: 'feeds.feed.created' } & FeedCreatedEvent)
+  | ({ type: 'feeds.feed.deleted' } & FeedDeletedEvent)
+  | ({ type: 'feeds.feed.updated' } & FeedUpdatedEvent)
+  | ({ type: 'feeds.feed_group.changed' } & FeedGroupChangedEvent)
+  | ({ type: 'feeds.feed_group.deleted' } & FeedGroupDeletedEvent)
+  | ({ type: 'feeds.feed_group.restored' } & FeedGroupRestoredEvent)
+  | ({ type: 'feeds.feed_member.added' } & FeedMemberAddedEvent)
+  | ({ type: 'feeds.feed_member.removed' } & FeedMemberRemovedEvent)
+  | ({ type: 'feeds.feed_member.updated' } & FeedMemberUpdatedEvent)
+  | ({ type: 'feeds.follow.created' } & FollowCreatedEvent)
+  | ({ type: 'feeds.follow.deleted' } & FollowDeletedEvent)
+  | ({ type: 'feeds.follow.updated' } & FollowUpdatedEvent)
+  | ({ type: 'feeds.notification_feed.updated' } & NotificationFeedUpdatedEvent)
+  | ({ type: 'feeds.poll.closed' } & PollClosedFeedEvent)
+  | ({ type: 'feeds.poll.deleted' } & PollDeletedFeedEvent)
+  | ({ type: 'feeds.poll.updated' } & PollUpdatedFeedEvent)
+  | ({ type: 'feeds.poll.vote_casted' } & PollVoteCastedFeedEvent)
+  | ({ type: 'feeds.poll.vote_changed' } & PollVoteChangedFeedEvent)
+  | ({ type: 'feeds.poll.vote_removed' } & PollVoteRemovedFeedEvent)
+  | ({ type: 'feeds.stories_feed.updated' } & StoriesFeedUpdatedEvent)
+  | ({ type: 'health.check' } & HealthCheckEvent)
+  | ({ type: 'moderation.custom_action' } & ModerationCustomActionEvent)
+  | ({ type: 'moderation.flagged' } & ModerationFlaggedEvent)
+  | ({ type: 'moderation.mark_reviewed' } & ModerationMarkReviewedEvent)
+  | ({ type: 'user.banned' } & UserBannedEvent)
+  | ({ type: 'user.deactivated' } & UserDeactivatedEvent)
+  | ({ type: 'user.reactivated' } & UserReactivatedEvent)
+  | ({ type: 'user.unbanned' } & UserUnbannedEvent)
+  | ({ type: 'user.updated' } & UserUpdatedEvent);

--- a/packages/feeds-client/src/gen/moderation/ModerationApi.ts
+++ b/packages/feeds-client/src/gen/moderation/ModerationApi.ts
@@ -1,288 +1,478 @@
-import { ApiClient, StreamResponse } from '../../gen-imports';
-import {  AIImageConfig,  AIImageLabelDefinition,  AITextConfig,  AIVideoConfig,  APIError,  AWSRekognitionRule,  AcceptFeedMemberInviteRequest,  AcceptFeedMemberInviteResponse,  AcceptFollowRequest,  AcceptFollowResponse,  Action,  ActionLogResponse,  ActionSequence,  ActivityAddedEvent,  ActivityDeletedEvent,  ActivityFeedbackEvent,  ActivityFeedbackEventPayload,  ActivityFeedbackRequest,  ActivityFeedbackResponse,  ActivityFilterConfig,  ActivityMarkEvent,  ActivityPinResponse,  ActivityPinnedEvent,  ActivityProcessorConfig,  ActivityReactionAddedEvent,  ActivityReactionDeletedEvent,  ActivityReactionUpdatedEvent,  ActivityRemovedFromFeedEvent,  ActivityRequest,  ActivityResponse,  ActivityRestoredEvent,  ActivitySelectorConfig,  ActivityUnpinnedEvent,  ActivityUpdatedEvent,  AddActivityRequest,  AddActivityResponse,  AddBookmarkRequest,  AddBookmarkResponse,  AddCommentBookmarkRequest,  AddCommentBookmarkResponse,  AddCommentReactionRequest,  AddCommentReactionResponse,  AddCommentRequest,  AddCommentResponse,  AddCommentsBatchRequest,  AddCommentsBatchResponse,  AddFolderRequest,  AddReactionRequest,  AddReactionResponse,  AddUserGroupMembersRequest,  AddUserGroupMembersResponse,  AggregatedActivityResponse,  AggregationConfig,  AppEventResponse,  AppResponseFields,  AppUpdatedEvent,  AppealItemResponse,  AppealRequest,  AppealResponse,  Attachment,  AutomodPlatformCircumventionConfig,  AutomodRule,  AutomodSemanticFiltersConfig,  AutomodSemanticFiltersRule,  AutomodToxicityConfig,  BanActionRequestPayload,  BanInfoResponse,  BanOptions,  BanRequest,  BanResponse,  BlockActionRequestPayload,  BlockListConfig,  BlockListOptions,  BlockListResponse,  BlockListRule,  BlockUsersRequest,  BlockUsersResponse,  BlockedUserResponse,  BodyguardProfileSummary,  BodyguardRule,  BodyguardSeverityRule,  BookmarkAddedEvent,  BookmarkDeletedEvent,  BookmarkFolderDeletedEvent,  BookmarkFolderResponse,  BookmarkFolderUpdatedEvent,  BookmarkResponse,  BookmarkUpdatedEvent,  BulkDeleteActionConfigRequest,  BulkDeleteActionConfigResponse,  BulkUpsertActionConfigRequest,  BulkUpsertActionConfigResponse,  BypassActionRequest,  CallActionOptions,  CallCustomPropertyParameters,  CallResponse,  CallRuleActionSequence,  CallTypeRuleParameters,  CallViolationCountParameters,  CastPollVoteRequest,  ChangeFeedVisibilityRequest,  ChangeFeedVisibilityResponse,  ChannelConfigWithInfo,  ChannelMemberResponse,  ChannelMessageCountRuleParameters,  ChannelMute,  ChannelOwnCapability,  ChannelPushPreferencesResponse,  ChannelResponse,  ChatDraftPayloadResponse,  ChatDraftResponse,  ChatMessageResponse,  ChatModerationV2Response,  ChatPreferences,  ChatPreferencesInput,  ChatPreferencesResponse,  ChatReactionGroupResponse,  ChatReactionGroupUserResponse,  ChatReactionResponse,  ChatReminderResponseData,  ChatSharedLocationResponseData,  ClosedCaptionRuleParameters,  CollectionRequest,  CollectionResponse,  Command,  CommentAddedEvent,  CommentDeletedEvent,  CommentReactionAddedEvent,  CommentReactionDeletedEvent,  CommentReactionUpdatedEvent,  CommentResponse,  CommentRestoredEvent,  CommentUpdatedEvent,  ConfigResponse,  ConnectUserDetailsRequest,  ContentCountRuleParameters,  CreateBlockListRequest,  CreateBlockListResponse,  CreateCollectionsRequest,  CreateCollectionsResponse,  CreateDeviceRequest,  CreateFeedsBatchRequest,  CreateFeedsBatchResponse,  CreateGuestRequest,  CreateGuestResponse,  CreatePollOptionRequest,  CreatePollRequest,  CreateUserGroupRequest,  CreateUserGroupResponse,  CustomActionRequestPayload,  Data,  DecayFunctionConfig,  DeleteActionConfigResponse,  DeleteActivitiesRequest,  DeleteActivitiesResponse,  DeleteActivityReactionResponse,  DeleteActivityRequestPayload,  DeleteActivityResponse,  DeleteBookmarkFolderResponse,  DeleteBookmarkResponse,  DeleteCollectionsResponse,  DeleteCommentBookmarkResponse,  DeleteCommentReactionResponse,  DeleteCommentRequestPayload,  DeleteCommentResponse,  DeleteFeedResponse,  DeleteMessageRequestPayload,  DeleteModerationConfigResponse,  DeleteReactionRequestPayload,  DeleteUserRequestPayload,  DeliveryReceiptsResponse,  DeviceResponse,  DraftPayloadResponse,  DraftResponse,  EnrichedActivity,  EnrichedCollectionResponse,  EnrichedReaction,  EnrichmentOptions,  EntityCreatorResponse,  EscalatePayload,  EscalationMetadata,  FeedCreatedEvent,  FeedDeletedEvent,  FeedGroup,  FeedGroupChangedEvent,  FeedGroupDeletedEvent,  FeedGroupRestoredEvent,  FeedInput,  FeedMemberAddedEvent,  FeedMemberRemovedEvent,  FeedMemberRequest,  FeedMemberResponse,  FeedMemberUpdatedEvent,  FeedOwnCapability,  FeedOwnData,  FeedRequest,  FeedResponse,  FeedSuggestionResponse,  FeedUpdatedEvent,  FeedsActivityLocation,  FeedsBookmarkResponse,  FeedsEnrichedCollectionResponse,  FeedsFeedResponse,  FeedsNotificationComment,  FeedsNotificationContext,  FeedsNotificationParentActivity,  FeedsNotificationTarget,  FeedsNotificationTrigger,  FeedsPreferences,  FeedsPreferencesResponse,  FeedsReactionGroupResponse,  FeedsReactionResponse,  FeedsV3ActivityResponse,  FeedsV3CommentResponse,  Field,  FileUploadConfig,  FileUploadRequest,  FileUploadResponse,  FilterConfigResponse,  FlagCountRuleParameters,  FlagRequest,  FlagResponse,  FlagUserOptions,  FollowBatchRequest,  FollowBatchResponse,  FollowCreatedEvent,  FollowDeletedEvent,  FollowRequest,  FollowResponse,  FollowUpdatedEvent,  FriendReactionsOptions,  FullUserResponse,  GetActionConfigResponse,  GetActivityResponse,  GetAppealResponse,  GetApplicationResponse,  GetBlockedUsersResponse,  GetCommentRepliesResponse,  GetCommentResponse,  GetCommentsResponse,  GetConfigResponse,  GetFollowSuggestionsResponse,  GetOGResponse,  GetOrCreateFeedRequest,  GetOrCreateFeedResponse,  GetUserGroupResponse,  GoogleVisionConfig,  HarmConfig,  HealthCheckEvent,  ImageContentParameters,  ImageData,  ImageRuleParameters,  ImageSize,  ImageUploadRequest,  ImageUploadResponse,  Images,  KeyframeRuleParameters,  LLMConfig,  LLMRule,  LabelThresholds,  ListBlockListResponse,  ListDevicesResponse,  ListUserGroupsResponse,  Location,  MarkActivityRequest,  MarkReviewedRequestPayload,  MembershipLevelResponse,  MessageResponse,  ModerationActionConfigResponse,  ModerationCustomActionEvent,  ModerationFlagResponse,  ModerationFlaggedEvent,  ModerationMarkReviewedEvent,  ModerationPayload,  ModerationPayloadResponse,  ModerationV2Response,  MuteRequest,  MuteResponse,  NotificationComment,  NotificationConfig,  NotificationContext,  NotificationFeedUpdatedEvent,  NotificationParentActivity,  NotificationStatusResponse,  NotificationTarget,  NotificationTrigger,  OCRRule,  OnlyUserID,  OwnBatchRequest,  OwnBatchResponse,  OwnUserResponse,  PagerRequest,  PagerResponse,  PinActivityRequest,  PinActivityResponse,  PollClosedFeedEvent,  PollDeletedFeedEvent,  PollOptionInput,  PollOptionRequest,  PollOptionResponse,  PollOptionResponseData,  PollResponse,  PollResponseData,  PollUpdatedFeedEvent,  PollVoteCastedFeedEvent,  PollVoteChangedFeedEvent,  PollVoteRemovedFeedEvent,  PollVoteResponse,  PollVoteResponseData,  PollVotesResponse,  PrivacySettingsResponse,  PushNotificationConfig,  PushPreferenceInput,  PushPreferencesResponse,  QueryActivitiesRequest,  QueryActivitiesResponse,  QueryActivityReactionsRequest,  QueryActivityReactionsResponse,  QueryAppealsRequest,  QueryAppealsResponse,  QueryBookmarkFoldersRequest,  QueryBookmarkFoldersResponse,  QueryBookmarksRequest,  QueryBookmarksResponse,  QueryCollectionsRequest,  QueryCollectionsResponse,  QueryCommentReactionsRequest,  QueryCommentReactionsResponse,  QueryCommentsRequest,  QueryCommentsResponse,  QueryFeedMembersRequest,  QueryFeedMembersResponse,  QueryFeedsRequest,  QueryFeedsResponse,  QueryFollowsRequest,  QueryFollowsResponse,  QueryModerationConfigsRequest,  QueryModerationConfigsResponse,  QueryPinnedActivitiesRequest,  QueryPinnedActivitiesResponse,  QueryPollVotesRequest,  QueryPollsRequest,  QueryPollsResponse,  QueryReviewQueueRequest,  QueryReviewQueueResponse,  QueryUsersPayload,  QueryUsersResponse,  RankingConfig,  Reaction,  ReactionGroupResponse,  ReactionGroupUserResponse,  ReactionResponse,  ReadCollectionsResponse,  ReadReceiptsResponse,  RejectAppealRequestPayload,  RejectFeedMemberInviteRequest,  RejectFeedMemberInviteResponse,  RejectFollowRequest,  RejectFollowResponse,  ReminderResponseData,  RemoveUserGroupMembersRequest,  RemoveUserGroupMembersResponse,  RepliesMeta,  Response,  RestoreActionRequestPayload,  RestoreActivityRequest,  RestoreActivityResponse,  RestoreCommentRequest,  RestoreCommentResponse,  ReviewQueueItemResponse,  RuleBuilderAction,  RuleBuilderCondition,  RuleBuilderConditionGroup,  RuleBuilderConfig,  RuleBuilderRule,  SearchUserGroupsResponse,  ShadowBlockActionRequestPayload,  SharedLocationResponse,  SharedLocationResponseData,  SharedLocationsResponse,  SingleFollowResponse,  SortParam,  SortParamRequest,  StoriesConfig,  StoriesFeedUpdatedEvent,  SubmitActionRequest,  SubmitActionResponse,  TextContentParameters,  TextRuleParameters,  ThreadedCommentResponse,  Thresholds,  Time,  TrackActivityMetricsEvent,  TrackActivityMetricsEventResult,  TrackActivityMetricsRequest,  TrackActivityMetricsResponse,  TypingIndicatorsResponse,  UnbanActionRequestPayload,  UnblockActionRequestPayload,  UnblockUsersRequest,  UnblockUsersResponse,  UnfollowBatchRequest,  UnfollowBatchResponse,  UnfollowPair,  UnfollowResponse,  UnpinActivityResponse,  UpdateActivityPartialRequest,  UpdateActivityPartialResponse,  UpdateActivityRequest,  UpdateActivityResponse,  UpdateBlockListRequest,  UpdateBlockListResponse,  UpdateBookmarkFolderRequest,  UpdateBookmarkFolderResponse,  UpdateBookmarkRequest,  UpdateBookmarkResponse,  UpdateCollectionRequest,  UpdateCollectionsRequest,  UpdateCollectionsResponse,  UpdateCommentBookmarkRequest,  UpdateCommentBookmarkResponse,  UpdateCommentPartialRequest,  UpdateCommentPartialResponse,  UpdateCommentRequest,  UpdateCommentResponse,  UpdateFeedMembersRequest,  UpdateFeedMembersResponse,  UpdateFeedRequest,  UpdateFeedResponse,  UpdateFollowRequest,  UpdateFollowResponse,  UpdateLiveLocationRequest,  UpdatePollOptionRequest,  UpdatePollPartialRequest,  UpdatePollRequest,  UpdateUserGroupRequest,  UpdateUserGroupResponse,  UpdateUserPartialRequest,  UpdateUsersPartialRequest,  UpdateUsersRequest,  UpdateUsersResponse,  UpsertActionConfigItem,  UpsertActionConfigRequest,  UpsertActionConfigResponse,  UpsertActivitiesRequest,  UpsertActivitiesResponse,  UpsertConfigRequest,  UpsertConfigResponse,  UpsertPushPreferencesRequest,  UpsertPushPreferencesResponse,  User,  UserBannedEvent,  UserCreatedWithinParameters,  UserCustomPropertyParameters,  UserDeactivatedEvent,  UserGroupMember,  UserGroupResponse,  UserIdenticalContentCountParameters,  UserMuteResponse,  UserReactivatedEvent,  UserRequest,  UserResponse,  UserResponseCommonFields,  UserResponsePrivacyFields,  UserRoleParameters,  UserRuleParameters,  UserUnbannedEvent,  UserUpdatedEvent,  VelocityFilterConfig,  VelocityFilterConfigRule,  VideoCallRuleConfig,  VideoContentParameters,  VideoEndCallRequestPayload,  VideoKickUserRequestPayload,  VideoRuleParameters,  VoteData,  WSAuthMessage,  WSClientEvent,  WSEvent,  } from '../models';
-import { decoders } from '../model-decoders/decoders'
+import type { ApiClient, StreamResponse } from '../../gen-imports';
+import type {
+  AppealRequest,
+  AppealResponse,
+  BanRequest,
+  BanResponse,
+  BulkDeleteActionConfigRequest,
+  BulkDeleteActionConfigResponse,
+  BulkUpsertActionConfigRequest,
+  BulkUpsertActionConfigResponse,
+  DeleteActionConfigResponse,
+  DeleteModerationConfigResponse,
+  FlagRequest,
+  FlagResponse,
+  GetActionConfigResponse,
+  GetAppealResponse,
+  GetConfigResponse,
+  MuteRequest,
+  MuteResponse,
+  QueryAppealsRequest,
+  QueryAppealsResponse,
+  QueryModerationConfigsRequest,
+  QueryModerationConfigsResponse,
+  QueryReviewQueueRequest,
+  QueryReviewQueueResponse,
+  SubmitActionRequest,
+  SubmitActionResponse,
+  UpsertActionConfigRequest,
+  UpsertActionConfigResponse,
+  UpsertConfigRequest,
+  UpsertConfigResponse,
+} from '../models';
+import { decoders } from '../model-decoders/decoders';
 
 export class ModerationApi {
+  constructor(public readonly apiClient: ApiClient) {}
 
-    constructor(public readonly apiClient: ApiClient) {}
+  async getActionConfig(request?: {
+    queue_type?: string;
+    entity_type?: string;
+    exclude_defaults?: boolean;
+    only_defaults?: boolean;
+  }): Promise<StreamResponse<GetActionConfigResponse>> {
+    const queryParams = {
+      queue_type: request?.queue_type,
+      entity_type: request?.entity_type,
+      exclude_defaults: request?.exclude_defaults,
+      only_defaults: request?.only_defaults,
+    };
 
-    
-    async getActionConfig (request?: 
-    
-    
-    {queue_type?: string,entity_type?: string,exclude_defaults?: boolean,only_defaults?: boolean,
-    }
-    ): Promise<StreamResponse<GetActionConfigResponse>> {
-        
-        const queryParams = {
-          queue_type: request?.queue_type, entity_type: request?.entity_type, exclude_defaults: request?.exclude_defaults, only_defaults: request?.only_defaults,
-        };
-        
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetActionConfigResponse>
+    >('GET', '/api/v2/moderation/action_config', undefined, queryParams);
 
-        const response = await this.apiClient.sendRequest<StreamResponse<GetActionConfigResponse>>('GET', '/api/v2/moderation/action_config',  undefined , queryParams  );
+    decoders.GetActionConfigResponse?.(response.body);
 
-       decoders["GetActionConfigResponse"]?.(response.body);
+    return { ...response.body, metadata: response.metadata };
+  }
 
-      return {...response.body, metadata: response.metadata};
+  async upsertActionConfig(
+    request: UpsertActionConfigRequest,
+  ): Promise<StreamResponse<UpsertActionConfigResponse>> {
+    const body = {
+      action: request?.action,
+      entity_type: request?.entity_type,
+      order: request?.order,
+      description: request?.description,
+      icon: request?.icon,
+      id: request?.id,
+      queue_type: request?.queue_type,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpsertActionConfigResponse>
+    >(
+      'POST',
+      '/api/v2/moderation/action_config',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpsertActionConfigResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async bulkUpsertActionConfig(
+    request: BulkUpsertActionConfigRequest,
+  ): Promise<StreamResponse<BulkUpsertActionConfigResponse>> {
+    const body = {
+      action_configs: request?.action_configs,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<BulkUpsertActionConfigResponse>
+    >(
+      'POST',
+      '/api/v2/moderation/action_config/bulk',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.BulkUpsertActionConfigResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async bulkDeleteActionConfig(
+    request: BulkDeleteActionConfigRequest,
+  ): Promise<StreamResponse<BulkDeleteActionConfigResponse>> {
+    const body = {
+      ids: request?.ids,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<BulkDeleteActionConfigResponse>
+    >(
+      'POST',
+      '/api/v2/moderation/action_config/bulk_delete',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.BulkDeleteActionConfigResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteActionConfig(request: {
+    id: string;
+  }): Promise<StreamResponse<DeleteActionConfigResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteActionConfigResponse>
+    >('DELETE', '/api/v2/moderation/action_config/{id}', pathParams, undefined);
+
+    decoders.DeleteActionConfigResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async appeal(
+    request: AppealRequest,
+  ): Promise<StreamResponse<AppealResponse>> {
+    const body = {
+      appeal_reason: request?.appeal_reason,
+      entity_id: request?.entity_id,
+      entity_type: request?.entity_type,
+      attachments: request?.attachments,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<AppealResponse>
+    >(
+      'POST',
+      '/api/v2/moderation/appeal',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.AppealResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getAppeal(request: {
+    id: string;
+  }): Promise<StreamResponse<GetAppealResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetAppealResponse>
+    >('GET', '/api/v2/moderation/appeal/{id}', pathParams, undefined);
+
+    decoders.GetAppealResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryAppeals(
+    request?: QueryAppealsRequest,
+  ): Promise<StreamResponse<QueryAppealsResponse>> {
+    const body = {
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryAppealsResponse>
+    >(
+      'POST',
+      '/api/v2/moderation/appeals',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryAppealsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async ban(request: BanRequest): Promise<StreamResponse<BanResponse>> {
+    const body = {
+      target_user_id: request?.target_user_id,
+      banned_by_id: request?.banned_by_id,
+      channel_cid: request?.channel_cid,
+      delete_messages: request?.delete_messages,
+      ip_ban: request?.ip_ban,
+      reason: request?.reason,
+      shadow: request?.shadow,
+      timeout: request?.timeout,
+      banned_by: request?.banned_by,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<BanResponse>
+    >(
+      'POST',
+      '/api/v2/moderation/ban',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.BanResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async upsertConfig(
+    request: UpsertConfigRequest,
+  ): Promise<StreamResponse<UpsertConfigResponse>> {
+    const body = {
+      key: request?.key,
+      async: request?.async,
+      team: request?.team,
+      ai_image_config: request?.ai_image_config,
+      ai_text_config: request?.ai_text_config,
+      ai_video_config: request?.ai_video_config,
+      automod_platform_circumvention_config:
+        request?.automod_platform_circumvention_config,
+      automod_semantic_filters_config: request?.automod_semantic_filters_config,
+      automod_toxicity_config: request?.automod_toxicity_config,
+      aws_rekognition_config: request?.aws_rekognition_config,
+      block_list_config: request?.block_list_config,
+      bodyguard_config: request?.bodyguard_config,
+      google_vision_config: request?.google_vision_config,
+      llm_config: request?.llm_config,
+      rule_builder_config: request?.rule_builder_config,
+      velocity_filter_config: request?.velocity_filter_config,
+      video_call_rule_config: request?.video_call_rule_config,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpsertConfigResponse>
+    >(
+      'POST',
+      '/api/v2/moderation/config',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpsertConfigResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteConfig(request: {
+    key: string;
+    team?: string;
+  }): Promise<StreamResponse<DeleteModerationConfigResponse>> {
+    const queryParams = {
+      team: request?.team,
+    };
+    const pathParams = {
+      key: request?.key,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteModerationConfigResponse>
+    >('DELETE', '/api/v2/moderation/config/{key}', pathParams, queryParams);
+
+    decoders.DeleteModerationConfigResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getConfig(request: {
+    key: string;
+    team?: string;
+  }): Promise<StreamResponse<GetConfigResponse>> {
+    const queryParams = {
+      team: request?.team,
+    };
+    const pathParams = {
+      key: request?.key,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetConfigResponse>
+    >('GET', '/api/v2/moderation/config/{key}', pathParams, queryParams);
+
+    decoders.GetConfigResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryModerationConfigs(
+    request?: QueryModerationConfigsRequest,
+  ): Promise<StreamResponse<QueryModerationConfigsResponse>> {
+    const body = {
+      limit: request?.limit,
+      next: request?.next,
+      prev: request?.prev,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryModerationConfigsResponse>
+    >(
+      'POST',
+      '/api/v2/moderation/configs',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryModerationConfigsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async flag(request: FlagRequest): Promise<StreamResponse<FlagResponse>> {
+    const body = {
+      entity_id: request?.entity_id,
+      entity_type: request?.entity_type,
+      entity_creator_id: request?.entity_creator_id,
+      reason: request?.reason,
+      custom: request?.custom,
+      moderation_payload: request?.moderation_payload,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<FlagResponse>
+    >(
+      'POST',
+      '/api/v2/moderation/flag',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.FlagResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async mute(request: MuteRequest): Promise<StreamResponse<MuteResponse>> {
+    const body = {
+      target_ids: request?.target_ids,
+      timeout: request?.timeout,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<MuteResponse>
+    >(
+      'POST',
+      '/api/v2/moderation/mute',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.MuteResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryReviewQueue(
+    request?: QueryReviewQueueRequest,
+  ): Promise<StreamResponse<QueryReviewQueueResponse>> {
+    const body = {
+      exclude_default_action_config: request?.exclude_default_action_config,
+      limit: request?.limit,
+      lock_count: request?.lock_count,
+      lock_duration: request?.lock_duration,
+      lock_items: request?.lock_items,
+      next: request?.next,
+      prev: request?.prev,
+      stats_only: request?.stats_only,
+      sort: request?.sort,
+      filter: request?.filter,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryReviewQueueResponse>
+    >(
+      'POST',
+      '/api/v2/moderation/review_queue',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryReviewQueueResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async submitAction(
+    request: SubmitActionRequest,
+  ): Promise<StreamResponse<SubmitActionResponse>> {
+    const body = {
+      action_type: request?.action_type,
+      appeal_id: request?.appeal_id,
+      item_id: request?.item_id,
+      ban: request?.ban,
+      block: request?.block,
+      bypass: request?.bypass,
+      custom: request?.custom,
+      delete_activity: request?.delete_activity,
+      delete_comment: request?.delete_comment,
+      delete_message: request?.delete_message,
+      delete_reaction: request?.delete_reaction,
+      delete_user: request?.delete_user,
+      escalate: request?.escalate,
+      flag: request?.flag,
+      mark_reviewed: request?.mark_reviewed,
+      reject_appeal: request?.reject_appeal,
+      restore: request?.restore,
+      shadow_block: request?.shadow_block,
+      unban: request?.unban,
+      unblock: request?.unblock,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<SubmitActionResponse>
+    >(
+      'POST',
+      '/api/v2/moderation/submit_action',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.SubmitActionResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
 }
-    
-    async upsertActionConfig (request: UpsertActionConfigRequest 
-    
-    ): Promise<StreamResponse<UpsertActionConfigResponse>> {
-        const body = {
-          action: request?.action,entity_type: request?.entity_type,order: request?.order,description: request?.description,icon: request?.icon,id: request?.id,queue_type: request?.queue_type,custom: request?.custom,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpsertActionConfigResponse>>('POST', '/api/v2/moderation/action_config',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["UpsertActionConfigResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async bulkUpsertActionConfig (request: BulkUpsertActionConfigRequest 
-    
-    ): Promise<StreamResponse<BulkUpsertActionConfigResponse>> {
-        const body = {
-          action_configs: request?.action_configs,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<BulkUpsertActionConfigResponse>>('POST', '/api/v2/moderation/action_config/bulk',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["BulkUpsertActionConfigResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async bulkDeleteActionConfig (request: BulkDeleteActionConfigRequest 
-    
-    ): Promise<StreamResponse<BulkDeleteActionConfigResponse>> {
-        const body = {
-          ids: request?.ids,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<BulkDeleteActionConfigResponse>>('POST', '/api/v2/moderation/action_config/bulk_delete',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["BulkDeleteActionConfigResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteActionConfig (request: 
-    
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<DeleteActionConfigResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<DeleteActionConfigResponse>>('DELETE', '/api/v2/moderation/action_config/{id}', pathParams ,  undefined  );
-
-       decoders["DeleteActionConfigResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async appeal (request: AppealRequest 
-    
-    ): Promise<StreamResponse<AppealResponse>> {
-        const body = {
-          appeal_reason: request?.appeal_reason,entity_id: request?.entity_id,entity_type: request?.entity_type,attachments: request?.attachments,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<AppealResponse>>('POST', '/api/v2/moderation/appeal',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["AppealResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getAppeal (request: 
-    
-    
-    {id: string,
-    }
-    ): Promise<StreamResponse<GetAppealResponse>> {
-        const pathParams = {
-          id: request?.id,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<GetAppealResponse>>('GET', '/api/v2/moderation/appeal/{id}', pathParams ,  undefined  );
-
-       decoders["GetAppealResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryAppeals (request?: QueryAppealsRequest 
-    
-    ): Promise<StreamResponse<QueryAppealsResponse>> {
-        const body = {
-          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryAppealsResponse>>('POST', '/api/v2/moderation/appeals',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["QueryAppealsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async ban (request: BanRequest 
-    
-    ): Promise<StreamResponse<BanResponse>> {
-        const body = {
-          target_user_id: request?.target_user_id,banned_by_id: request?.banned_by_id,channel_cid: request?.channel_cid,delete_messages: request?.delete_messages,ip_ban: request?.ip_ban,reason: request?.reason,shadow: request?.shadow,timeout: request?.timeout,banned_by: request?.banned_by,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<BanResponse>>('POST', '/api/v2/moderation/ban',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["BanResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async upsertConfig (request: UpsertConfigRequest 
-    
-    ): Promise<StreamResponse<UpsertConfigResponse>> {
-        const body = {
-          key: request?.key,async: request?.async,team: request?.team,ai_image_config: request?.ai_image_config,ai_text_config: request?.ai_text_config,ai_video_config: request?.ai_video_config,automod_platform_circumvention_config: request?.automod_platform_circumvention_config,automod_semantic_filters_config: request?.automod_semantic_filters_config,automod_toxicity_config: request?.automod_toxicity_config,aws_rekognition_config: request?.aws_rekognition_config,block_list_config: request?.block_list_config,bodyguard_config: request?.bodyguard_config,google_vision_config: request?.google_vision_config,llm_config: request?.llm_config,rule_builder_config: request?.rule_builder_config,velocity_filter_config: request?.velocity_filter_config,video_call_rule_config: request?.video_call_rule_config,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<UpsertConfigResponse>>('POST', '/api/v2/moderation/config',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["UpsertConfigResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async deleteConfig (request: 
-    
-    
-    {key: string,team?: string,
-    }
-    ): Promise<StreamResponse<DeleteModerationConfigResponse>> {
-        
-        const queryParams = {
-          team: request?.team,
-        };
-        const pathParams = {
-          key: request?.key,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<DeleteModerationConfigResponse>>('DELETE', '/api/v2/moderation/config/{key}', pathParams , queryParams  );
-
-       decoders["DeleteModerationConfigResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async getConfig (request: 
-    
-    
-    {key: string,team?: string,
-    }
-    ): Promise<StreamResponse<GetConfigResponse>> {
-        
-        const queryParams = {
-          team: request?.team,
-        };
-        const pathParams = {
-          key: request?.key,
-        };
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<GetConfigResponse>>('GET', '/api/v2/moderation/config/{key}', pathParams , queryParams  );
-
-       decoders["GetConfigResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryModerationConfigs (request?: QueryModerationConfigsRequest 
-    
-    ): Promise<StreamResponse<QueryModerationConfigsResponse>> {
-        const body = {
-          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryModerationConfigsResponse>>('POST', '/api/v2/moderation/configs',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["QueryModerationConfigsResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async flag (request: FlagRequest 
-    
-    ): Promise<StreamResponse<FlagResponse>> {
-        const body = {
-          entity_id: request?.entity_id,entity_type: request?.entity_type,entity_creator_id: request?.entity_creator_id,reason: request?.reason,custom: request?.custom,moderation_payload: request?.moderation_payload,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<FlagResponse>>('POST', '/api/v2/moderation/flag',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["FlagResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async mute (request: MuteRequest 
-    
-    ): Promise<StreamResponse<MuteResponse>> {
-        const body = {
-          target_ids: request?.target_ids,timeout: request?.timeout,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<MuteResponse>>('POST', '/api/v2/moderation/mute',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["MuteResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async queryReviewQueue (request?: QueryReviewQueueRequest 
-    
-    ): Promise<StreamResponse<QueryReviewQueueResponse>> {
-        const body = {
-          exclude_default_action_config: request?.exclude_default_action_config,limit: request?.limit,lock_count: request?.lock_count,lock_duration: request?.lock_duration,lock_items: request?.lock_items,next: request?.next,prev: request?.prev,stats_only: request?.stats_only,sort: request?.sort,filter: request?.filter,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<QueryReviewQueueResponse>>('POST', '/api/v2/moderation/review_queue',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["QueryReviewQueueResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    
-    async submitAction (request: SubmitActionRequest 
-    
-    ): Promise<StreamResponse<SubmitActionResponse>> {
-        const body = {
-          action_type: request?.action_type,appeal_id: request?.appeal_id,item_id: request?.item_id,ban: request?.ban,block: request?.block,bypass: request?.bypass,custom: request?.custom,delete_activity: request?.delete_activity,delete_comment: request?.delete_comment,delete_message: request?.delete_message,delete_reaction: request?.delete_reaction,delete_user: request?.delete_user,escalate: request?.escalate,flag: request?.flag,mark_reviewed: request?.mark_reviewed,reject_appeal: request?.reject_appeal,restore: request?.restore,shadow_block: request?.shadow_block,unban: request?.unban,unblock: request?.unblock,
-        }
-        
-
-        const response = await this.apiClient.sendRequest<StreamResponse<SubmitActionResponse>>('POST', '/api/v2/moderation/submit_action',  undefined ,  undefined  , body, 'application/json');
-
-       decoders["SubmitActionResponse"]?.(response.body);
-
-      return {...response.body, metadata: response.metadata};
-}
-    }

--- a/packages/feeds-client/src/gen/moderation/ModerationApi.ts
+++ b/packages/feeds-client/src/gen/moderation/ModerationApi.ts
@@ -1,355 +1,288 @@
-import type { ApiClient, StreamResponse } from '../../gen-imports';
-import type {
-  AppealRequest,
-  AppealResponse,
-  BanRequest,
-  BanResponse,
-  DeleteModerationConfigResponse,
-  FlagRequest,
-  FlagResponse,
-  GetAppealResponse,
-  GetConfigResponse,
-  MuteRequest,
-  MuteResponse,
-  QueryAppealsRequest,
-  QueryAppealsResponse,
-  QueryModerationConfigsRequest,
-  QueryModerationConfigsResponse,
-  QueryReviewQueueRequest,
-  QueryReviewQueueResponse,
-  SubmitActionRequest,
-  SubmitActionResponse,
-  UpsertConfigRequest,
-  UpsertConfigResponse,
-} from '../models';
-import { decoders } from '../model-decoders/decoders';
+import { ApiClient, StreamResponse } from '../../gen-imports';
+import {  AIImageConfig,  AIImageLabelDefinition,  AITextConfig,  AIVideoConfig,  APIError,  AWSRekognitionRule,  AcceptFeedMemberInviteRequest,  AcceptFeedMemberInviteResponse,  AcceptFollowRequest,  AcceptFollowResponse,  Action,  ActionLogResponse,  ActionSequence,  ActivityAddedEvent,  ActivityDeletedEvent,  ActivityFeedbackEvent,  ActivityFeedbackEventPayload,  ActivityFeedbackRequest,  ActivityFeedbackResponse,  ActivityFilterConfig,  ActivityMarkEvent,  ActivityPinResponse,  ActivityPinnedEvent,  ActivityProcessorConfig,  ActivityReactionAddedEvent,  ActivityReactionDeletedEvent,  ActivityReactionUpdatedEvent,  ActivityRemovedFromFeedEvent,  ActivityRequest,  ActivityResponse,  ActivityRestoredEvent,  ActivitySelectorConfig,  ActivityUnpinnedEvent,  ActivityUpdatedEvent,  AddActivityRequest,  AddActivityResponse,  AddBookmarkRequest,  AddBookmarkResponse,  AddCommentBookmarkRequest,  AddCommentBookmarkResponse,  AddCommentReactionRequest,  AddCommentReactionResponse,  AddCommentRequest,  AddCommentResponse,  AddCommentsBatchRequest,  AddCommentsBatchResponse,  AddFolderRequest,  AddReactionRequest,  AddReactionResponse,  AddUserGroupMembersRequest,  AddUserGroupMembersResponse,  AggregatedActivityResponse,  AggregationConfig,  AppEventResponse,  AppResponseFields,  AppUpdatedEvent,  AppealItemResponse,  AppealRequest,  AppealResponse,  Attachment,  AutomodPlatformCircumventionConfig,  AutomodRule,  AutomodSemanticFiltersConfig,  AutomodSemanticFiltersRule,  AutomodToxicityConfig,  BanActionRequestPayload,  BanInfoResponse,  BanOptions,  BanRequest,  BanResponse,  BlockActionRequestPayload,  BlockListConfig,  BlockListOptions,  BlockListResponse,  BlockListRule,  BlockUsersRequest,  BlockUsersResponse,  BlockedUserResponse,  BodyguardProfileSummary,  BodyguardRule,  BodyguardSeverityRule,  BookmarkAddedEvent,  BookmarkDeletedEvent,  BookmarkFolderDeletedEvent,  BookmarkFolderResponse,  BookmarkFolderUpdatedEvent,  BookmarkResponse,  BookmarkUpdatedEvent,  BulkDeleteActionConfigRequest,  BulkDeleteActionConfigResponse,  BulkUpsertActionConfigRequest,  BulkUpsertActionConfigResponse,  BypassActionRequest,  CallActionOptions,  CallCustomPropertyParameters,  CallResponse,  CallRuleActionSequence,  CallTypeRuleParameters,  CallViolationCountParameters,  CastPollVoteRequest,  ChangeFeedVisibilityRequest,  ChangeFeedVisibilityResponse,  ChannelConfigWithInfo,  ChannelMemberResponse,  ChannelMessageCountRuleParameters,  ChannelMute,  ChannelOwnCapability,  ChannelPushPreferencesResponse,  ChannelResponse,  ChatDraftPayloadResponse,  ChatDraftResponse,  ChatMessageResponse,  ChatModerationV2Response,  ChatPreferences,  ChatPreferencesInput,  ChatPreferencesResponse,  ChatReactionGroupResponse,  ChatReactionGroupUserResponse,  ChatReactionResponse,  ChatReminderResponseData,  ChatSharedLocationResponseData,  ClosedCaptionRuleParameters,  CollectionRequest,  CollectionResponse,  Command,  CommentAddedEvent,  CommentDeletedEvent,  CommentReactionAddedEvent,  CommentReactionDeletedEvent,  CommentReactionUpdatedEvent,  CommentResponse,  CommentRestoredEvent,  CommentUpdatedEvent,  ConfigResponse,  ConnectUserDetailsRequest,  ContentCountRuleParameters,  CreateBlockListRequest,  CreateBlockListResponse,  CreateCollectionsRequest,  CreateCollectionsResponse,  CreateDeviceRequest,  CreateFeedsBatchRequest,  CreateFeedsBatchResponse,  CreateGuestRequest,  CreateGuestResponse,  CreatePollOptionRequest,  CreatePollRequest,  CreateUserGroupRequest,  CreateUserGroupResponse,  CustomActionRequestPayload,  Data,  DecayFunctionConfig,  DeleteActionConfigResponse,  DeleteActivitiesRequest,  DeleteActivitiesResponse,  DeleteActivityReactionResponse,  DeleteActivityRequestPayload,  DeleteActivityResponse,  DeleteBookmarkFolderResponse,  DeleteBookmarkResponse,  DeleteCollectionsResponse,  DeleteCommentBookmarkResponse,  DeleteCommentReactionResponse,  DeleteCommentRequestPayload,  DeleteCommentResponse,  DeleteFeedResponse,  DeleteMessageRequestPayload,  DeleteModerationConfigResponse,  DeleteReactionRequestPayload,  DeleteUserRequestPayload,  DeliveryReceiptsResponse,  DeviceResponse,  DraftPayloadResponse,  DraftResponse,  EnrichedActivity,  EnrichedCollectionResponse,  EnrichedReaction,  EnrichmentOptions,  EntityCreatorResponse,  EscalatePayload,  EscalationMetadata,  FeedCreatedEvent,  FeedDeletedEvent,  FeedGroup,  FeedGroupChangedEvent,  FeedGroupDeletedEvent,  FeedGroupRestoredEvent,  FeedInput,  FeedMemberAddedEvent,  FeedMemberRemovedEvent,  FeedMemberRequest,  FeedMemberResponse,  FeedMemberUpdatedEvent,  FeedOwnCapability,  FeedOwnData,  FeedRequest,  FeedResponse,  FeedSuggestionResponse,  FeedUpdatedEvent,  FeedsActivityLocation,  FeedsBookmarkResponse,  FeedsEnrichedCollectionResponse,  FeedsFeedResponse,  FeedsNotificationComment,  FeedsNotificationContext,  FeedsNotificationParentActivity,  FeedsNotificationTarget,  FeedsNotificationTrigger,  FeedsPreferences,  FeedsPreferencesResponse,  FeedsReactionGroupResponse,  FeedsReactionResponse,  FeedsV3ActivityResponse,  FeedsV3CommentResponse,  Field,  FileUploadConfig,  FileUploadRequest,  FileUploadResponse,  FilterConfigResponse,  FlagCountRuleParameters,  FlagRequest,  FlagResponse,  FlagUserOptions,  FollowBatchRequest,  FollowBatchResponse,  FollowCreatedEvent,  FollowDeletedEvent,  FollowRequest,  FollowResponse,  FollowUpdatedEvent,  FriendReactionsOptions,  FullUserResponse,  GetActionConfigResponse,  GetActivityResponse,  GetAppealResponse,  GetApplicationResponse,  GetBlockedUsersResponse,  GetCommentRepliesResponse,  GetCommentResponse,  GetCommentsResponse,  GetConfigResponse,  GetFollowSuggestionsResponse,  GetOGResponse,  GetOrCreateFeedRequest,  GetOrCreateFeedResponse,  GetUserGroupResponse,  GoogleVisionConfig,  HarmConfig,  HealthCheckEvent,  ImageContentParameters,  ImageData,  ImageRuleParameters,  ImageSize,  ImageUploadRequest,  ImageUploadResponse,  Images,  KeyframeRuleParameters,  LLMConfig,  LLMRule,  LabelThresholds,  ListBlockListResponse,  ListDevicesResponse,  ListUserGroupsResponse,  Location,  MarkActivityRequest,  MarkReviewedRequestPayload,  MembershipLevelResponse,  MessageResponse,  ModerationActionConfigResponse,  ModerationCustomActionEvent,  ModerationFlagResponse,  ModerationFlaggedEvent,  ModerationMarkReviewedEvent,  ModerationPayload,  ModerationPayloadResponse,  ModerationV2Response,  MuteRequest,  MuteResponse,  NotificationComment,  NotificationConfig,  NotificationContext,  NotificationFeedUpdatedEvent,  NotificationParentActivity,  NotificationStatusResponse,  NotificationTarget,  NotificationTrigger,  OCRRule,  OnlyUserID,  OwnBatchRequest,  OwnBatchResponse,  OwnUserResponse,  PagerRequest,  PagerResponse,  PinActivityRequest,  PinActivityResponse,  PollClosedFeedEvent,  PollDeletedFeedEvent,  PollOptionInput,  PollOptionRequest,  PollOptionResponse,  PollOptionResponseData,  PollResponse,  PollResponseData,  PollUpdatedFeedEvent,  PollVoteCastedFeedEvent,  PollVoteChangedFeedEvent,  PollVoteRemovedFeedEvent,  PollVoteResponse,  PollVoteResponseData,  PollVotesResponse,  PrivacySettingsResponse,  PushNotificationConfig,  PushPreferenceInput,  PushPreferencesResponse,  QueryActivitiesRequest,  QueryActivitiesResponse,  QueryActivityReactionsRequest,  QueryActivityReactionsResponse,  QueryAppealsRequest,  QueryAppealsResponse,  QueryBookmarkFoldersRequest,  QueryBookmarkFoldersResponse,  QueryBookmarksRequest,  QueryBookmarksResponse,  QueryCollectionsRequest,  QueryCollectionsResponse,  QueryCommentReactionsRequest,  QueryCommentReactionsResponse,  QueryCommentsRequest,  QueryCommentsResponse,  QueryFeedMembersRequest,  QueryFeedMembersResponse,  QueryFeedsRequest,  QueryFeedsResponse,  QueryFollowsRequest,  QueryFollowsResponse,  QueryModerationConfigsRequest,  QueryModerationConfigsResponse,  QueryPinnedActivitiesRequest,  QueryPinnedActivitiesResponse,  QueryPollVotesRequest,  QueryPollsRequest,  QueryPollsResponse,  QueryReviewQueueRequest,  QueryReviewQueueResponse,  QueryUsersPayload,  QueryUsersResponse,  RankingConfig,  Reaction,  ReactionGroupResponse,  ReactionGroupUserResponse,  ReactionResponse,  ReadCollectionsResponse,  ReadReceiptsResponse,  RejectAppealRequestPayload,  RejectFeedMemberInviteRequest,  RejectFeedMemberInviteResponse,  RejectFollowRequest,  RejectFollowResponse,  ReminderResponseData,  RemoveUserGroupMembersRequest,  RemoveUserGroupMembersResponse,  RepliesMeta,  Response,  RestoreActionRequestPayload,  RestoreActivityRequest,  RestoreActivityResponse,  RestoreCommentRequest,  RestoreCommentResponse,  ReviewQueueItemResponse,  RuleBuilderAction,  RuleBuilderCondition,  RuleBuilderConditionGroup,  RuleBuilderConfig,  RuleBuilderRule,  SearchUserGroupsResponse,  ShadowBlockActionRequestPayload,  SharedLocationResponse,  SharedLocationResponseData,  SharedLocationsResponse,  SingleFollowResponse,  SortParam,  SortParamRequest,  StoriesConfig,  StoriesFeedUpdatedEvent,  SubmitActionRequest,  SubmitActionResponse,  TextContentParameters,  TextRuleParameters,  ThreadedCommentResponse,  Thresholds,  Time,  TrackActivityMetricsEvent,  TrackActivityMetricsEventResult,  TrackActivityMetricsRequest,  TrackActivityMetricsResponse,  TypingIndicatorsResponse,  UnbanActionRequestPayload,  UnblockActionRequestPayload,  UnblockUsersRequest,  UnblockUsersResponse,  UnfollowBatchRequest,  UnfollowBatchResponse,  UnfollowPair,  UnfollowResponse,  UnpinActivityResponse,  UpdateActivityPartialRequest,  UpdateActivityPartialResponse,  UpdateActivityRequest,  UpdateActivityResponse,  UpdateBlockListRequest,  UpdateBlockListResponse,  UpdateBookmarkFolderRequest,  UpdateBookmarkFolderResponse,  UpdateBookmarkRequest,  UpdateBookmarkResponse,  UpdateCollectionRequest,  UpdateCollectionsRequest,  UpdateCollectionsResponse,  UpdateCommentBookmarkRequest,  UpdateCommentBookmarkResponse,  UpdateCommentPartialRequest,  UpdateCommentPartialResponse,  UpdateCommentRequest,  UpdateCommentResponse,  UpdateFeedMembersRequest,  UpdateFeedMembersResponse,  UpdateFeedRequest,  UpdateFeedResponse,  UpdateFollowRequest,  UpdateFollowResponse,  UpdateLiveLocationRequest,  UpdatePollOptionRequest,  UpdatePollPartialRequest,  UpdatePollRequest,  UpdateUserGroupRequest,  UpdateUserGroupResponse,  UpdateUserPartialRequest,  UpdateUsersPartialRequest,  UpdateUsersRequest,  UpdateUsersResponse,  UpsertActionConfigItem,  UpsertActionConfigRequest,  UpsertActionConfigResponse,  UpsertActivitiesRequest,  UpsertActivitiesResponse,  UpsertConfigRequest,  UpsertConfigResponse,  UpsertPushPreferencesRequest,  UpsertPushPreferencesResponse,  User,  UserBannedEvent,  UserCreatedWithinParameters,  UserCustomPropertyParameters,  UserDeactivatedEvent,  UserGroupMember,  UserGroupResponse,  UserIdenticalContentCountParameters,  UserMuteResponse,  UserReactivatedEvent,  UserRequest,  UserResponse,  UserResponseCommonFields,  UserResponsePrivacyFields,  UserRoleParameters,  UserRuleParameters,  UserUnbannedEvent,  UserUpdatedEvent,  VelocityFilterConfig,  VelocityFilterConfigRule,  VideoCallRuleConfig,  VideoContentParameters,  VideoEndCallRequestPayload,  VideoKickUserRequestPayload,  VideoRuleParameters,  VoteData,  WSAuthMessage,  WSClientEvent,  WSEvent,  } from '../models';
+import { decoders } from '../model-decoders/decoders'
 
 export class ModerationApi {
-  constructor(public readonly apiClient: ApiClient) {}
 
-  async appeal(
-    request: AppealRequest,
-  ): Promise<StreamResponse<AppealResponse>> {
-    const body = {
-      appeal_reason: request?.appeal_reason,
-      entity_id: request?.entity_id,
-      entity_type: request?.entity_type,
-      attachments: request?.attachments,
-    };
+    constructor(public readonly apiClient: ApiClient) {}
 
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<AppealResponse>
-    >(
-      'POST',
-      '/api/v2/moderation/appeal',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
+    
+    async getActionConfig (request?: 
+    
+    
+    {queue_type?: string,entity_type?: string,exclude_defaults?: boolean,only_defaults?: boolean,
+    }
+    ): Promise<StreamResponse<GetActionConfigResponse>> {
+        
+        const queryParams = {
+          queue_type: request?.queue_type, entity_type: request?.entity_type, exclude_defaults: request?.exclude_defaults, only_defaults: request?.only_defaults,
+        };
+        
 
-    decoders.AppealResponse?.(response.body);
+        const response = await this.apiClient.sendRequest<StreamResponse<GetActionConfigResponse>>('GET', '/api/v2/moderation/action_config',  undefined , queryParams  );
 
-    return { ...response.body, metadata: response.metadata };
-  }
+       decoders["GetActionConfigResponse"]?.(response.body);
 
-  async getAppeal(request: {
-    id: string;
-  }): Promise<StreamResponse<GetAppealResponse>> {
-    const pathParams = {
-      id: request?.id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetAppealResponse>
-    >('GET', '/api/v2/moderation/appeal/{id}', pathParams, undefined);
-
-    decoders.GetAppealResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryAppeals(
-    request?: QueryAppealsRequest,
-  ): Promise<StreamResponse<QueryAppealsResponse>> {
-    const body = {
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryAppealsResponse>
-    >(
-      'POST',
-      '/api/v2/moderation/appeals',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryAppealsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async ban(request: BanRequest): Promise<StreamResponse<BanResponse>> {
-    const body = {
-      target_user_id: request?.target_user_id,
-      banned_by_id: request?.banned_by_id,
-      channel_cid: request?.channel_cid,
-      delete_messages: request?.delete_messages,
-      ip_ban: request?.ip_ban,
-      reason: request?.reason,
-      shadow: request?.shadow,
-      timeout: request?.timeout,
-      banned_by: request?.banned_by,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<BanResponse>
-    >(
-      'POST',
-      '/api/v2/moderation/ban',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.BanResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async upsertConfig(
-    request: UpsertConfigRequest,
-  ): Promise<StreamResponse<UpsertConfigResponse>> {
-    const body = {
-      key: request?.key,
-      async: request?.async,
-      team: request?.team,
-      ai_image_config: request?.ai_image_config,
-      ai_text_config: request?.ai_text_config,
-      ai_video_config: request?.ai_video_config,
-      automod_platform_circumvention_config:
-        request?.automod_platform_circumvention_config,
-      automod_semantic_filters_config: request?.automod_semantic_filters_config,
-      automod_toxicity_config: request?.automod_toxicity_config,
-      aws_rekognition_config: request?.aws_rekognition_config,
-      block_list_config: request?.block_list_config,
-      bodyguard_config: request?.bodyguard_config,
-      google_vision_config: request?.google_vision_config,
-      llm_config: request?.llm_config,
-      rule_builder_config: request?.rule_builder_config,
-      velocity_filter_config: request?.velocity_filter_config,
-      video_call_rule_config: request?.video_call_rule_config,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpsertConfigResponse>
-    >(
-      'POST',
-      '/api/v2/moderation/config',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpsertConfigResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async deleteConfig(request: {
-    key: string;
-    team?: string;
-  }): Promise<StreamResponse<DeleteModerationConfigResponse>> {
-    const queryParams = {
-      team: request?.team,
-    };
-    const pathParams = {
-      key: request?.key,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteModerationConfigResponse>
-    >('DELETE', '/api/v2/moderation/config/{key}', pathParams, queryParams);
-
-    decoders.DeleteModerationConfigResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getConfig(request: {
-    key: string;
-    team?: string;
-  }): Promise<StreamResponse<GetConfigResponse>> {
-    const queryParams = {
-      team: request?.team,
-    };
-    const pathParams = {
-      key: request?.key,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetConfigResponse>
-    >('GET', '/api/v2/moderation/config/{key}', pathParams, queryParams);
-
-    decoders.GetConfigResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryModerationConfigs(
-    request?: QueryModerationConfigsRequest,
-  ): Promise<StreamResponse<QueryModerationConfigsResponse>> {
-    const body = {
-      limit: request?.limit,
-      next: request?.next,
-      prev: request?.prev,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryModerationConfigsResponse>
-    >(
-      'POST',
-      '/api/v2/moderation/configs',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryModerationConfigsResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async flag(request: FlagRequest): Promise<StreamResponse<FlagResponse>> {
-    const body = {
-      entity_id: request?.entity_id,
-      entity_type: request?.entity_type,
-      entity_creator_id: request?.entity_creator_id,
-      reason: request?.reason,
-      custom: request?.custom,
-      moderation_payload: request?.moderation_payload,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<FlagResponse>
-    >(
-      'POST',
-      '/api/v2/moderation/flag',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.FlagResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async mute(request: MuteRequest): Promise<StreamResponse<MuteResponse>> {
-    const body = {
-      target_ids: request?.target_ids,
-      timeout: request?.timeout,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<MuteResponse>
-    >(
-      'POST',
-      '/api/v2/moderation/mute',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.MuteResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async queryReviewQueue(
-    request?: QueryReviewQueueRequest,
-  ): Promise<StreamResponse<QueryReviewQueueResponse>> {
-    const body = {
-      limit: request?.limit,
-      lock_count: request?.lock_count,
-      lock_duration: request?.lock_duration,
-      lock_items: request?.lock_items,
-      next: request?.next,
-      prev: request?.prev,
-      stats_only: request?.stats_only,
-      sort: request?.sort,
-      filter: request?.filter,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<QueryReviewQueueResponse>
-    >(
-      'POST',
-      '/api/v2/moderation/review_queue',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.QueryReviewQueueResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async submitAction(
-    request: SubmitActionRequest,
-  ): Promise<StreamResponse<SubmitActionResponse>> {
-    const body = {
-      action_type: request?.action_type,
-      appeal_id: request?.appeal_id,
-      item_id: request?.item_id,
-      ban: request?.ban,
-      block: request?.block,
-      bypass: request?.bypass,
-      custom: request?.custom,
-      delete_activity: request?.delete_activity,
-      delete_comment: request?.delete_comment,
-      delete_message: request?.delete_message,
-      delete_reaction: request?.delete_reaction,
-      delete_user: request?.delete_user,
-      escalate: request?.escalate,
-      flag: request?.flag,
-      mark_reviewed: request?.mark_reviewed,
-      reject_appeal: request?.reject_appeal,
-      restore: request?.restore,
-      shadow_block: request?.shadow_block,
-      unban: request?.unban,
-      unblock: request?.unblock,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<SubmitActionResponse>
-    >(
-      'POST',
-      '/api/v2/moderation/submit_action',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.SubmitActionResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
+      return {...response.body, metadata: response.metadata};
 }
+    
+    async upsertActionConfig (request: UpsertActionConfigRequest 
+    
+    ): Promise<StreamResponse<UpsertActionConfigResponse>> {
+        const body = {
+          action: request?.action,entity_type: request?.entity_type,order: request?.order,description: request?.description,icon: request?.icon,id: request?.id,queue_type: request?.queue_type,custom: request?.custom,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpsertActionConfigResponse>>('POST', '/api/v2/moderation/action_config',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["UpsertActionConfigResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async bulkUpsertActionConfig (request: BulkUpsertActionConfigRequest 
+    
+    ): Promise<StreamResponse<BulkUpsertActionConfigResponse>> {
+        const body = {
+          action_configs: request?.action_configs,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<BulkUpsertActionConfigResponse>>('POST', '/api/v2/moderation/action_config/bulk',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["BulkUpsertActionConfigResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async bulkDeleteActionConfig (request: BulkDeleteActionConfigRequest 
+    
+    ): Promise<StreamResponse<BulkDeleteActionConfigResponse>> {
+        const body = {
+          ids: request?.ids,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<BulkDeleteActionConfigResponse>>('POST', '/api/v2/moderation/action_config/bulk_delete',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["BulkDeleteActionConfigResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteActionConfig (request: 
+    
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<DeleteActionConfigResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<DeleteActionConfigResponse>>('DELETE', '/api/v2/moderation/action_config/{id}', pathParams ,  undefined  );
+
+       decoders["DeleteActionConfigResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async appeal (request: AppealRequest 
+    
+    ): Promise<StreamResponse<AppealResponse>> {
+        const body = {
+          appeal_reason: request?.appeal_reason,entity_id: request?.entity_id,entity_type: request?.entity_type,attachments: request?.attachments,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<AppealResponse>>('POST', '/api/v2/moderation/appeal',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["AppealResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getAppeal (request: 
+    
+    
+    {id: string,
+    }
+    ): Promise<StreamResponse<GetAppealResponse>> {
+        const pathParams = {
+          id: request?.id,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<GetAppealResponse>>('GET', '/api/v2/moderation/appeal/{id}', pathParams ,  undefined  );
+
+       decoders["GetAppealResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryAppeals (request?: QueryAppealsRequest 
+    
+    ): Promise<StreamResponse<QueryAppealsResponse>> {
+        const body = {
+          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryAppealsResponse>>('POST', '/api/v2/moderation/appeals',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["QueryAppealsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async ban (request: BanRequest 
+    
+    ): Promise<StreamResponse<BanResponse>> {
+        const body = {
+          target_user_id: request?.target_user_id,banned_by_id: request?.banned_by_id,channel_cid: request?.channel_cid,delete_messages: request?.delete_messages,ip_ban: request?.ip_ban,reason: request?.reason,shadow: request?.shadow,timeout: request?.timeout,banned_by: request?.banned_by,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<BanResponse>>('POST', '/api/v2/moderation/ban',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["BanResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async upsertConfig (request: UpsertConfigRequest 
+    
+    ): Promise<StreamResponse<UpsertConfigResponse>> {
+        const body = {
+          key: request?.key,async: request?.async,team: request?.team,ai_image_config: request?.ai_image_config,ai_text_config: request?.ai_text_config,ai_video_config: request?.ai_video_config,automod_platform_circumvention_config: request?.automod_platform_circumvention_config,automod_semantic_filters_config: request?.automod_semantic_filters_config,automod_toxicity_config: request?.automod_toxicity_config,aws_rekognition_config: request?.aws_rekognition_config,block_list_config: request?.block_list_config,bodyguard_config: request?.bodyguard_config,google_vision_config: request?.google_vision_config,llm_config: request?.llm_config,rule_builder_config: request?.rule_builder_config,velocity_filter_config: request?.velocity_filter_config,video_call_rule_config: request?.video_call_rule_config,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<UpsertConfigResponse>>('POST', '/api/v2/moderation/config',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["UpsertConfigResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async deleteConfig (request: 
+    
+    
+    {key: string,team?: string,
+    }
+    ): Promise<StreamResponse<DeleteModerationConfigResponse>> {
+        
+        const queryParams = {
+          team: request?.team,
+        };
+        const pathParams = {
+          key: request?.key,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<DeleteModerationConfigResponse>>('DELETE', '/api/v2/moderation/config/{key}', pathParams , queryParams  );
+
+       decoders["DeleteModerationConfigResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async getConfig (request: 
+    
+    
+    {key: string,team?: string,
+    }
+    ): Promise<StreamResponse<GetConfigResponse>> {
+        
+        const queryParams = {
+          team: request?.team,
+        };
+        const pathParams = {
+          key: request?.key,
+        };
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<GetConfigResponse>>('GET', '/api/v2/moderation/config/{key}', pathParams , queryParams  );
+
+       decoders["GetConfigResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryModerationConfigs (request?: QueryModerationConfigsRequest 
+    
+    ): Promise<StreamResponse<QueryModerationConfigsResponse>> {
+        const body = {
+          limit: request?.limit,next: request?.next,prev: request?.prev,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryModerationConfigsResponse>>('POST', '/api/v2/moderation/configs',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["QueryModerationConfigsResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async flag (request: FlagRequest 
+    
+    ): Promise<StreamResponse<FlagResponse>> {
+        const body = {
+          entity_id: request?.entity_id,entity_type: request?.entity_type,entity_creator_id: request?.entity_creator_id,reason: request?.reason,custom: request?.custom,moderation_payload: request?.moderation_payload,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<FlagResponse>>('POST', '/api/v2/moderation/flag',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["FlagResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async mute (request: MuteRequest 
+    
+    ): Promise<StreamResponse<MuteResponse>> {
+        const body = {
+          target_ids: request?.target_ids,timeout: request?.timeout,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<MuteResponse>>('POST', '/api/v2/moderation/mute',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["MuteResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async queryReviewQueue (request?: QueryReviewQueueRequest 
+    
+    ): Promise<StreamResponse<QueryReviewQueueResponse>> {
+        const body = {
+          exclude_default_action_config: request?.exclude_default_action_config,limit: request?.limit,lock_count: request?.lock_count,lock_duration: request?.lock_duration,lock_items: request?.lock_items,next: request?.next,prev: request?.prev,stats_only: request?.stats_only,sort: request?.sort,filter: request?.filter,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<QueryReviewQueueResponse>>('POST', '/api/v2/moderation/review_queue',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["QueryReviewQueueResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    
+    async submitAction (request: SubmitActionRequest 
+    
+    ): Promise<StreamResponse<SubmitActionResponse>> {
+        const body = {
+          action_type: request?.action_type,appeal_id: request?.appeal_id,item_id: request?.item_id,ban: request?.ban,block: request?.block,bypass: request?.bypass,custom: request?.custom,delete_activity: request?.delete_activity,delete_comment: request?.delete_comment,delete_message: request?.delete_message,delete_reaction: request?.delete_reaction,delete_user: request?.delete_user,escalate: request?.escalate,flag: request?.flag,mark_reviewed: request?.mark_reviewed,reject_appeal: request?.reject_appeal,restore: request?.restore,shadow_block: request?.shadow_block,unban: request?.unban,unblock: request?.unblock,
+        }
+        
+
+        const response = await this.apiClient.sendRequest<StreamResponse<SubmitActionResponse>>('POST', '/api/v2/moderation/submit_action',  undefined ,  undefined  , body, 'application/json');
+
+       decoders["SubmitActionResponse"]?.(response.body);
+
+      return {...response.body, metadata: response.metadata};
+}
+    }


### PR DESCRIPTION
## Summary
- regenerate `packages/feeds-client/src/gen` outputs using `./generate-openapi.sh`
- include generated SDK updates across feed/moderation APIs, model decoders, and model exports
- note: most file churn comes from generator template/output formatting and import style changes (not hand-written source edits)

## Test plan
- [ ] Run `yarn lint:gen`
- [ ] Run `yarn build:all`
- [ ] Run `yarn test:ci:libs`

Made with [Cursor](https://cursor.com)