### PR TITLE
feat: new endpoint for fetching user interests and opt-in flag for purge user…

### DIFF
--- a/packages/feeds-client/src/gen/feeds/FeedApi.ts
+++ b/packages/feeds-client/src/gen/feeds/FeedApi.ts
@@ -33,6 +33,7 @@ export class FeedApi {
 
   delete(request?: {
     hard_delete?: boolean;
+    purge_user_activities?: boolean;
   }): Promise<StreamResponse<DeleteFeedResponse>> {
     return this.feedsApi.deleteFeed({
       feed_id: this.id,

--- a/packages/feeds-client/src/gen/feeds/FeedsApi.ts
+++ b/packages/feeds-client/src/gen/feeds/FeedsApi.ts
@@ -70,6 +70,7 @@ import type {
   GetOrCreateUnfollowRequest,
   GetOrCreateUnfollowResponse,
   GetUserGroupResponse,
+  GetUserInterestsResponse,
   ImageUploadRequest,
   ImageUploadResponse,
   ListBlockListResponse,
@@ -1545,9 +1546,11 @@ export class FeedsApi {
     feed_group_id: string;
     feed_id: string;
     hard_delete?: boolean;
+    purge_user_activities?: boolean;
   }): Promise<StreamResponse<DeleteFeedResponse>> {
     const queryParams = {
       hard_delete: request?.hard_delete,
+      purge_user_activities: request?.purge_user_activities,
     };
     const pathParams = {
       feed_group_id: request?.feed_group_id,
@@ -2359,6 +2362,31 @@ export class FeedsApi {
     );
 
     decoders.GetOrCreateUnfollowResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getUserInterests(request: {
+    user_id: string;
+    limit?: number;
+  }): Promise<StreamResponse<GetUserInterestsResponse>> {
+    const queryParams = {
+      limit: request?.limit,
+    };
+    const pathParams = {
+      user_id: request?.user_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetUserInterestsResponse>
+    >(
+      'GET',
+      '/api/v2/feeds/users/{user_id}/interests',
+      pathParams,
+      queryParams,
+    );
+
+    decoders.GetUserInterestsResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/packages/feeds-client/src/gen/models/index.ts
+++ b/packages/feeds-client/src/gen/models/index.ts
@@ -5897,6 +5897,15 @@ export interface GetUserGroupResponse {
   user_group?: UserGroupResponse;
 }
 
+export interface GetUserInterestsResponse {
+  duration: string;
+
+  /**
+   * Top-N interest tags sorted by descending count, then alphabetically by tag
+   */
+  interests: InterestTagResponse[];
+}
+
 export interface GoogleVisionConfig {
   enabled?: boolean;
 }
@@ -6022,6 +6031,18 @@ export interface Images {
   fixed_width_still: ImageData;
 
   original: ImageData;
+}
+
+export interface InterestTagResponse {
+  /**
+   * Number of distinct reacted-to activities tagged with this value
+   */
+  count: number;
+
+  /**
+   * The interest tag value
+   */
+  tag: string;
 }
 
 export interface KeyframeRuleParameters {


### PR DESCRIPTION
new endpoint for fetching user interests + opt-in flag for purge user activities on hard delete feed

🎫 Tickets: 
https://linear.app/stream/issue/FEEDS-1511/new-endpoint-for-retrieving-user-interests
https://linear.app/stream/issue/FEEDS-1460/orphaned-activities-post-feed-delete

### 💡 Overview

### 📝 Implementation notes
