### PR TITLE
chore(CI): add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/cleanup-old-users.yml
+++ b/.github/workflows/cleanup-old-users.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 2 * * *' # Daily at 02:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   lint-and-test:
     timeout-minutes: 30

--- a/.github/workflows/refresh-demo-data.yml
+++ b/.github/workflows/refresh-demo-data.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 */10 * *' # Every 10 days at 00:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   refresh-data:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **3** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
