### PR TITLE
fix: late WS events override state

### DIFF
--- a/packages/feeds-client/src/feed/event-handlers/activity/handle-activity-added.test.ts
+++ b/packages/feeds-client/src/feed/event-handlers/activity/handle-activity-added.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Feed } from '../../../feed';
 import { FeedsClient } from '../../../feeds-client';
 import { handleActivityAdded } from './handle-activity-added';
+import { handleActivityDeleted } from './handle-activity-deleted';
+import type { ActivityResponse } from '../../../gen/models';
 import {
   generateActivityAddedEvent,
   generateActivityResponse,
@@ -141,5 +143,83 @@ describe(handleActivityAdded.name, () => {
     handleActivityAdded.call(feed, event);
     expect(feed.currentState.activities).toHaveLength(1);
     expect(feed.currentState.activities?.[0]).toBe(event.activity);
+  });
+
+  describe('HTTP + WS deduplication (watch)', () => {
+    let watchedFeed: Feed;
+
+    beforeEach(() => {
+      const feedResponse = generateFeedResponse({
+        id: 'watched',
+        group_id: 'user',
+        created_by: { id: currentUserId },
+      });
+      watchedFeed = new Feed(
+        client,
+        feedResponse.group_id,
+        feedResponse.id,
+        feedResponse,
+        true,
+      );
+      watchedFeed.state.partialNext({
+        activities: [],
+        last_get_or_create_request_config: {},
+      });
+    });
+
+    const generateOwnActivity = () =>
+      generateActivityResponse({
+        user: generateUserResponse({ id: currentUserId }),
+      });
+
+    // simulates client.addActivity applying its HTTP response to the feed
+    const applyHttpResponse = (activity: ActivityResponse) =>
+      watchedFeed['addActivityFromHTTPResponse'](activity);
+
+    it('skips the WS broadcast of an add already applied from the HTTP response', () => {
+      const activity = generateOwnActivity();
+
+      applyHttpResponse(activity);
+      expect(watchedFeed.currentState.activities).toHaveLength(1);
+
+      const stateAfterHttp = watchedFeed.currentState;
+      handleActivityAdded.call(watchedFeed, { activity });
+
+      expect(watchedFeed.currentState).toBe(stateAfterHttp);
+      expect(watchedFeed.currentState.activities).toHaveLength(1);
+    });
+
+    it('skips the HTTP response when the WS broadcast arrived first', () => {
+      const activity = generateOwnActivity();
+
+      handleActivityAdded.call(watchedFeed, { activity });
+      expect(watchedFeed.currentState.activities).toHaveLength(1);
+
+      const stateAfterWs = watchedFeed.currentState;
+      applyHttpResponse(activity);
+
+      expect(watchedFeed.currentState).toBe(stateAfterWs);
+      expect(watchedFeed.currentState.activities).toHaveLength(1);
+    });
+
+    it('does not re-add an activity deleted before its delayed WS broadcast arrives', () => {
+      const activity = generateOwnActivity();
+
+      // add, applied from the HTTP response; the WS broadcast is still in flight
+      applyHttpResponse(activity);
+      expect(watchedFeed.currentState.activities).toHaveLength(1);
+
+      // the activity is deleted before the add is broadcast
+      handleActivityDeleted.call(watchedFeed, { activity }, false);
+      expect(watchedFeed.currentState.activities).toHaveLength(0);
+
+      // the delayed add broadcast must not resurrect it
+      handleActivityAdded.call(watchedFeed, { activity });
+      expect(watchedFeed.currentState.activities).toHaveLength(0);
+
+      // ...and the delete broadcast is still deduplicated against its HTTP response
+      handleActivityDeleted.call(watchedFeed, { activity });
+      expect(watchedFeed.currentState.activities).toHaveLength(0);
+    });
   });
 });

--- a/packages/feeds-client/src/feed/event-handlers/activity/handle-activity-added.ts
+++ b/packages/feeds-client/src/feed/event-handlers/activity/handle-activity-added.ts
@@ -1,6 +1,13 @@
 import type { Feed } from '../../feed';
 import type { ActivityResponse } from '../../../gen/models';
-import type { EventPayload } from '../../../types-internal';
+import type { EventPayload, PartializeAllBut } from '../../../types-internal';
+import { getStateUpdateQueueId, shouldUpdateState } from '../../../utils';
+import { eventTriggeredByConnectedUser } from '../../../utils/event-triggered-by-connected-user';
+
+export type ActivityAddedPayload = PartializeAllBut<
+  EventPayload<'feeds.activity.added'>,
+  'activity'
+>;
 
 export function addActivitiesToState(
   this: Feed,
@@ -51,13 +58,43 @@ export function addActivitiesToState(
   return result;
 }
 
+/**
+ * Adding an activity reaches a watched feed twice — once through the HTTP response and
+ * once as a WebSocket broadcast — so the two have to be paired off through the state
+ * update queue.
+ *
+ * `hasActivity` alone is not enough: it only says whether the activity is in state right
+ * now, so a WS broadcast delayed past a subsequent delete would re-add an activity that
+ * has already been removed.
+ */
+export function shouldApplyActivityAdded(
+  this: Feed,
+  activity: ActivityResponse,
+  fromWs: boolean,
+) {
+  return shouldUpdateState({
+    stateUpdateQueueId: getStateUpdateQueueId({ activity }, 'activity-added'),
+    stateUpdateQueue: this.stateUpdateQueue,
+    watch: this.currentState.watch,
+    fromWs,
+    isTriggeredByConnectedUser: eventTriggeredByConnectedUser.call(this, {
+      user: activity.user,
+    }),
+  });
+}
+
 export function handleActivityAdded(
   this: Feed,
-  event: EventPayload<'feeds.activity.added'>,
+  payload: ActivityAddedPayload,
+  fromWs = true,
 ) {
+  if (!shouldApplyActivityAdded.call(this, payload.activity, fromWs)) {
+    return;
+  }
+
   const currentUser = this.client.state.getLatestValue().connected_user;
   const decision = this.resolveNewActivityDecision(
-    event.activity,
+    payload.activity,
     currentUser,
     false,
   );
@@ -67,13 +104,13 @@ export function handleActivityAdded(
   const position = decision === 'add-to-end' ? 'end' : 'start';
   const currentActivities = this.currentState.activities;
   const result = addActivitiesToState.bind(this)(
-    [event.activity],
+    [payload.activity],
     currentActivities,
     position,
     { hasOwnFields: false, backfillOwnFields: true },
   );
   if (result.changed) {
-    const activity = event.activity;
+    const activity = payload.activity;
     this.client.hydratePollCache([activity]);
 
     this.state.partialNext({ activities: result.activities });

--- a/packages/feeds-client/src/feed/event-handlers/bookmark/bookmark-utils.ts
+++ b/packages/feeds-client/src/feed/event-handlers/bookmark/bookmark-utils.ts
@@ -1,0 +1,104 @@
+import type { BookmarkResponse } from '../../../gen/models';
+
+/**
+ * Options shared by the bookmark handlers that need to know where a bookmark used to
+ * live before the change they are applying.
+ */
+export type BookmarkUpdateOptions = {
+  /**
+   * The folder the bookmark was in *before* the update. `updateBookmark` can move a
+   * bookmark between folders, and the payload only carries the new folder, so the
+   * bookmark cannot be located in state by identity alone. The HTTP call site knows the
+   * previous folder from the request (`folder_id`); WS events do not carry it.
+   */
+  previousFolderId?: string;
+};
+
+/**
+ * A bookmark's stable identity. The same user can bookmark the same activity once per
+ * folder, so user + activity + folder is what identifies a single bookmark.
+ *
+ * `updated_at` is deliberately *not* part of the identity. It changes on every update,
+ * so including it would make an out-of-order payload (an HTTP response and a WS
+ * broadcast for the same change can arrive in either order, and either can be delayed
+ * past a subsequent change) look like a different bookmark — which is how duplicates and
+ * undeletable bookmarks end up in state. Use {@link isStaleBookmark} to compare
+ * freshness instead.
+ */
+export const isSameBookmark = (
+  bookmark1: BookmarkResponse,
+  bookmark2: BookmarkResponse,
+): boolean =>
+  bookmark1.user.id === bookmark2.user.id &&
+  bookmark1.activity.id === bookmark2.activity.id &&
+  bookmark1.folder?.id === bookmark2.folder?.id;
+
+/**
+ * True when `bookmark` carries nothing newer than `comparedTo`.
+ *
+ * Equal timestamps count as stale on purpose: the HTTP response and the WS broadcast of
+ * the same change carry the same `updated_at`, so whichever arrives second must be a
+ * no-op.
+ */
+export const isStaleBookmark = (
+  bookmark: BookmarkResponse,
+  comparedTo: BookmarkResponse,
+): boolean => bookmark.updated_at.getTime() <= comparedTo.updated_at.getTime();
+
+/**
+ * Index of `bookmark` in `ownBookmarks` by identity, or -1.
+ */
+export const findBookmarkIndex = (
+  ownBookmarks: BookmarkResponse[],
+  bookmark: BookmarkResponse,
+): number => ownBookmarks.findIndex((b) => isSameBookmark(b, bookmark));
+
+const isSameBookmarkIgnoringFolder = (
+  bookmark1: BookmarkResponse,
+  bookmark2: BookmarkResponse,
+): boolean =>
+  bookmark1.user.id === bookmark2.user.id &&
+  bookmark1.activity.id === bookmark2.activity.id;
+
+/**
+ * Index of the entry an *update* applies to, or -1. Unlike {@link findBookmarkIndex}
+ * this tolerates the bookmark having moved folders, which changes its identity:
+ *
+ * 1. identity match — the folder did not change, or the update was already applied;
+ * 2. the folder the caller says it moved out of (HTTP path only);
+ * 3. the only bookmark this user holds for the activity — WS events carry no previous
+ *    folder, and with a single candidate a move is the only thing it can be. With
+ *    several candidates the move is ambiguous, so nothing is touched.
+ */
+export const findBookmarkIndexForUpdate = (
+  ownBookmarks: BookmarkResponse[],
+  bookmark: BookmarkResponse,
+  options?: BookmarkUpdateOptions,
+): number => {
+  const byIdentity = findBookmarkIndex(ownBookmarks, bookmark);
+
+  if (byIdentity !== -1) {
+    return byIdentity;
+  }
+
+  if (options) {
+    const byPreviousFolder = ownBookmarks.findIndex(
+      (b) =>
+        isSameBookmarkIgnoringFolder(b, bookmark) &&
+        b.folder?.id === options.previousFolderId,
+    );
+
+    if (byPreviousFolder !== -1) {
+      return byPreviousFolder;
+    }
+  }
+
+  const candidates = ownBookmarks.reduce<number[]>((acc, b, index) => {
+    if (isSameBookmarkIgnoringFolder(b, bookmark)) {
+      acc.push(index);
+    }
+    return acc;
+  }, []);
+
+  return candidates.length === 1 ? candidates[0] : -1;
+};

--- a/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-added.test.ts
+++ b/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-added.test.ts
@@ -10,6 +10,7 @@ import {
   getHumanId,
   generateFeedReactionResponse,
   generateBookmarkAddedEvent,
+  generateBookmarkResponse,
 } from '../../../test-utils/response-generators';
 
 describe(handleBookmarkAdded.name, () => {
@@ -205,5 +206,95 @@ describe(handleBookmarkAdded.name, () => {
 
     const stateAfter = feed.currentState;
     expect(stateAfter).toBe(stateBefore);
+  });
+
+  it('ignores a delayed added event for a bookmark that has since been updated', () => {
+    // the HTTP response for addBookmark is applied first, then the bookmark is updated;
+    // the WS broadcast for the original add only arrives afterwards, carrying an older
+    // snapshot of a bookmark we already track — applying it would duplicate the entry
+    const activityId = crypto.randomUUID();
+    const event = generateBookmarkAddedEvent({
+      bookmark: {
+        activity: {
+          id: activityId,
+          own_reactions: [],
+          bookmark_count: 1,
+        },
+        user: { id: currentUserId },
+        updated_at: new Date('2025-08-05T12:00:00Z'),
+      },
+    });
+    const updatedBookmark = generateBookmarkResponse({
+      activity: { id: activityId },
+      user: { id: currentUserId },
+      updated_at: new Date('2025-08-06T12:00:00Z'),
+      custom: { color: 'red' },
+    });
+    const activity = generateActivityResponse({
+      id: activityId,
+      bookmark_count: 1,
+      own_bookmarks: [updatedBookmark],
+      own_reactions: [generateFeedReactionResponse()],
+    });
+    const activityPin = generateActivityPinResponse({
+      activity: { ...activity },
+    });
+    feed.state.partialNext({
+      activities: [activity],
+      pinned_activities: [activityPin],
+    });
+
+    const stateBefore = feed.currentState;
+
+    handleBookmarkAdded.call(feed, event);
+
+    const stateAfter = feed.currentState;
+    expect(stateAfter).toBe(stateBefore);
+    expect(stateAfter.activities![0].own_bookmarks).toEqual([updatedBookmark]);
+    expect(stateAfter.pinned_activities![0].activity.own_bookmarks).toEqual([
+      updatedBookmark,
+    ]);
+  });
+
+  it('replaces the existing entry instead of duplicating it when the added event is fresher', () => {
+    const activityId = crypto.randomUUID();
+    const event = generateBookmarkAddedEvent({
+      bookmark: {
+        activity: {
+          id: activityId,
+          own_reactions: [],
+          bookmark_count: 1,
+        },
+        user: { id: currentUserId },
+        updated_at: new Date('2025-08-06T12:00:00Z'),
+      },
+    });
+    const activity = generateActivityResponse({
+      id: activityId,
+      bookmark_count: 1,
+      own_bookmarks: [
+        generateBookmarkResponse({
+          activity: { id: activityId },
+          user: { id: currentUserId },
+          updated_at: new Date('2025-08-05T12:00:00Z'),
+        }),
+      ],
+      own_reactions: [generateFeedReactionResponse()],
+    });
+    const activityPin = generateActivityPinResponse({
+      activity: { ...activity },
+    });
+    feed.state.partialNext({
+      activities: [activity],
+      pinned_activities: [activityPin],
+    });
+
+    handleBookmarkAdded.call(feed, event);
+
+    const stateAfter = feed.currentState;
+    expect(stateAfter.activities![0].own_bookmarks).toEqual([event.bookmark]);
+    expect(stateAfter.pinned_activities![0].activity.own_bookmarks).toEqual([
+      event.bookmark,
+    ]);
   });
 });

--- a/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-added.ts
+++ b/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-added.ts
@@ -2,15 +2,30 @@ import type { Feed } from '../../../feed';
 import type {
   ActivityPinResponse,
   ActivityResponse,
+  BookmarkResponse,
 } from '../../../gen/models';
 import type { EventPayload, PartializeAllBut } from '../../../types-internal';
 import { updateEntityInArray } from '../../../utils';
-import { isSameBookmark } from './handle-bookmark-deleted';
+import { findBookmarkIndex, isStaleBookmark } from './bookmark-utils';
 
 export type BookmarkAddedPayload = PartializeAllBut<
   EventPayload<'feeds.bookmark.added'>,
   'bookmark'
 >;
+
+/**
+ * The same add arrives twice (HTTP response + WS broadcast), and the WS copy can be
+ * delayed past a later update of the same bookmark. Only apply a payload that adds a
+ * bookmark we don't hold yet, or that is fresher than the one we do.
+ */
+const shouldApplyToOwnBookmarks = (
+  ownBookmarks: BookmarkResponse[],
+  bookmark: BookmarkResponse,
+): boolean => {
+  const index = findBookmarkIndex(ownBookmarks, bookmark);
+
+  return index === -1 || !isStaleBookmark(bookmark, ownBookmarks[index]);
+};
 
 const sharedUpdateActivity = ({
   currentActivity,
@@ -24,7 +39,14 @@ const sharedUpdateActivity = ({
   let newOwnBookmarks = currentActivity.own_bookmarks;
 
   if (eventBelongsToCurrentUser) {
-    newOwnBookmarks = [...newOwnBookmarks, event.bookmark];
+    const index = findBookmarkIndex(newOwnBookmarks, event.bookmark);
+
+    if (index === -1) {
+      newOwnBookmarks = [...newOwnBookmarks, event.bookmark];
+    } else if (!isStaleBookmark(event.bookmark, newOwnBookmarks[index])) {
+      newOwnBookmarks = [...newOwnBookmarks];
+      newOwnBookmarks[index] = event.bookmark;
+    }
   }
 
   return {
@@ -44,7 +66,7 @@ export const addBookmarkToActivities = (
     matcher: (activity) =>
       activity.id === event.bookmark.activity.id &&
       (!eventBelongsToCurrentUser ||
-        !activity.own_bookmarks.some((b) => isSameBookmark(b, event.bookmark))),
+        shouldApplyToOwnBookmarks(activity.own_bookmarks, event.bookmark)),
     updater: (matchedActivity) =>
       sharedUpdateActivity({
         currentActivity: matchedActivity,
@@ -63,8 +85,9 @@ export const addBookmarkToPinnedActivities = (
     matcher: (pinnedActivity) =>
       pinnedActivity.activity.id === event.bookmark.activity.id &&
       (!eventBelongsToCurrentUser ||
-        !pinnedActivity.activity.own_bookmarks.some((b) =>
-          isSameBookmark(b, event.bookmark),
+        shouldApplyToOwnBookmarks(
+          pinnedActivity.activity.own_bookmarks,
+          event.bookmark,
         )),
     updater: (matchedPinnedActivity) => {
       const newActivity = sharedUpdateActivity({

--- a/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-deleted.test.ts
+++ b/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-deleted.test.ts
@@ -231,4 +231,90 @@ describe(handleBookmarkDeleted.name, () => {
     const stateAfter = feed.currentState;
     expect(stateAfter).toBe(stateBefore);
   });
+
+  it('removes the bookmark even when the delete payload carries a newer updated_at', () => {
+    // the payload describing the deleted bookmark does not have to be the exact snapshot
+    // we hold — it only has to identify the same bookmark
+    const activityId = crypto.randomUUID();
+    const event = generateBookmarkDeletedEvent({
+      bookmark: {
+        activity: {
+          id: activityId,
+          own_reactions: [],
+          bookmark_count: 0,
+        },
+        user: { id: currentUserId },
+        updated_at: new Date('2025-08-06T12:00:00Z'),
+      },
+    });
+    const activity = generateActivityResponse({
+      id: activityId,
+      bookmark_count: 1,
+      own_bookmarks: [
+        generateBookmarkResponse({
+          activity: { id: activityId },
+          user: { id: currentUserId },
+          updated_at: new Date('2025-08-05T12:00:00Z'),
+        }),
+      ],
+      own_reactions: [generateFeedReactionResponse()],
+    });
+    const activityPin = generateActivityPinResponse({
+      activity: { ...activity },
+    });
+    feed.state.partialNext({
+      activities: [activity],
+      pinned_activities: [activityPin],
+    });
+
+    handleBookmarkDeleted.call(feed, event);
+
+    const stateAfter = feed.currentState;
+    expect(stateAfter.activities![0].own_bookmarks).toHaveLength(0);
+    expect(
+      stateAfter.pinned_activities![0].activity.own_bookmarks,
+    ).toHaveLength(0);
+    expect(stateAfter.activities![0].bookmark_count).toBe(0);
+  });
+
+  it('keeps a bookmark that was re-added after the delete the event describes', () => {
+    const activityId = crypto.randomUUID();
+    const event = generateBookmarkDeletedEvent({
+      bookmark: {
+        activity: {
+          id: activityId,
+          own_reactions: [],
+          bookmark_count: 0,
+        },
+        user: { id: currentUserId },
+        updated_at: new Date('2025-08-05T12:00:00Z'),
+      },
+    });
+    const reAddedBookmark = generateBookmarkResponse({
+      activity: { id: activityId },
+      user: { id: currentUserId },
+      updated_at: new Date('2025-08-06T12:00:00Z'),
+    });
+    const activity = generateActivityResponse({
+      id: activityId,
+      bookmark_count: 1,
+      own_bookmarks: [reAddedBookmark],
+      own_reactions: [generateFeedReactionResponse()],
+    });
+    const activityPin = generateActivityPinResponse({
+      activity: { ...activity },
+    });
+    feed.state.partialNext({
+      activities: [activity],
+      pinned_activities: [activityPin],
+    });
+
+    const stateBefore = feed.currentState;
+
+    handleBookmarkDeleted.call(feed, event);
+
+    const stateAfter = feed.currentState;
+    expect(stateAfter).toBe(stateBefore);
+    expect(stateAfter.activities![0].own_bookmarks).toEqual([reAddedBookmark]);
+  });
 });

--- a/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-deleted.ts
+++ b/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-deleted.ts
@@ -6,22 +6,27 @@ import type {
 } from '../../../gen/models';
 import type { EventPayload, PartializeAllBut } from '../../../types-internal';
 import { updateEntityInArray } from '../../../utils';
+import { findBookmarkIndex, isStaleBookmark } from './bookmark-utils';
 
 export type BookmarkDeletedPayload = PartializeAllBut<
   EventPayload<'feeds.bookmark.deleted'>,
   'bookmark'
 >;
 
-export const isSameBookmark = (
-  bookmark1: BookmarkResponse,
-  bookmark2: BookmarkResponse,
-): boolean => {
-  return (
-    bookmark1.user.id === bookmark2.user.id &&
-    bookmark1.activity.id === bookmark2.activity.id &&
-    bookmark1.folder?.id === bookmark2.folder?.id &&
-    bookmark1.updated_at.getTime() === bookmark2.updated_at.getTime()
-  );
+/**
+ * -1 when there is nothing to remove: either we never had the bookmark (the delete
+ * already arrived over the other channel), or the entry we hold is newer than the delete
+ * payload, meaning the bookmark has been re-added since and this is a late delete.
+ */
+const findBookmarkToRemove = (
+  ownBookmarks: BookmarkResponse[],
+  bookmark: BookmarkResponse,
+): number => {
+  const index = findBookmarkIndex(ownBookmarks, bookmark);
+
+  return index !== -1 && isStaleBookmark(ownBookmarks[index], bookmark)
+    ? index
+    : -1;
 };
 
 const sharedUpdateActivity = ({
@@ -36,9 +41,11 @@ const sharedUpdateActivity = ({
   let newOwnBookmarks = currentActivity.own_bookmarks;
 
   if (eventBelongsToCurrentUser) {
-    newOwnBookmarks = currentActivity.own_bookmarks.filter(
-      (bookmark) => !isSameBookmark(bookmark, event.bookmark),
-    );
+    const index = findBookmarkToRemove(newOwnBookmarks, event.bookmark);
+
+    if (index !== -1) {
+      newOwnBookmarks = newOwnBookmarks.filter((_, i) => i !== index);
+    }
   }
 
   return {
@@ -58,7 +65,7 @@ export const removeBookmarkFromActivities = (
     matcher: (activity) =>
       activity.id === event.bookmark.activity.id &&
       (!eventBelongsToCurrentUser ||
-        activity.own_bookmarks.some((b) => isSameBookmark(b, event.bookmark))),
+        findBookmarkToRemove(activity.own_bookmarks, event.bookmark) !== -1),
     updater: (matchedActivity) =>
       sharedUpdateActivity({
         currentActivity: matchedActivity,
@@ -77,9 +84,10 @@ export const removeBookmarkFromPinnedActivities = (
     matcher: (pinnedActivity) =>
       pinnedActivity.activity.id === event.bookmark.activity.id &&
       (!eventBelongsToCurrentUser ||
-        pinnedActivity.activity.own_bookmarks.some((b) =>
-          isSameBookmark(b, event.bookmark),
-        )),
+        findBookmarkToRemove(
+          pinnedActivity.activity.own_bookmarks,
+          event.bookmark,
+        ) !== -1),
     updater: (matchedPinnedActivity) => {
       const newActivity = sharedUpdateActivity({
         currentActivity: matchedPinnedActivity.activity,

--- a/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-updated.test.ts
+++ b/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-updated.test.ts
@@ -13,6 +13,14 @@ import {
   generateBookmarkResponse,
 } from '../../../test-utils/response-generators';
 
+const generateBookmarkFolder = (id: string) => ({
+  id,
+  name: `Folder ${id}`,
+  created_at: new Date(),
+  updated_at: new Date(),
+  custom: {},
+});
+
 describe(handleBookmarkUpdated.name, () => {
   let feed: Feed;
   let client: FeedsClient;
@@ -237,5 +245,190 @@ describe(handleBookmarkUpdated.name, () => {
     handleBookmarkUpdated.call(feed, event);
     const stateAfter = feed.currentState;
     expect(stateAfter).toBe(stateBefore);
+  });
+
+  it('ignores an update event older than the bookmark in state', () => {
+    const activityId = crypto.randomUUID();
+    const event = generateBookmarkUpdatedEvent({
+      bookmark: {
+        activity: {
+          id: activityId,
+          own_reactions: [],
+          bookmark_count: 1,
+        },
+        user: { id: currentUserId },
+        updated_at: new Date('2025-08-05T12:00:00Z'),
+      },
+    });
+    const currentBookmark = generateBookmarkResponse({
+      activity: { id: activityId },
+      user: { id: currentUserId },
+      updated_at: new Date('2025-08-06T12:00:00Z'),
+    });
+    const activity = generateActivityResponse({
+      id: activityId,
+      bookmark_count: 1,
+      own_bookmarks: [currentBookmark],
+      own_reactions: [generateFeedReactionResponse()],
+    });
+    feed.state.partialNext({
+      activities: [activity],
+      pinned_activities: [generateActivityPinResponse({ activity })],
+    });
+
+    const stateBefore = feed.currentState;
+
+    handleBookmarkUpdated.call(feed, event);
+
+    const stateAfter = feed.currentState;
+    expect(stateAfter).toBe(stateBefore);
+    expect(stateAfter.activities![0].own_bookmarks).toEqual([currentBookmark]);
+  });
+
+  describe('folder moves', () => {
+    it('moves a bookmark to another folder using the previous folder from the request', () => {
+      // the payload carries the folder the bookmark was moved *to*, so it no longer
+      // matches the entry in state by identity — only the request knows where it came
+      // from
+      const activityId = crypto.randomUUID();
+      const event = generateBookmarkUpdatedEvent({
+        bookmark: {
+          activity: {
+            id: activityId,
+            own_reactions: [],
+            bookmark_count: 1,
+          },
+          user: { id: currentUserId },
+          folder: generateBookmarkFolder('folder2'),
+          updated_at: new Date('2025-08-06T12:00:00Z'),
+        },
+      });
+      const activity = generateActivityResponse({
+        id: activityId,
+        bookmark_count: 1,
+        own_bookmarks: [
+          generateBookmarkResponse({
+            activity: { id: activityId },
+            user: { id: currentUserId },
+            folder: generateBookmarkFolder('folder1'),
+            updated_at: new Date('2025-08-05T12:00:00Z'),
+          }),
+          // a second bookmark of the same activity, which must not be touched
+          generateBookmarkResponse({
+            activity: { id: activityId },
+            user: { id: currentUserId },
+            folder: generateBookmarkFolder('folder3'),
+            updated_at: new Date('2025-08-05T12:00:00Z'),
+          }),
+        ],
+        own_reactions: [generateFeedReactionResponse()],
+      });
+      const activityPin = generateActivityPinResponse({
+        activity: { ...activity },
+      });
+      feed.state.partialNext({
+        activities: [activity],
+        pinned_activities: [activityPin],
+      });
+
+      handleBookmarkUpdated.call(feed, event, { previousFolderId: 'folder1' });
+
+      const ownBookmarks = feed.currentState.activities![0].own_bookmarks;
+      expect(ownBookmarks).toHaveLength(2);
+      expect(ownBookmarks[0]).toBe(event.bookmark);
+      expect(ownBookmarks[1].folder?.id).toBe('folder3');
+      expect(
+        feed.currentState.pinned_activities![0].activity.own_bookmarks[0],
+      ).toBe(event.bookmark);
+    });
+
+    it('moves a bookmark to another folder from a WS event when it is the only bookmark for the activity', () => {
+      // WS events carry no previous folder; with a single candidate the move is
+      // unambiguous
+      const activityId = crypto.randomUUID();
+      const event = generateBookmarkUpdatedEvent({
+        bookmark: {
+          activity: {
+            id: activityId,
+            own_reactions: [],
+            bookmark_count: 1,
+          },
+          user: { id: currentUserId },
+          folder: generateBookmarkFolder('folder2'),
+          updated_at: new Date('2025-08-06T12:00:00Z'),
+        },
+      });
+      const activity = generateActivityResponse({
+        id: activityId,
+        bookmark_count: 1,
+        own_bookmarks: [
+          generateBookmarkResponse({
+            activity: { id: activityId },
+            user: { id: currentUserId },
+            folder: generateBookmarkFolder('folder1'),
+            updated_at: new Date('2025-08-05T12:00:00Z'),
+          }),
+        ],
+        own_reactions: [generateFeedReactionResponse()],
+      });
+      feed.state.partialNext({
+        activities: [activity],
+        pinned_activities: [generateActivityPinResponse({ activity })],
+      });
+
+      handleBookmarkUpdated.call(feed, event);
+
+      expect(feed.currentState.activities![0].own_bookmarks).toEqual([
+        event.bookmark,
+      ]);
+    });
+
+    it('leaves own_bookmarks untouched when a WS folder move is ambiguous', () => {
+      const activityId = crypto.randomUUID();
+      const event = generateBookmarkUpdatedEvent({
+        bookmark: {
+          activity: {
+            id: activityId,
+            own_reactions: [],
+            bookmark_count: 2,
+          },
+          user: { id: currentUserId },
+          folder: generateBookmarkFolder('folder3'),
+          updated_at: new Date('2025-08-06T12:00:00Z'),
+        },
+      });
+      const ownBookmarks = [
+        generateBookmarkResponse({
+          activity: { id: activityId },
+          user: { id: currentUserId },
+          folder: generateBookmarkFolder('folder1'),
+          updated_at: new Date('2025-08-05T12:00:00Z'),
+        }),
+        generateBookmarkResponse({
+          activity: { id: activityId },
+          user: { id: currentUserId },
+          folder: generateBookmarkFolder('folder2'),
+          updated_at: new Date('2025-08-05T12:00:00Z'),
+        }),
+      ];
+      const activity = generateActivityResponse({
+        id: activityId,
+        bookmark_count: 2,
+        own_bookmarks: ownBookmarks,
+        own_reactions: [generateFeedReactionResponse()],
+      });
+      feed.state.partialNext({
+        activities: [activity],
+        pinned_activities: [generateActivityPinResponse({ activity })],
+      });
+
+      const stateBefore = feed.currentState;
+
+      handleBookmarkUpdated.call(feed, event);
+
+      const stateAfter = feed.currentState;
+      expect(stateAfter).toBe(stateBefore);
+      expect(stateAfter.activities![0].own_bookmarks).toEqual(ownBookmarks);
+    });
   });
 });

--- a/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-updated.ts
+++ b/packages/feeds-client/src/feed/event-handlers/bookmark/handle-bookmark-updated.ts
@@ -2,39 +2,59 @@ import type { Feed } from '../../../feed';
 import type {
   ActivityPinResponse,
   ActivityResponse,
+  BookmarkResponse,
 } from '../../../gen/models';
 import type { EventPayload, PartializeAllBut } from '../../../types-internal';
 import { updateEntityInArray } from '../../../utils';
 
-import { isSameBookmark } from './handle-bookmark-deleted';
+import type { BookmarkUpdateOptions } from './bookmark-utils';
+import { findBookmarkIndexForUpdate, isStaleBookmark } from './bookmark-utils';
 
 export type BookmarkUpdatedPayload = PartializeAllBut<
   EventPayload<'feeds.bookmark.updated'>,
   'bookmark'
 >;
 
+/**
+ * -1 when there is nothing to update: either the bookmark isn't in state, or the payload
+ * carries nothing newer than what we already applied (the same change reaches us over
+ * both HTTP and the WebSocket).
+ */
+const findBookmarkToUpdate = (
+  ownBookmarks: BookmarkResponse[],
+  bookmark: BookmarkResponse,
+  options?: BookmarkUpdateOptions,
+): number => {
+  const index = findBookmarkIndexForUpdate(ownBookmarks, bookmark, options);
+
+  return index !== -1 && !isStaleBookmark(bookmark, ownBookmarks[index])
+    ? index
+    : -1;
+};
+
 const sharedUpdateActivity = ({
   currentActivity,
   event,
   eventBelongsToCurrentUser,
+  options,
 }: {
   currentActivity: ActivityResponse;
   event: BookmarkUpdatedPayload;
   eventBelongsToCurrentUser: boolean;
+  options?: BookmarkUpdateOptions;
 }): ActivityResponse => {
   let newOwnBookmarks = currentActivity.own_bookmarks;
 
   if (eventBelongsToCurrentUser) {
-    const bookmarkIndex = newOwnBookmarks.findIndex(
-      (bookmark) =>
-        bookmark.user.id === event.bookmark.user.id &&
-        bookmark.activity.id === event.bookmark.activity.id &&
-        bookmark.folder?.id === event.bookmark.folder?.id,
+    const index = findBookmarkToUpdate(
+      newOwnBookmarks,
+      event.bookmark,
+      options,
     );
 
-    if (bookmarkIndex !== -1) {
+    if (index !== -1) {
       newOwnBookmarks = [...newOwnBookmarks];
-      newOwnBookmarks[bookmarkIndex] = event.bookmark;
+      newOwnBookmarks[index] = event.bookmark;
     }
   }
 
@@ -49,18 +69,24 @@ export const updateBookmarkInActivities = (
   event: BookmarkUpdatedPayload,
   activities: ActivityResponse[] | undefined,
   eventBelongsToCurrentUser: boolean,
+  options?: BookmarkUpdateOptions,
 ) =>
   updateEntityInArray({
     entities: activities,
     matcher: (activity) =>
       activity.id === event.bookmark.activity.id &&
       (!eventBelongsToCurrentUser ||
-        !activity.own_bookmarks.some((b) => isSameBookmark(b, event.bookmark))),
+        findBookmarkToUpdate(
+          activity.own_bookmarks,
+          event.bookmark,
+          options,
+        ) !== -1),
     updater: (matchedActivity) =>
       sharedUpdateActivity({
         currentActivity: matchedActivity,
         event,
         eventBelongsToCurrentUser,
+        options,
       }),
   });
 
@@ -68,20 +94,24 @@ export const updateBookmarkInPinnedActivities = (
   event: BookmarkUpdatedPayload,
   pinnedActivities: ActivityPinResponse[] | undefined,
   eventBelongsToCurrentUser: boolean,
+  options?: BookmarkUpdateOptions,
 ) =>
   updateEntityInArray({
     entities: pinnedActivities,
     matcher: (pinnedActivity) =>
       pinnedActivity.activity.id === event.bookmark.activity.id &&
       (!eventBelongsToCurrentUser ||
-        !pinnedActivity.activity.own_bookmarks.some((b) =>
-          isSameBookmark(b, event.bookmark),
-        )),
+        findBookmarkToUpdate(
+          pinnedActivity.activity.own_bookmarks,
+          event.bookmark,
+          options,
+        ) !== -1),
     updater: (matchedPinnedActivity) => {
       const newActivity = sharedUpdateActivity({
         currentActivity: matchedPinnedActivity.activity,
         event,
         eventBelongsToCurrentUser,
+        options,
       });
 
       if (newActivity === matchedPinnedActivity.activity) {
@@ -98,6 +128,7 @@ export const updateBookmarkInPinnedActivities = (
 export function handleBookmarkUpdated(
   this: Feed,
   event: BookmarkUpdatedPayload,
+  options?: BookmarkUpdateOptions,
 ) {
   const {
     activities: currentActivities,
@@ -112,11 +143,13 @@ export function handleBookmarkUpdated(
       event,
       currentActivities,
       eventBelongsToCurrentUser,
+      options,
     ),
     updateBookmarkInPinnedActivities(
       event,
       currentPinnedActivities,
       eventBelongsToCurrentUser,
+      options,
     ),
   ];
 

--- a/packages/feeds-client/src/feed/event-handlers/bookmark/index.ts
+++ b/packages/feeds-client/src/feed/event-handlers/bookmark/index.ts
@@ -1,3 +1,4 @@
+export * from './bookmark-utils';
 export * from './handle-bookmark-added';
 export * from './handle-bookmark-deleted';
 export * from './handle-bookmark-updated';

--- a/packages/feeds-client/src/feed/feed.ts
+++ b/packages/feeds-client/src/feed/feed.ts
@@ -31,6 +31,7 @@ import {
   handleBookmarkUpdated,
   handleActivityAdded,
   addActivitiesToState,
+  shouldApplyActivityAdded,
   handleActivityUpdated,
   handleFeedMemberAdded,
   handleFeedMemberRemoved,
@@ -964,6 +965,10 @@ export class Feed extends FeedApi {
    * Used when the activity was added via this feed's addActivity or via client.addActivity.
    */
   protected addActivityFromHTTPResponse(activity: ActivityResponse): void {
+    if (!shouldApplyActivityAdded.call(this, activity, false)) {
+      return;
+    }
+
     const currentUser = this.client.state.getLatestValue().connected_user;
     const decision = this.resolveNewActivityDecision(
       activity,

--- a/packages/feeds-client/src/feeds-client/feeds-client.ts
+++ b/packages/feeds-client/src/feeds-client/feeds-client.ts
@@ -801,7 +801,11 @@ export class FeedsClient extends FeedsApi {
   ): Promise<StreamResponse<UpdateBookmarkResponse>> => {
     const response = await super.updateBookmark(request);
     for (const feed of this.allActiveFeeds) {
-      handleBookmarkUpdated.bind(feed)(response);
+      // the response carries the folder the bookmark was moved *to*; only the request
+      // knows where it was moved from, which is how state locates the existing entry
+      handleBookmarkUpdated.bind(feed)(response, {
+        previousFolderId: request.folder_id,
+      });
     }
     return response;
   };

--- a/packages/feeds-client/src/utils/state-update-queue.ts
+++ b/packages/feeds-client/src/utils/state-update-queue.ts
@@ -1,5 +1,6 @@
 import type { FollowResponse } from '../gen/models';
 import type {
+  ActivityAddedPayload,
   ActivityDeletedPayload,
   ActivityPinnedPayload,
   ActivityReactionAddedPayload,
@@ -20,6 +21,7 @@ import type { FeedMemberUpdatedPayload } from '../feed/event-handlers/feed-membe
 import type { FeedMemberRemovedPayload } from '../feed/event-handlers/feed-member/handle-feed-member-removed';
 
 export type StateUpdateQueuePrefix =
+  | 'activity-added'
   | 'activity-deleted'
   | 'activity-pinned'
   | 'activity-unpinned'
@@ -41,6 +43,7 @@ export type StateUpdateQueuePrefix =
   | 'feed-member-removed';
 
 type StateUpdateQueuePayloadByPrefix = {
+  'activity-added': ActivityAddedPayload;
   'activity-deleted': ActivityDeletedPayload;
   'activity-pinned': ActivityPinnedPayload;
   'activity-unpinned': ActivityUnpinnedPayload;
@@ -179,6 +182,7 @@ export function getStateUpdateQueueId(...args: StateUpdateQueuePairTuples) {
   const toJoin = [prefix as string];
 
   switch (prefix) {
+    case 'activity-added':
     case 'activity-deleted': {
       return toJoin.concat([data.activity.id]).join('-');
     }


### PR DESCRIPTION
Not related to the state deduplication method, but two specific bugs:
- Bookmarks -> we won't update the bookmark if `updated_at` is older than what we currently store -> when we do quick bookmark operations the WS event can arrive AFTER another HTTP operation changed the bookmark; relevant mainly for tests only
- When I added HTTP handler for `addActivity` I didn't add `activity.added` event to the state dedup queue, I thought we don't need it since we have id duplication check already. But if we add-delete an activity very quickly, probably only relevant to tests; the `activity.added` event can arrive after delete, and readd the activity; using the state dedup queue fixes it because we'll ignore the late WS event
