### PR TITLE
feat: apply filters for aggregated activities

### DIFF
--- a/packages/feeds-client/__integration-tests__/aggregated-notification-feed-filter.test.ts
+++ b/packages/feeds-client/__integration-tests__/aggregated-notification-feed-filter.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  createTestClient,
+  createTestTokenGenerator,
+  getServerClient,
+  getTestUser,
+  waitForEvent,
+} from './utils';
+
+import type { UserRequest } from '../src/gen/models';
+import type { FeedsClient } from '../src/feeds-client';
+import type { Feed } from '../src/feed';
+import type { StreamClient } from '@stream-io/node-sdk';
+
+describe('Aggregated notification feed with filter_tags filter', () => {
+  let client: FeedsClient;
+  let serverClient: StreamClient;
+  let feed: Feed;
+  const user: UserRequest = getTestUser();
+
+  beforeAll(async () => {
+    client = createTestClient();
+    await client.connectUser(user, createTestTokenGenerator(user));
+    serverClient = getServerClient();
+
+    feed = client.feed('notification', crypto.randomUUID());
+    await feed.getOrCreate({
+      watch: true,
+      filter: { filter_tags: ['blue'] },
+    });
+  });
+
+  it('adds an aggregated group and increments unread/unseen when a matching activity is added', async () => {
+    const updated = waitForEvent(feed, 'feeds.notification_feed.updated');
+    void serverClient.feeds.addActivity({
+      type: 'post',
+      feeds: [feed.feed],
+      text: 'blue post',
+      filter_tags: ['blue'],
+      user_id: user.id,
+    });
+    await updated;
+
+    const state = feed.state.getLatestValue();
+    expect(state.aggregated_activities).toHaveLength(1);
+    expect(state.notification_status?.unread).toBe(1);
+    expect(state.notification_status?.unseen).toBe(1);
+  });
+
+  it('drops the group and keeps unread/unseen unchanged when a non-matching activity is added', async () => {
+    const updated = waitForEvent(feed, 'feeds.notification_feed.updated');
+    void serverClient.feeds.addActivity({
+      type: 'comment',
+      feeds: [feed.feed],
+      text: 'red comment',
+      filter_tags: ['red'],
+      user_id: user.id,
+    });
+    await updated;
+
+    const state = feed.state.getLatestValue();
+    expect(state.aggregated_activities).toHaveLength(1);
+    expect(state.notification_status?.unread).toBe(1);
+    expect(state.notification_status?.unseen).toBe(1);
+  });
+
+  it('adds existing group if a matching activity is added', async () => {
+    const updated = waitForEvent(feed, 'feeds.notification_feed.updated');
+    void serverClient.feeds.addActivity({
+      type: 'comment',
+      feeds: [feed.feed],
+      text: 'blue comment',
+      filter_tags: ['blue'],
+      user_id: user.id,
+    });
+    await updated;
+
+    const state = feed.state.getLatestValue();
+    expect(state.aggregated_activities).toHaveLength(2);
+    expect(state.notification_status?.unread).toBe(2);
+    expect(state.notification_status?.unseen).toBe(2);
+  });
+
+  it('adds a third aggregated group and increments unread/unseen when another matching activity of a new type is added', async () => {
+    const updated = waitForEvent(feed, 'feeds.notification_feed.updated');
+    void serverClient.feeds.addActivity({
+      type: 'like',
+      feeds: [feed.feed],
+      text: 'blue like',
+      filter_tags: ['blue'],
+      user_id: user.id,
+    });
+    await updated;
+
+    const state = feed.state.getLatestValue();
+    expect(state.aggregated_activities).toHaveLength(3);
+    expect(state.notification_status?.unread).toBe(3);
+    expect(state.notification_status?.unseen).toBe(3);
+  });
+
+  it('decrements unread via delta when an existing group is marked as read', async () => {
+    const firstGroup = feed.state.getLatestValue().aggregated_activities?.[0]!;
+
+    const updated = waitForEvent(feed, 'feeds.notification_feed.updated');
+    await feed.markActivity({ mark_read: [firstGroup.group] });
+    await updated;
+
+    const state = feed.state.getLatestValue();
+    expect(state.aggregated_activities).toHaveLength(3);
+    expect(state.notification_status?.unread).toBe(2);
+    expect(state.notification_status?.unseen).toBe(3);
+
+    const groupAfter = state.aggregated_activities?.find(
+      (g) => g.group === firstGroup.group,
+    );
+    expect(groupAfter?.is_read).toBe(true);
+  });
+
+  afterAll(async () => {
+    await feed.delete({ hard_delete: true });
+    await client.disconnectUser();
+  });
+});

--- a/packages/feeds-client/src/feed/activity-filter.test.ts
+++ b/packages/feeds-client/src/feed/activity-filter.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { activityFilter } from './activity-filter';
+import { activityFilter, filterAggregatedActivities } from './activity-filter';
 import type { GetOrCreateFeedRequest } from '../gen/models';
-import { generateActivityResponse } from '../test-utils';
+import {
+  createMockAggregatedActivity,
+  generateActivityResponse,
+} from '../test-utils';
 
 describe('activityFilter', () => {
   it('returns true when requestConfig is undefined', () => {
@@ -173,5 +176,160 @@ describe('activityFilter', () => {
         },
       }),
     ).toBe(false);
+  });
+});
+
+describe('filterAggregatedActivities', () => {
+  it('returns input unchanged when requestConfig is undefined', () => {
+    const groups = [
+      createMockAggregatedActivity({
+        group: 'g1',
+        activities: [generateActivityResponse({ filter_tags: ['blue'] })],
+      }),
+    ];
+    expect(filterAggregatedActivities(groups, undefined)).toBe(groups);
+  });
+
+  it('returns input unchanged when filter is empty', () => {
+    const groups = [
+      createMockAggregatedActivity({
+        group: 'g1',
+        activities: [generateActivityResponse({ filter_tags: ['blue'] })],
+      }),
+    ];
+    expect(filterAggregatedActivities(groups, { filter: {} })).toBe(groups);
+  });
+
+  it('keeps a group with only the matching activities', () => {
+    const matching = generateActivityResponse({
+      id: 'a-match',
+      filter_tags: ['blue'],
+    });
+    const notMatching = generateActivityResponse({
+      id: 'a-miss',
+      filter_tags: ['red'],
+    });
+    const groups = [
+      createMockAggregatedActivity({
+        group: 'g1',
+        activities: [matching, notMatching],
+      }),
+    ];
+
+    const result = filterAggregatedActivities(groups, {
+      filter: { filter_tags: ['blue'] },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].group).toBe('g1');
+    expect(result[0].activities).toHaveLength(1);
+    expect(result[0].activities[0].id).toBe('a-match');
+  });
+
+  it('drops a group entirely when no activity matches the filter', () => {
+    const groups = [
+      createMockAggregatedActivity({
+        group: 'g1',
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['red'] }),
+          generateActivityResponse({ id: 'a2', filter_tags: ['green'] }),
+        ],
+      }),
+    ];
+
+    const result = filterAggregatedActivities(groups, {
+      filter: { filter_tags: ['blue'] },
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('keeps groups that have at least one matching activity and drops groups with none', () => {
+    const groups = [
+      createMockAggregatedActivity({
+        group: 'g-match',
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['blue'] }),
+          generateActivityResponse({ id: 'a2', filter_tags: ['red'] }),
+        ],
+      }),
+      createMockAggregatedActivity({
+        group: 'g-miss',
+        activities: [
+          generateActivityResponse({ id: 'a3', filter_tags: ['red'] }),
+        ],
+      }),
+    ];
+
+    const result = filterAggregatedActivities(groups, {
+      filter: { filter_tags: ['blue'] },
+    });
+
+    expect(result.map((g) => g.group)).toEqual(['g-match']);
+    expect(result[0].activities).toHaveLength(1);
+    expect(result[0].activities[0].id).toBe('a1');
+  });
+
+  it('applies activity_type filter to activities inside groups', () => {
+    const groups = [
+      createMockAggregatedActivity({
+        group: 'g1',
+        activities: [
+          generateActivityResponse({ id: 'a1', type: 'hike' }),
+          generateActivityResponse({ id: 'a2', type: 'post' }),
+        ],
+      }),
+    ];
+
+    const result = filterAggregatedActivities(groups, {
+      filter: { activity_type: 'hike' },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].activities.map((a) => a.id)).toEqual(['a1']);
+  });
+
+  it('preserves server-aggregated counts on the kept group', () => {
+    const groups = [
+      createMockAggregatedActivity({
+        group: 'g1',
+        activity_count: 99,
+        user_count: 42,
+        score: 7,
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['blue'] }),
+          generateActivityResponse({ id: 'a2', filter_tags: ['red'] }),
+        ],
+      }),
+    ];
+
+    const result = filterAggregatedActivities(groups, {
+      filter: { filter_tags: ['blue'] },
+    });
+
+    expect(result[0].activity_count).toBe(99);
+    expect(result[0].user_count).toBe(42);
+    expect(result[0].score).toBe(7);
+  });
+
+  it('does not mutate the input groups or their activity arrays', () => {
+    const matching = generateActivityResponse({
+      id: 'a-match',
+      filter_tags: ['blue'],
+    });
+    const notMatching = generateActivityResponse({
+      id: 'a-miss',
+      filter_tags: ['red'],
+    });
+    const group = createMockAggregatedActivity({
+      group: 'g1',
+      activities: [matching, notMatching],
+    });
+    const originalActivities = group.activities;
+
+    filterAggregatedActivities([group], { filter: { filter_tags: ['blue'] } });
+
+    expect(group.activities).toBe(originalActivities);
+    expect(group.activities).toHaveLength(2);
   });
 });

--- a/packages/feeds-client/src/feed/activity-filter.test.ts
+++ b/packages/feeds-client/src/feed/activity-filter.test.ts
@@ -289,7 +289,7 @@ describe('filterAggregatedActivities', () => {
     expect(result[0].activities.map((a) => a.id)).toEqual(['a1']);
   });
 
-  it('preserves server-aggregated counts on the kept group', () => {
+  it('decreases activity_count by the number of filtered-out activities and preserves other server-aggregated counts', () => {
     const groups = [
       createMockAggregatedActivity({
         group: 'g1',
@@ -307,9 +307,48 @@ describe('filterAggregatedActivities', () => {
       filter: { filter_tags: ['blue'] },
     });
 
-    expect(result[0].activity_count).toBe(99);
+    expect(result[0].activity_count).toBe(98);
     expect(result[0].user_count).toBe(42);
     expect(result[0].score).toBe(7);
+  });
+
+  it('keeps activity_count unchanged when no activities are filtered out of a kept group', () => {
+    const groups = [
+      createMockAggregatedActivity({
+        group: 'g1',
+        activity_count: 5,
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['blue'] }),
+          generateActivityResponse({ id: 'a2', filter_tags: ['blue'] }),
+        ],
+      }),
+    ];
+
+    const result = filterAggregatedActivities(groups, {
+      filter: { filter_tags: ['blue'] },
+    });
+
+    expect(result[0].activity_count).toBe(5);
+  });
+
+  it('floors activity_count at 0 if more activities are filtered out than the server-reported count', () => {
+    const groups = [
+      createMockAggregatedActivity({
+        group: 'g1',
+        activity_count: 1,
+        activities: [
+          generateActivityResponse({ id: 'a-match', filter_tags: ['blue'] }),
+          generateActivityResponse({ id: 'a-miss-1', filter_tags: ['red'] }),
+          generateActivityResponse({ id: 'a-miss-2', filter_tags: ['red'] }),
+        ],
+      }),
+    ];
+
+    const result = filterAggregatedActivities(groups, {
+      filter: { filter_tags: ['blue'] },
+    });
+
+    expect(result[0].activity_count).toBe(0);
   });
 
   it('does not mutate the input groups or their activity arrays', () => {

--- a/packages/feeds-client/src/feed/activity-filter.ts
+++ b/packages/feeds-client/src/feed/activity-filter.ts
@@ -1,5 +1,9 @@
 import { itemMatchesFilter, resolveDotPathValue } from '@stream-io/filter';
-import type { ActivityResponse, GetOrCreateFeedRequest } from '../gen/models';
+import type {
+  ActivityResponse,
+  AggregatedActivityResponse,
+  GetOrCreateFeedRequest,
+} from '../gen/models';
 
 /**
  * Resolvers that map feed filter field names to activity properties.
@@ -41,4 +45,40 @@ export function activityFilter(
     resolvers: [...activityResolvers],
     arrayEqMode: 'contains',
   });
+}
+
+/**
+ * Applies the feed's getOrCreate filter to an array of aggregated activity groups.
+ *
+ * For each group, individual activities that don't match the filter are removed.
+ * A group is kept only if at least one activity matches; otherwise the whole
+ * group is dropped. Server-aggregated metadata (`activity_count`, `user_count`,
+ * `score`, etc.) is preserved as-is — only the `activities` array is trimmed.
+ *
+ * If `requestConfig` has no filter (or an empty filter), the input array is
+ * returned as-is to preserve referential equality.
+ */
+export function filterAggregatedActivities(
+  aggregatedActivities: AggregatedActivityResponse[],
+  requestConfig?: GetOrCreateFeedRequest,
+): AggregatedActivityResponse[] {
+  const filter = requestConfig?.filter;
+  if (
+    !filter ||
+    typeof filter !== 'object' ||
+    Object.keys(filter).length === 0
+  ) {
+    return aggregatedActivities;
+  }
+
+  const result: AggregatedActivityResponse[] = [];
+  for (const group of aggregatedActivities) {
+    const matching = group.activities.filter((activity) =>
+      activityFilter(activity, requestConfig),
+    );
+    if (matching.length > 0) {
+      result.push({ ...group, activities: matching });
+    }
+  }
+  return result;
 }

--- a/packages/feeds-client/src/feed/activity-filter.ts
+++ b/packages/feeds-client/src/feed/activity-filter.ts
@@ -52,8 +52,9 @@ export function activityFilter(
  *
  * For each group, individual activities that don't match the filter are removed.
  * A group is kept only if at least one activity matches; otherwise the whole
- * group is dropped. Server-aggregated metadata (`activity_count`, `user_count`,
- * `score`, etc.) is preserved as-is — only the `activities` array is trimmed.
+ * group is dropped. `activity_count` is decreased by the number of activities
+ * filtered out; other server-aggregated metadata (`user_count`, `score`, etc.)
+ * is preserved as-is.
  *
  * If `requestConfig` has no filter (or an empty filter), the input array is
  * returned as-is to preserve referential equality.
@@ -77,7 +78,12 @@ export function filterAggregatedActivities(
       activityFilter(activity, requestConfig),
     );
     if (matching.length > 0) {
-      result.push({ ...group, activities: matching });
+      const removed = group.activities.length - matching.length;
+      result.push({
+        ...group,
+        activities: matching,
+        activity_count: Math.max(0, group.activity_count - removed),
+      });
     }
   }
   return result;

--- a/packages/feeds-client/src/feed/event-handlers/notification-feed/handle-notification-feed-updated.test.ts
+++ b/packages/feeds-client/src/feed/event-handlers/notification-feed/handle-notification-feed-updated.test.ts
@@ -379,6 +379,147 @@ describe('notification-feed-utils', () => {
       expect(groups?.every((g) => g.is_seen === true)).toBe(true);
     });
   });
+
+  describe('aggregated_activities filtering by requestConfig', () => {
+    it('drops groups whose activities do not match the filter', () => {
+      const matchingGroup = createMockAggregatedActivity({
+        group: 'g-match',
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['blue'] }),
+        ],
+      });
+      const missingGroup = createMockAggregatedActivity({
+        group: 'g-miss',
+        activities: [
+          generateActivityResponse({ id: 'a2', filter_tags: ['red'] }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        aggregated_activities: [matchingGroup, missingGroup],
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [],
+        undefined,
+        undefined,
+        { filter: { filter_tags: ['blue'] } },
+      );
+
+      expect(result.changed).toBe(true);
+      expect(result.data?.aggregated_activities?.map((g) => g.group)).toEqual([
+        'g-match',
+      ]);
+    });
+
+    it('keeps a group but trims its activities to only those matching the filter', () => {
+      const group = createMockAggregatedActivity({
+        group: 'g1',
+        activities: [
+          generateActivityResponse({ id: 'a-match', filter_tags: ['blue'] }),
+          generateActivityResponse({ id: 'a-miss', filter_tags: ['red'] }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        aggregated_activities: [group],
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [],
+        undefined,
+        undefined,
+        { filter: { filter_tags: ['blue'] } },
+      );
+
+      const merged = result.data?.aggregated_activities;
+      expect(merged).toHaveLength(1);
+      expect(merged?.[0].activities.map((a) => a.id)).toEqual(['a-match']);
+    });
+
+    it('passes aggregated_activities through unchanged when requestConfig has no filter', () => {
+      const group = createMockAggregatedActivity({
+        group: 'g1',
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['red'] }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        aggregated_activities: [group],
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [],
+        undefined,
+        undefined,
+        { limit: 10 },
+      );
+
+      expect(result.data?.aggregated_activities).toHaveLength(1);
+      expect(result.data?.aggregated_activities?.[0].group).toBe('g1');
+    });
+
+    it('applies activity_type filter to event groups', () => {
+      const group = createMockAggregatedActivity({
+        group: 'g1',
+        activities: [
+          generateActivityResponse({ id: 'a1', type: 'hike' }),
+          generateActivityResponse({ id: 'a2', type: 'post' }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        aggregated_activities: [group],
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [],
+        undefined,
+        undefined,
+        { filter: { activity_type: 'hike' } },
+      );
+
+      const merged = result.data?.aggregated_activities;
+      expect(merged).toHaveLength(1);
+      expect(merged?.[0].activities.map((a) => a.id)).toEqual(['a1']);
+    });
+
+    it('replaces an existing group with its filtered version (replace-then-start merge)', () => {
+      const existingGroup = createMockAggregatedActivity({
+        group: 'g1',
+        activities: [
+          generateActivityResponse({ id: 'a-old', filter_tags: ['blue'] }),
+        ],
+      });
+      const incomingGroup = createMockAggregatedActivity({
+        group: 'g1',
+        activities: [
+          generateActivityResponse({
+            id: 'a-new-match',
+            filter_tags: ['blue'],
+          }),
+          generateActivityResponse({ id: 'a-new-miss', filter_tags: ['red'] }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        aggregated_activities: [incomingGroup],
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [existingGroup],
+        undefined,
+        undefined,
+        { filter: { filter_tags: ['blue'] } },
+      );
+
+      const merged = result.data?.aggregated_activities;
+      expect(merged).toHaveLength(1);
+      expect(merged?.[0].group).toBe('g1');
+      expect(merged?.[0].activities.map((a) => a.id)).toEqual(['a-new-match']);
+    });
+  });
 });
 
 describe(handleNotificationFeedUpdated.name, () => {
@@ -402,6 +543,43 @@ describe(handleNotificationFeedUpdated.name, () => {
       feedResponse.id,
       feedResponse,
     );
+  });
+
+  it('drops event groups that do not match the feed-level filter stored in last_get_or_create_request_config', () => {
+    const matchingGroup = createMockAggregatedActivity({
+      group: 'g-match',
+      activities: [
+        generateActivityResponse({ id: 'a1', filter_tags: ['blue'] }),
+        generateActivityResponse({ id: 'a2', filter_tags: ['red'] }),
+      ],
+    });
+    const missingGroup = createMockAggregatedActivity({
+      group: 'g-miss',
+      activities: [
+        generateActivityResponse({ id: 'a3', filter_tags: ['red'] }),
+      ],
+    });
+
+    feed.state.partialNext({
+      aggregated_activities: [],
+      last_get_or_create_request_config: {
+        filter: { filter_tags: ['blue'] },
+      },
+    });
+
+    const event = createMockNotificationFeedUpdatedEvent({
+      aggregated_activities: [matchingGroup, missingGroup],
+    });
+
+    handleNotificationFeedUpdated.call(
+      feed,
+      event as Parameters<typeof handleNotificationFeedUpdated>[1],
+    );
+
+    const aggregated = feed.currentState.aggregated_activities;
+    expect(aggregated).toHaveLength(1);
+    expect(aggregated?.[0].group).toBe('g-match');
+    expect(aggregated?.[0].activities.map((a) => a.id)).toEqual(['a1']);
   });
 
   it('keeps aggregated_activities when a status-only event refreshes last_seen_at and groups are unchanged', () => {

--- a/packages/feeds-client/src/feed/event-handlers/notification-feed/handle-notification-feed-updated.test.ts
+++ b/packages/feeds-client/src/feed/event-handlers/notification-feed/handle-notification-feed-updated.test.ts
@@ -730,7 +730,7 @@ describe('notification-feed-utils', () => {
       expect(result.data?.notification_status?.unseen).toBe(4);
     });
 
-    it('falls back to the event value as base when currentNotificationStatus is undefined', () => {
+    it('copies event notification_status verbatim when currentNotificationStatus is undefined (no base for delta)', () => {
       const newGroup = createMockAggregatedActivity({
         group: 'g-new',
         is_read: false,
@@ -755,8 +755,8 @@ describe('notification-feed-utils', () => {
         filteredConfig,
       );
 
-      expect(result.data?.notification_status?.unread).toBe(6);
-      expect(result.data?.notification_status?.unseen).toBe(6);
+      expect(result.data?.notification_status?.unread).toBe(5);
+      expect(result.data?.notification_status?.unseen).toBe(5);
     });
 
     it('keeps current unread/unseen when neither aggregated_activities nor flags change', () => {

--- a/packages/feeds-client/src/feed/event-handlers/notification-feed/handle-notification-feed-updated.test.ts
+++ b/packages/feeds-client/src/feed/event-handlers/notification-feed/handle-notification-feed-updated.test.ts
@@ -520,6 +520,314 @@ describe('notification-feed-utils', () => {
       expect(merged?.[0].activities.map((a) => a.id)).toEqual(['a-new-match']);
     });
   });
+
+  describe('notification_status delta logic for filtered aggregated feeds', () => {
+    const filteredConfig = { filter: { filter_tags: ['blue'] } };
+
+    it('increments unread/unseen by 1 when a filter-matching unread group is added', () => {
+      const newGroup = createMockAggregatedActivity({
+        group: 'g-new',
+        is_read: false,
+        is_seen: false,
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['blue'] }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        aggregated_activities: [newGroup],
+        notification_status: createMockNotificationStatus({
+          unread: 5,
+          unseen: 5,
+        }),
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [],
+        createMockNotificationStatus({ unread: 3, unseen: 3 }),
+        undefined,
+        filteredConfig,
+      );
+
+      expect(result.data?.notification_status?.unread).toBe(4);
+      expect(result.data?.notification_status?.unseen).toBe(4);
+    });
+
+    it('keeps unread/unseen unchanged when a non-matching unread group is filtered out', () => {
+      const missingGroup = createMockAggregatedActivity({
+        group: 'g-miss',
+        is_read: false,
+        is_seen: false,
+        activities: [
+          generateActivityResponse({ id: 'a-miss', filter_tags: ['red'] }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        aggregated_activities: [missingGroup],
+        notification_status: createMockNotificationStatus({
+          unread: 5,
+          unseen: 5,
+        }),
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [],
+        createMockNotificationStatus({ unread: 3, unseen: 3 }),
+        undefined,
+        filteredConfig,
+      );
+
+      expect(result.data?.notification_status?.unread).toBe(3);
+      expect(result.data?.notification_status?.unseen).toBe(3);
+    });
+
+    it('decrements unread when last_read_at flips an existing group to read', () => {
+      const existingGroup = createMockAggregatedActivity({
+        group: 'g1',
+        updated_at: new Date('2023-01-01'),
+        is_read: false,
+        is_seen: false,
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['blue'] }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        notification_status: createMockNotificationStatus({
+          unread: 5,
+          unseen: 5,
+          last_read_at: new Date('2023-06-01'),
+        }),
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [existingGroup],
+        createMockNotificationStatus({ unread: 3, unseen: 3 }),
+        undefined,
+        filteredConfig,
+      );
+
+      expect(result.data?.notification_status?.unread).toBe(2);
+      expect(result.data?.notification_status?.unseen).toBe(3);
+    });
+
+    it('copies last_read_at, last_seen_at, read_activities, seen_activities verbatim from the event', () => {
+      const lastReadAt = new Date('2023-06-01');
+      const lastSeenAt = new Date('2023-07-01');
+      const event = createMockNotificationFeedUpdatedEvent({
+        notification_status: createMockNotificationStatus({
+          unread: 5,
+          unseen: 5,
+          last_read_at: lastReadAt,
+          last_seen_at: lastSeenAt,
+          read_activities: ['g-read-1', 'g-read-2'],
+          seen_activities: ['g-seen-1'],
+        }),
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [],
+        createMockNotificationStatus({ unread: 1, unseen: 1 }),
+        undefined,
+        filteredConfig,
+      );
+
+      const status = result.data?.notification_status;
+      expect(status?.last_read_at).toEqual(lastReadAt);
+      expect(status?.last_seen_at).toEqual(lastSeenAt);
+      expect(status?.read_activities).toEqual(['g-read-1', 'g-read-2']);
+      expect(status?.seen_activities).toEqual(['g-seen-1']);
+    });
+
+    it('clamps unread/unseen to 0 when the delta would push them negative', () => {
+      const existingGroup = createMockAggregatedActivity({
+        group: 'g1',
+        updated_at: new Date('2023-01-01'),
+        is_read: false,
+        is_seen: false,
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['blue'] }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        notification_status: createMockNotificationStatus({
+          unread: 1,
+          unseen: 1,
+          last_read_at: new Date('2023-06-01'),
+          last_seen_at: new Date('2023-06-01'),
+        }),
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [existingGroup],
+        createMockNotificationStatus({ unread: 0, unseen: 0 }),
+        undefined,
+        filteredConfig,
+      );
+
+      expect(result.data?.notification_status?.unread).toBe(0);
+      expect(result.data?.notification_status?.unseen).toBe(0);
+    });
+
+    it('short-circuits to 0 when the event reports unread=0 or unseen=0', () => {
+      const newGroup = createMockAggregatedActivity({
+        group: 'g-new',
+        is_read: false,
+        is_seen: false,
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['blue'] }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        aggregated_activities: [newGroup],
+        notification_status: createMockNotificationStatus({
+          unread: 0,
+          unseen: 0,
+        }),
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [],
+        createMockNotificationStatus({ unread: 10, unseen: 10 }),
+        undefined,
+        filteredConfig,
+      );
+
+      expect(result.data?.notification_status?.unread).toBe(0);
+      expect(result.data?.notification_status?.unseen).toBe(0);
+    });
+
+    it('short-circuits unread and unseen independently', () => {
+      const newGroup = createMockAggregatedActivity({
+        group: 'g-new',
+        is_read: false,
+        is_seen: false,
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['blue'] }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        aggregated_activities: [newGroup],
+        notification_status: createMockNotificationStatus({
+          unread: 0,
+          unseen: 5,
+        }),
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [],
+        createMockNotificationStatus({ unread: 3, unseen: 3 }),
+        undefined,
+        filteredConfig,
+      );
+
+      expect(result.data?.notification_status?.unread).toBe(0);
+      expect(result.data?.notification_status?.unseen).toBe(4);
+    });
+
+    it('falls back to the event value as base when currentNotificationStatus is undefined', () => {
+      const newGroup = createMockAggregatedActivity({
+        group: 'g-new',
+        is_read: false,
+        is_seen: false,
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['blue'] }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        aggregated_activities: [newGroup],
+        notification_status: createMockNotificationStatus({
+          unread: 5,
+          unseen: 5,
+        }),
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [],
+        undefined,
+        undefined,
+        filteredConfig,
+      );
+
+      expect(result.data?.notification_status?.unread).toBe(6);
+      expect(result.data?.notification_status?.unseen).toBe(6);
+    });
+
+    it('keeps current unread/unseen when neither aggregated_activities nor flags change', () => {
+      const event = createMockNotificationFeedUpdatedEvent({
+        notification_status: createMockNotificationStatus({
+          unread: 99,
+          unseen: 99,
+        }),
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [],
+        createMockNotificationStatus({ unread: 3, unseen: 3 }),
+        undefined,
+        filteredConfig,
+      );
+
+      expect(result.data?.notification_status?.unread).toBe(3);
+      expect(result.data?.notification_status?.unseen).toBe(3);
+    });
+
+    it('uses full copy (no delta) when the request has no filter', () => {
+      const newGroup = createMockAggregatedActivity({
+        group: 'g-new',
+        is_read: false,
+        is_seen: false,
+        activities: [
+          generateActivityResponse({ id: 'a1', filter_tags: ['blue'] }),
+        ],
+      });
+      const event = createMockNotificationFeedUpdatedEvent({
+        aggregated_activities: [newGroup],
+        notification_status: createMockNotificationStatus({
+          unread: 9,
+          unseen: 9,
+        }),
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        [],
+        createMockNotificationStatus({ unread: 3, unseen: 3 }),
+        undefined,
+        { limit: 10 },
+      );
+
+      expect(result.data?.notification_status?.unread).toBe(9);
+      expect(result.data?.notification_status?.unseen).toBe(9);
+    });
+
+    it('uses full copy (no delta) for a flat feed even when filter is active', () => {
+      const event = createMockNotificationFeedUpdatedEvent({
+        notification_status: createMockNotificationStatus({
+          unread: 9,
+          unseen: 9,
+        }),
+      });
+
+      const result = updateNotificationFeedFromEvent(
+        event,
+        undefined,
+        createMockNotificationStatus({ unread: 3, unseen: 3 }),
+        undefined,
+        filteredConfig,
+      );
+
+      expect(result.data?.notification_status?.unread).toBe(9);
+      expect(result.data?.notification_status?.unseen).toBe(9);
+    });
+  });
 });
 
 describe(handleNotificationFeedUpdated.name, () => {

--- a/packages/feeds-client/src/feed/event-handlers/notification-feed/handle-notification-feed-updated.ts
+++ b/packages/feeds-client/src/feed/event-handlers/notification-feed/handle-notification-feed-updated.ts
@@ -140,7 +140,7 @@ export const updateNotificationFeedFromEvent = (
       !!filter && typeof filter === 'object' && Object.keys(filter).length > 0;
     const isAggregatedFeed = currentAggregatedActivities !== undefined;
 
-    if (hasFilter && isAggregatedFeed) {
+    if (hasFilter && isAggregatedFeed && currentNotificationStatus) {
       const finalAggregated =
         updates.aggregated_activities ?? currentAggregatedActivities ?? [];
       const before = currentAggregatedActivities ?? [];
@@ -154,7 +154,7 @@ export const updateNotificationFeedFromEvent = (
           ? 0
           : Math.max(
               0,
-              (currentNotificationStatus?.unread ?? eventUnread) +
+              currentNotificationStatus.unread +
                 (countGroupsWithFlag(finalAggregated, 'is_read', false) -
                   countGroupsWithFlag(before, 'is_read', false)),
             );
@@ -163,7 +163,7 @@ export const updateNotificationFeedFromEvent = (
           ? 0
           : Math.max(
               0,
-              (currentNotificationStatus?.unseen ?? eventUnseen) +
+              currentNotificationStatus.unseen +
                 (countGroupsWithFlag(finalAggregated, 'is_seen', false) -
                   countGroupsWithFlag(before, 'is_seen', false)),
             );

--- a/packages/feeds-client/src/feed/event-handlers/notification-feed/handle-notification-feed-updated.ts
+++ b/packages/feeds-client/src/feed/event-handlers/notification-feed/handle-notification-feed-updated.ts
@@ -34,6 +34,12 @@ export const updateNotificationStatus = (
   }
 };
 
+const countGroupsWithFlag = (
+  groups: AggregatedActivityResponse[],
+  flag: 'is_read' | 'is_seen',
+  value: boolean,
+) => groups.reduce((n, g) => (g[flag] === value ? n + 1 : n), 0);
+
 export const updateNotificationFeedFromEvent = (
   event: NotificationFeedUpdatedEvent,
   currentAggregatedActivities?: AggregatedActivityResponse[],
@@ -52,18 +58,6 @@ export const updateNotificationFeedFromEvent = (
     aggregated_activities?: AggregatedActivityResponse[];
     activities?: ActivityResponse[];
   } = {};
-
-  if (event.notification_status) {
-    const notificationStatusResult = updateNotificationStatus(
-      event.notification_status,
-      currentNotificationStatus,
-    );
-
-    if (notificationStatusResult.changed) {
-      updates.notification_status =
-        notificationStatusResult.notification_status;
-    }
-  }
 
   // Determine effective notification status (prefer new from event, fall back to current)
   const effectiveStatus =
@@ -120,7 +114,6 @@ export const updateNotificationFeedFromEvent = (
     }
   }
 
-  // Leave this to the end, because notification_status may not be 100% accurate (only includes last 100 activities)
   if (event.aggregated_activities && currentAggregatedActivities) {
     const filteredAggregated = filterAggregatedActivities(
       event.aggregated_activities,
@@ -135,6 +128,61 @@ export const updateNotificationFeedFromEvent = (
     if (aggregatedActivitiesResult.changed) {
       updates.aggregated_activities =
         aggregatedActivitiesResult.aggregated_activities;
+    }
+  }
+
+  // Update notification_status. For filtered aggregated feeds, derive unread/unseen
+  // by delta from aggregated_activities changes — the server's counts are computed
+  // across all groups regardless of client-side filtering.
+  if (event.notification_status) {
+    const filter = requestConfig?.filter;
+    const hasFilter =
+      !!filter && typeof filter === 'object' && Object.keys(filter).length > 0;
+    const isAggregatedFeed = currentAggregatedActivities !== undefined;
+
+    if (hasFilter && isAggregatedFeed) {
+      const finalAggregated =
+        updates.aggregated_activities ?? currentAggregatedActivities ?? [];
+      const before = currentAggregatedActivities ?? [];
+
+      const eventUnread = event.notification_status.unread;
+      const eventUnseen = event.notification_status.unseen;
+
+      // Server-side 0 → filtered count is also 0 (filtering can only remove groups).
+      const unread =
+        eventUnread === 0
+          ? 0
+          : Math.max(
+              0,
+              (currentNotificationStatus?.unread ?? eventUnread) +
+                (countGroupsWithFlag(finalAggregated, 'is_read', false) -
+                  countGroupsWithFlag(before, 'is_read', false)),
+            );
+      const unseen =
+        eventUnseen === 0
+          ? 0
+          : Math.max(
+              0,
+              (currentNotificationStatus?.unseen ?? eventUnseen) +
+                (countGroupsWithFlag(finalAggregated, 'is_seen', false) -
+                  countGroupsWithFlag(before, 'is_seen', false)),
+            );
+
+      updates.notification_status = {
+        ...event.notification_status,
+        unread,
+        unseen,
+      };
+    } else {
+      const notificationStatusResult = updateNotificationStatus(
+        event.notification_status,
+        currentNotificationStatus,
+      );
+
+      if (notificationStatusResult.changed) {
+        updates.notification_status =
+          notificationStatusResult.notification_status;
+      }
     }
   }
 

--- a/packages/feeds-client/src/feed/event-handlers/notification-feed/handle-notification-feed-updated.ts
+++ b/packages/feeds-client/src/feed/event-handlers/notification-feed/handle-notification-feed-updated.ts
@@ -2,10 +2,12 @@ import type { Feed } from '../..';
 import type {
   ActivityResponse,
   AggregatedActivityResponse,
+  GetOrCreateFeedRequest,
   NotificationFeedUpdatedEvent,
   NotificationStatusResponse,
 } from '../../../gen/models';
 import type { EventPayload, UpdateStateResult } from '../../../types-internal';
+import { filterAggregatedActivities } from '../../activity-filter';
 import { addAggregatedActivitiesToState } from '../add-aggregated-activities-to-state';
 
 export const updateNotificationStatus = (
@@ -37,6 +39,7 @@ export const updateNotificationFeedFromEvent = (
   currentAggregatedActivities?: AggregatedActivityResponse[],
   currentNotificationStatus?: NotificationStatusResponse,
   currentActivities?: ActivityResponse[],
+  requestConfig?: GetOrCreateFeedRequest,
 ): UpdateStateResult<{
   data?: {
     notification_status?: NotificationStatusResponse;
@@ -119,8 +122,12 @@ export const updateNotificationFeedFromEvent = (
 
   // Leave this to the end, because notification_status may not be 100% accurate (only includes last 100 activities)
   if (event.aggregated_activities && currentAggregatedActivities) {
-    const aggregatedActivitiesResult = addAggregatedActivitiesToState(
+    const filteredAggregated = filterAggregatedActivities(
       event.aggregated_activities,
+      requestConfig,
+    );
+    const aggregatedActivitiesResult = addAggregatedActivitiesToState(
+      filteredAggregated,
       updates.aggregated_activities ?? currentAggregatedActivities,
       'replace-then-start',
     );
@@ -152,6 +159,7 @@ export function handleNotificationFeedUpdated(
     this.currentState.aggregated_activities,
     this.currentState.notification_status,
     this.currentState.activities,
+    this.currentState.last_get_or_create_request_config,
   );
   if (result.changed) {
     this.state.partialNext({


### PR DESCRIPTION
https://github.com/GetStream/stream-feeds-js/issues/277 

Applies `filters` in the `feeds.notification_feed_updated` WS event handler. Logic: if any activity within an aggregated activity group matches the filter, the group is added/updated to the notification feed. If a group is removed, the `unread/unseen` count in `notification_status` is adjusted. If the group contains activities not matching the filter, the given activity is removed (and the group's `activity_count` is decreased)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented filtering support for aggregated notification feeds.

* **Tests**
  * Added integration tests for filtered aggregated notification feeds.
  * Expanded activity filter test coverage with aggregated activity scenarios.
  * Added comprehensive tests for notification status delta logic with filters applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-feeds-js/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->